### PR TITLE
Improve vscode-package-json

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-817e4b96072d8107ce0332774e85e0a5:.
+7ea428816b44f1b6dae75197a477ee15:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -501,7 +501,7 @@ b9a14c96cce8e365e1d7494d078d73fe:src/lsp/superbol-free/linking_flags.sh
 
 # begin context for src/vscode/vscode-json/dune
 # file src/vscode/vscode-json/dune
-452540098fd6ae61c5f364330d4ec493:src/vscode/vscode-json/dune
+c57e4311cc67d76a32541e4dc3132913:src/vscode/vscode-json/dune
 # end context for src/vscode/vscode-json/dune
 
 # begin context for src/vscode/vscode-json/index.mld

--- a/src/vscode/vscode-json/dune
+++ b/src/vscode/vscode-json/dune
@@ -9,7 +9,7 @@
   ; use field 'dune-flags' to set this value
   (flags (:standard))
   ; use field 'dune-stanzas' to add more stanzas here
-  (preprocess (pps ppx_deriving_encoding))
+  (preprocess (pps ppx_deriving_encoding ppx_deriving.show))
   
   )
 

--- a/src/vscode/vscode-json/ezjsonm.ml
+++ b/src/vscode/vscode-json/ezjsonm.ml
@@ -1,0 +1,411 @@
+(* This file contains a small patch, see the SUPERBOL comments.
+
+   We use the Jsonm.Uncut.decode function to parse Javascript comments
+   that are allowed by VSCODE in JSON files.
+
+  *)
+
+(*
+ * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* From http://erratique.ch/software/jsonm/doc/Jsonm.html#datamodel *)
+type value =
+  [ `Null
+  | `Bool of bool
+  | `Float of float
+  | `String of string
+  | `A of value list
+  | `O of (string * value) list ]
+
+type t =
+  [ `A of value list
+  | `O of (string * value) list ]
+
+let value: t -> value = fun t -> (t :> value)
+
+module List = struct
+  include List
+
+  (* Tail-recursive List.map *)
+  let map f l = rev (rev_map f l)
+end
+
+type error_location = (int * int) * (int * int)
+type read_value_error = [
+  | `Error of error_location * Jsonm.error
+  | `Unexpected of [ `Lexeme of error_location * Jsonm.lexeme * string | `End_of_input ]
+]
+type read_error = [ read_value_error | `Not_a_t of value ]
+
+let json_of_src src : (value, [> read_value_error]) result =
+  let d = Jsonm.decoder src in
+  let exception Abort of read_value_error in
+  let module Stack = struct
+      type t =
+        | In_array of value list * t
+        | In_object of string * (string * value) list * t
+        | Empty
+    end
+  in
+  let loc () = Jsonm.decoded_range d in
+(* BEGIN PATCH FOR SUPERBOL *)
+  let rec dec () = match Jsonm.Uncut.decode d with
+    | `Comment _ | `White _ -> dec ()
+(* END PATCH FOR SUPERBOL *)
+    | `Lexeme l -> l
+    | `Error e  -> raise (Abort (`Error (loc (), e)))
+    | `End      -> raise (Abort (`Unexpected `End_of_input))
+    | `Await    -> assert false
+  in
+  let rec value l stack = match l with
+    | `Os -> obj [] stack
+    | `As -> arr [] stack
+    | `Null
+    | `Bool _
+    | `String _
+    | `Float _ as l -> continue l stack
+    | _ ->
+      raise (Abort (`Unexpected (`Lexeme (loc (), l, "value"))))
+  and arr so_far stack = match dec () with
+    | `Ae -> continue (`A (List.rev so_far)) stack
+    | l ->
+      let stack = Stack.In_array (so_far, stack) in
+      value l stack
+  and obj so_far stack = match dec () with
+    | `Oe -> continue (`O (List.rev so_far)) stack
+    | `Name n ->
+       let stack = Stack.In_object (n, so_far, stack) in
+       value (dec ()) stack
+    | l       ->
+       raise (Abort (`Unexpected (`Lexeme (loc (), l, "object fields"))))
+  and continue v stack =
+    match stack with
+    | Stack.In_array (vs, stack) ->
+       let so_far = (v :: vs) in
+       arr so_far stack
+    | Stack.In_object (n, ms, stack) ->
+       let so_far = ((n,v) :: ms) in
+       obj so_far stack
+    | Stack.Empty -> v
+  in
+  try Ok (value (dec ()) Empty)
+  with Abort (#read_value_error as err) -> Error err
+
+let value_to_dst ?(minify=true) dst json =
+  let module Stack = struct
+      type t =
+        | In_array of value list * t
+        | In_object of (string * value) list * t
+        | Empty
+    end
+  in
+  let enc e l = ignore (Jsonm.encode e (`Lexeme l)) in
+  let rec t v e stack = match v with
+    | `A vs ->
+       enc e `As;
+       arr vs e stack
+    | `O ms ->
+       enc e `Os;
+       obj ms e stack
+  and value v e stack = match v with
+    | `Null | `Bool _ | `Float _ | `String _ as v ->
+       enc e v;
+       continue e stack
+    | #t as x -> t (x :> t) e stack
+  and arr vs e stack = match vs with
+    | v :: vs' ->
+       let stack = Stack.In_array (vs', stack) in
+       value v e stack
+    | [] -> enc e `Ae; continue e stack
+  and obj ms e stack = match ms with
+    | (n, v) :: ms ->
+       enc e (`Name n);
+       let stack = Stack.In_object (ms, stack) in
+       value v e stack
+    | [] -> enc e `Oe; continue e stack
+  and continue e stack = match stack with
+    | Stack.In_array (vs, stack) -> arr vs e stack
+    | Stack.In_object (ms, stack) -> obj ms e stack
+    | Stack.Empty -> ()
+  in
+  let e = Jsonm.encoder ~minify dst in
+  value json e Stack.Empty;
+  ignore (Jsonm.encode e `End)
+
+let value_to_buffer ?minify buf json =
+  value_to_dst ?minify (`Buffer buf) json
+
+let to_buffer ?minify buf json = value_to_buffer ?minify buf (json :> value)
+
+let value_to_string ?minify json =
+  let buf = Buffer.create 1024 in
+  value_to_buffer ?minify buf json;
+  Buffer.contents buf
+
+let to_string ?minify json = value_to_string ?minify (json :> value)
+
+let value_to_channel ?minify oc json =
+  value_to_dst ?minify (`Channel oc) json
+
+let to_channel ?minify oc json = value_to_channel ?minify oc (json :> value)
+
+exception Parse_error of value * string
+
+let parse_error t fmt =
+  Printf.kprintf (fun msg ->
+      raise (Parse_error (t, msg))
+    ) fmt
+
+let wrap t = `A [t]
+
+let unwrap = function
+  | `A [t] -> t
+  | v -> parse_error (v :> value) "Not unwrappable"
+
+let read_error_description : [< read_error ] -> string = function
+  | `Error (_loc, err) ->
+    Format.asprintf "%a" Jsonm.pp_error err
+  | `Unexpected `End_of_input ->
+    Format.sprintf "Unexpected end of input"
+  | `Unexpected (`Lexeme (_loc, _l, expectation)) ->
+    Format.sprintf "Unexpected input when parsing a %s" expectation
+  | `Not_a_t _value ->
+    "We expected a well-formed JSON document (array or object)"
+
+let read_error_location : [< read_error ] -> error_location option = function
+  | `Error (loc, _) -> Some loc
+  | `Unexpected `End_of_input -> None
+  | `Unexpected (`Lexeme (loc, _l, _expectation)) -> Some loc
+  | `Not_a_t _value -> None
+
+let value_from_src_result src = json_of_src src
+
+let value_from_src src =
+  match value_from_src_result src with
+  | Ok t      -> t
+  | Error e -> parse_error `Null "JSON.of_buffer %s" (read_error_description e)
+
+let value_from_string_result str = value_from_src_result (`String str)
+let value_from_string str = value_from_src (`String str)
+
+let value_from_channel_result chan = value_from_src_result (`Channel chan)
+let value_from_channel chan = value_from_src (`Channel chan)
+
+let ensure_document_result: [> value] -> ([> t], [> read_error]) result = function
+  | #t as t -> Ok t
+  | value -> Error (`Not_a_t value)
+
+let ensure_document: [> value] -> [> t] = function
+  | #t as t -> t
+  | t -> raise (Parse_error (t, "not a valid JSON array/object"))
+
+let from_string str = value_from_string str |> ensure_document
+let from_channel chan = value_from_channel chan |> ensure_document
+
+let from_string_result str =
+  Result.bind (value_from_string_result str) ensure_document_result
+let from_channel_result chan =
+  Result.bind (value_from_channel_result chan) ensure_document_result
+
+(* unit *)
+let unit () = `Null
+
+let get_unit = function
+  | `Null  -> ()
+  | j      -> parse_error j "Ezjsonm.get_unit"
+
+(* bool *)
+let bool b = `Bool b
+
+let get_bool = function
+  | `Bool b -> b
+  | j       -> parse_error j "Ezjsonm.get_bool"
+
+(* string *)
+let string s = `String s
+
+let get_string = function
+  | `String s -> s
+  | j         -> parse_error j "Ezjsonm.get_string"
+
+(* int *)
+let int i = `Float (float_of_int i)
+let int32 i = `Float (Int32.to_float i)
+let int64 i = `Float (Int64.to_float i)
+
+let get_int = function
+  | `Float f -> int_of_float f
+  | j        -> parse_error j "Ezjsonm.get_int"
+
+let get_int32 = function
+  | `Float f -> Int32.of_float f
+  | j        -> parse_error j "Ezjsonm.get_int32"
+
+let get_int64 = function
+  | `Float f -> Int64.of_float f
+  | j        -> parse_error j "Ezjsonm.get_int64"
+
+(* float *)
+let float f = `Float f
+
+let get_float = function
+  | `Float f -> f
+  | j        -> parse_error j "Ezjsonm.get_float"
+
+(* list *)
+let list fn l =
+  `A (List.map fn l)
+
+let get_list fn = function
+  | `A ks -> List.map fn ks
+  | j     -> parse_error j "Ezjsonm.get_list"
+
+(* string lists *)
+let strings strings = list string strings
+
+let get_strings = get_list get_string
+
+(* options *)
+let option fn = function
+  | None   -> `Null
+  | Some x -> `A [fn x]
+
+let get_option fn = function
+  | `Null  -> None
+  | `A [j] -> Some (fn j)
+  | j -> parse_error j "Ezjsonm.get_option"
+
+(* dict *)
+let dict d = `O d
+
+let get_dict = function
+  | `O d -> d
+  | j    -> parse_error j "Ezjsonm.get_dict"
+
+(* pairs *)
+let pair fk fv (k, v) =
+  `A [fk k; fv v]
+
+let get_pair fk fv = function
+  | `A [k; v] -> (fk k, fv v)
+  | j         -> parse_error j "Ezjsonm.get_pair"
+
+(* triple *)
+
+let triple fa fb fc (a, b, c) =
+  `A [fa a; fb b; fc c]
+
+let get_triple fa fb fc = function
+  | `A [a; b; c] -> (fa a, fb b, fc c)
+  | j -> parse_error j "Ezjsonm.get_triple"
+
+let mem t path =
+  let rec aux j p = match p, j with
+    | []   , _    -> true
+    | h::tl, `O o -> List.mem_assoc h o && aux (List.assoc h o) tl
+    | _           -> false in
+  aux t path
+
+let find t path =
+  let rec aux j p = match p, j with
+    | []   , j    -> j
+    | h::tl, `O o -> aux (List.assoc h o) tl
+    | _           -> raise Not_found in
+  aux t path
+
+let find_opt t path =
+  try Some (find t path) with Not_found -> None
+
+let map_dict f dict label =
+  let rec aux acc = function
+    | []    ->
+      begin match f `Null with
+        | None   -> List.rev acc
+        | Some j -> List.rev_append acc [label, j]
+      end
+    | (l,j) as e :: dict ->
+      if l = label then
+        match f j with
+        | None   -> List.rev_append acc dict
+        | Some j -> List.rev_append acc ((l,j)::dict)
+      else
+        aux (e::acc) dict in
+  aux [] dict
+
+let map f t path =
+  let rec aux t = function
+    | []    -> f t
+    | h::tl ->
+      match t with
+      | `O d -> Some (`O (map_dict (fun t -> aux t tl) d h))
+      | _    -> None in
+  match aux t path with
+  | None   -> raise Not_found
+  | Some j -> j
+
+let update t path v =
+  map (fun _ -> v) t path
+
+exception Not_utf8
+
+let is_valid_utf8 str =
+  try
+    Uutf.String.fold_utf_8 (fun _ _ -> function
+        | `Malformed _ -> raise Not_utf8
+        | _ -> ()
+      ) () str;
+    true
+  with Not_utf8 -> false
+
+let encode_string str =
+  if is_valid_utf8 str
+  then string str
+  else
+    let `Hex h = Hex.of_string str in
+    `O [ "hex", string h ]
+
+let decode_string = function
+  | `String str               -> Some str
+  | `O [ "hex", `String str ] -> Some (Hex.to_string (`Hex str))
+  | _                         -> None
+
+let decode_string_exn j =
+  match decode_string j with
+  | Some s -> s
+  | None   -> parse_error j "Ezjsonm.decode_string_exn"
+
+let rec of_sexp = function
+  | Sexplib0.Sexp.Atom x -> encode_string x
+  | Sexplib0.Sexp.List l -> list of_sexp l
+
+let value_of_sexp = of_sexp
+
+let t_of_sexp s = match value_of_sexp s with
+  | `A x -> `A x
+  | `O x -> `O x
+  | _ -> failwith "Ezjsonm: t_of_sexp encountered a value (fragment) rather than a t"
+
+let rec to_sexp json =
+  match decode_string json with
+  | Some s -> Sexplib0.Sexp.Atom s
+  | None   ->
+    match json with
+    | `A l -> Sexplib0.Sexp.List (List.map to_sexp l)
+    | _    -> parse_error json "Ezjsonm.to_sexp"
+
+let sexp_of_value = to_sexp
+
+let sexp_of_t t = sexp_of_value @@ value t

--- a/src/vscode/vscode-json/ezjsonm.mli
+++ b/src/vscode/vscode-json/ezjsonm.mli
@@ -1,0 +1,272 @@
+(*
+ * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** An easy interface on top of the [Jsonm] library.
+
+    This version provides more convenient (but far less flexible)
+    input and output functions that go to and from [string] values.
+    This avoids the need to write signal code, which is useful for
+    quick scripts that manipulate JSON.
+
+    More advanced users should go straight to the [Jsonm] library and
+    use it directly, rather than be saddled with the Ezjsonm interface
+    below.
+*)
+
+(** {2 Basic types} *)
+
+type value =
+  [ `Null
+  | `Bool of bool
+  | `Float of float
+  | `String of string
+  | `A of value list
+  | `O of (string * value) list ]
+(** JSON fragments. *)
+
+type t =
+  [ `A of value list
+  | `O of (string * value) list ]
+(** Well-formed JSON documents. *)
+
+val value: t -> value
+(** Cast a JSON well-formed document into a JSON fragment. *)
+
+val wrap: value -> [> t]
+(** [wrap v] wraps the value [v] into a JSON array. To use when it is
+    not possible to statically know that [v] is a value JSON value. *)
+
+val unwrap: t -> value
+(** [unwrap t] is the reverse of [wrap]. It expects [t] to be a
+    singleton JSON object and it return the unique element. *)
+
+(** {2 Reading JSON documents and values} *)
+val from_channel: in_channel -> [> t]
+(** Read a JSON document from an input channel. *)
+
+val from_string: string -> [> t]
+(** Read a JSON document from a string. *)
+
+val value_from_channel: in_channel -> value
+(** Read a JSON value from an input channel. *)
+
+val value_from_string: string -> value
+(** Read a JSON value from a string. *)
+
+val value_from_src: Jsonm.src -> value
+(** Low-level function to read directly from a [Jsonm] source. *)
+
+(** {2 Reading JSON documents and values -- with proper errors} *)
+
+type error_location = (int * int) * (int * int)
+(** Error locations in a source document follow the Jsonm representation
+    of pairs of pairs [((start_line, start_col), (end_line, end_col))]
+    with 0-indexed lines and 1-indexed columns. *)
+
+type read_value_error = [
+  | `Error of error_location * Jsonm.error
+  | `Unexpected of [ `Lexeme of error_location * Jsonm.lexeme * string | `End_of_input ]
+]
+type read_error = [ read_value_error | `Not_a_t of value ]
+
+val read_error_description : [< read_error ] -> string
+(** A human-readable description of an error -- without using the error location. *)
+
+val read_error_location : [< read_error ] -> error_location option
+(** If the error is attached to a specific location in the buffer,
+    return this location. *)
+
+val from_channel_result: in_channel -> ([> t], [> read_error]) result
+(** See {!from_channel}. *)
+
+val from_string_result: string -> ([> t], [> read_error]) result
+(** See {!from_string}. *)
+
+val value_from_channel_result: in_channel -> (value, [> read_value_error]) result
+(** See {!value_from_channel}. *)
+
+val value_from_string_result: string -> (value, [> read_value_error]) result
+(** See {!value_from_string}. *)
+
+val value_from_src_result: Jsonm.src -> (value, [> read_value_error]) result
+(** See {!value_from_src}. *)
+
+(** {2 Writing JSON documents and values} *)
+
+val to_channel: ?minify:bool -> out_channel -> t -> unit
+(** Write a JSON document to an output channel. *)
+
+val to_buffer: ?minify:bool -> Buffer.t -> t -> unit
+(** Write a JSON document to a buffer. *)
+
+val to_string: ?minify:bool -> t -> string
+(** Write a JSON document to a string. This goes via an intermediate
+    buffer and so may be slow on large documents. *)
+
+val value_to_channel: ?minify:bool -> out_channel -> value -> unit
+(** Write a JSON value to an output channel. *)
+
+val value_to_buffer: ?minify:bool -> Buffer.t -> value -> unit
+(** Write a JSON value to a buffer. *)
+
+val value_to_string: ?minify:bool -> value -> string
+(** Write a JSON value to a string. This goes via an intermediate
+    buffer and so may be slow on large documents. *)
+
+val value_to_dst: ?minify:bool -> Jsonm.dst-> value -> unit
+(** Low-level function to write directly to a [Jsonm] destination. *)
+
+(** {2 Constructors} *)
+
+val unit: unit -> value
+(** Same as [`Null]. *)
+
+val bool: bool -> value
+(** Same as [`Bool b]. *)
+
+val string: string -> value
+(** Same as [`String s]. *)
+
+val strings: string list -> [> t]
+(** Same as [`A [`String s1; ..; `String sn]]. *)
+
+val int: int -> value
+(** Same as [`Float (float_of_int i)]. *)
+
+val int32: int32 -> value
+(** Same as [`Float (Int32.to_float i)] *)
+
+val int64: int64 -> value
+(** Same as [`Float (Int64.to_float i)] *)
+
+val float: float -> value
+(** Some as [`Float f]. *)
+
+val list: ('a -> value) -> 'a list -> [> t]
+(** Build a list of values. *)
+
+val option: ('a -> value) -> 'a option -> value
+(** Either [`Null] or a JSON value. *)
+
+val dict: (string * value) list -> [> t]
+(** Build a dictionnary. *)
+
+val pair: ('a -> value) -> ('b -> value) -> ('a * 'b) -> [> t]
+(** Build a pair. *)
+
+val triple: ('a -> value) -> ('b -> value) -> ('c -> value) ->
+  ('a * 'b * 'c) -> [> t]
+(** Build a triple. *)
+
+(** {2 Accessors} *)
+
+exception Parse_error of value * string
+(** All the following accessor functions expect the provided JSON
+    document to be of a certain kind. In case this is not the case,
+    [Parse_error] is raised. *)
+
+val get_unit: value -> unit
+(** Check that the JSON document is [`Null]. *)
+
+val get_bool: value -> bool
+(** Extract [b] from [`Bool b]. *)
+
+val get_string: value -> string
+(** Extract [s] from [`String s]. *)
+
+val get_strings: value -> string list
+(** Extract [s1;..;sn] from [`A [`String s1; ...; `String sn]]. *)
+
+val get_int: value -> int
+(** Extract an integer. *)
+
+val get_int32: value -> int32
+(** Extract a 32-bits integer. *)
+
+val get_int64: value -> int64
+(** Extract a 64-bits integer. *)
+
+val get_float: value -> float
+(** Extract a float. *)
+
+val get_list: (value -> 'a) -> value -> 'a list
+(** Extract elements from a JSON array. *)
+
+val get_option: (value -> 'a) -> value -> 'a option
+(** Extract an optional document. *)
+
+val get_dict: value -> (string * value) list
+(** Extract the elements from a dictionnary document. *)
+
+val get_pair: (value -> 'a) -> (value -> 'b) -> value -> ('a * 'b)
+(** Extract the pair. *)
+
+val get_triple: (value -> 'a) -> (value -> 'b) -> (value -> 'c) ->
+    value -> ('a * 'b * 'c)
+(** Extract the triple. *)
+
+(** {2 High-level functions} *)
+
+val mem: value -> string list -> bool
+(** [mem v path] is true if the given path is valid for the JSON document [v]. *)
+
+val find: value -> string list -> value
+(** Find the sub-document addressed by the given path. Raise
+    [Not_found] if the path is invalid. *)
+
+val find_opt : value -> string list -> value option
+(** Find the sub-document addressed by the given path. Returns
+    [None] if the path is invalid. *)
+
+val update: value -> string list -> value option -> value
+(** Update the sub-document addressed by the given path. If the
+    provided value is [None], then removes the sub-document. *)
+
+val map: (value -> value option) -> value -> string list -> value
+(** Apply a given function to a subdocument. *)
+
+val encode_string: string -> value
+(** Convert a (possibly non-valid UTF8) string to a JSON object.*)
+
+val decode_string: value -> string option
+(** Convert a JSON object to a (possibly non-valid UTF8)
+    string. Return [None] if the JSON object is not a valid string. *)
+
+val decode_string_exn: value -> string
+(** Convert a JSON object to a (possibly non-valid UTF8) string. *)
+
+val to_sexp: value -> Sexplib0.Sexp.t
+(** Convert a JSON fragment to an S-expression. *)
+
+val sexp_of_value: value -> Sexplib0.Sexp.t
+(** An alias of [to_sexp] *)
+
+val sexp_of_t: t -> Sexplib0.Sexp.t
+(** Convert a JSON object to an S-expression *)
+
+val of_sexp: Sexplib0.Sexp.t -> value
+(** Convert an S-expression to a JSON fragment *)
+
+val value_of_sexp: Sexplib0.Sexp.t -> value
+(** AN alias of [of_sexp] *)
+
+val t_of_sexp: Sexplib0.Sexp.t -> t
+(** Convert an S-expression to a JSON object *)
+
+(** {2 Error handling} *)
+
+val parse_error: value -> ('a, unit, string, 'b) format4 -> 'a
+(** Raise [Parse_error] *)

--- a/src/vscode/vscode-json/grammar.ml
+++ b/src/vscode/vscode-json/grammar.ml
@@ -17,18 +17,18 @@
 type capture_pattern = {
   pattern_include : string ; [@key "include"]
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type capture = {
   capture_name : string option ;
   capture_patterns : capture_pattern list option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type captures = (string * capture) list [@assoc]
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
-type endCaptures = captures
+type endCaptures = captures [@@deriving show]
 
 let endCaptures_enc =
   let open Json_encoding in
@@ -56,10 +56,10 @@ type pattern = {
   pat_contentName : string option ;
   pat_while : string option ;
 }
-[@@deriving json_encoding {recursive}]
+[@@deriving json_encoding {recursive}, show]
 
 type patterns = (string * pattern) list [@assoc]
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 type grammar = {
@@ -76,7 +76,7 @@ type grammar = {
   schema : string option ; [@key "$schema"]
   injectionSelector : string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 let schema = {|{
   "$schema": "http://json-schema.org/schema#",

--- a/src/vscode/vscode-json/language.ml
+++ b/src/vscode/vscode-json/language.ml
@@ -17,23 +17,23 @@
 type comments = {
   lineComment : string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type markers = {
   marker_start : string ;
   marker_end : string ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type folding = ( string * markers ) list [@assoc] (* "markers" *)
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type pair = {
   pair_open : string ;
   pair_close : string ;
   pair_notIn : string list ; [@dft []]
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 let pair_enc =
   let open Json_encoding in
@@ -53,7 +53,7 @@ type onEnterRule = {
   endTest : string option ;
   action : ( string * string ) list ;[@assoc] [@dft []]
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type language = {
   comments : comments option ;
@@ -64,4 +64,4 @@ type language = {
   folding : folding ; [@dft []]
   onEnterRules : onEnterRule list ; [@dft []]
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]

--- a/src/vscode/vscode-json/main.mli
+++ b/src/vscode/vscode-json/main.mli
@@ -19,8 +19,11 @@ type 'a result =
 type errors = (* warnings *) string list * (* errors *) string list
 
 
-val check_project : string -> errors
-val check_file : 'a Json_encoding.encoding -> string -> errors
+val check_project : ?verbose:bool -> string -> errors
+val check_file :
+  'a Json_encoding.encoding ->
+  ( Format.formatter -> 'a -> unit) ->
+  string -> errors
 
 val read_file : string -> 'a Json_encoding.encoding -> 'a result
 val write_file : string -> 'a Json_encoding.encoding -> 'a -> unit

--- a/src/vscode/vscode-json/package.toml
+++ b/src/vscode/vscode-json/package.toml
@@ -43,7 +43,7 @@ gen-version = "version.ml"
 
 # preprocessing options
 #  preprocess = "per-module (((action (run ./toto.sh %{input-file})) mod))" 
-preprocess = "pps ppx_deriving_encoding"
+preprocess = "pps ppx_deriving_encoding ppx_deriving.show"
 
 # files to skip while updating at package level
 # skip = []

--- a/src/vscode/vscode-json/snippets.ml
+++ b/src/vscode/vscode-json/snippets.ml
@@ -18,11 +18,11 @@ type snippet = {
   scope : string option ;
   description : string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 (* paths to files are available from the 'path' field of the 'snippets' field
    of 'package.json' *)
 type snippets =
   ( string * snippet ) list [@assoc]
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]

--- a/src/vscode/vscode-json/tasks.ml
+++ b/src/vscode/vscode-json/tasks.ml
@@ -19,6 +19,7 @@ let version = "2.0.0"
 type 'a string_or =
   | String of string
   | Or of 'a
+[@@deriving show]
 
 let string_or_enc encoding =
   let open Json_encoding in
@@ -57,7 +58,7 @@ type runOptions = {
    *)
   runOn :  string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type problemPattern = {
   (**
@@ -138,7 +139,7 @@ type problemPattern = {
    *)
   loop :  bool option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 (**
@@ -162,7 +163,7 @@ type backgroundMatcher = {
    *)
   endsPattern :  string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 (**
@@ -229,7 +230,7 @@ type problemMatcher = {
    *)
   background :  backgroundMatcher option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 type presentationOptions = {
@@ -277,13 +278,13 @@ type presentationOptions = {
    *)
   group :  string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type groupDescription = {
     kind : string option ; (* 'build' | 'test' *)
     isDefault : bool
     }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 (**
@@ -293,7 +294,7 @@ type taskDescription = {
   (**
    * The task's name
    *)
-  label : string;
+  label : string option;
 
   (**
    * The type of a custom task. Tasks of type "shell" are executed
@@ -344,7 +345,7 @@ type taskDescription = {
   dependsOn : string Manifest.list_or_one ; [@dft []]
   dependsOrder : string option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 
 type shellDescription = {
@@ -359,7 +360,7 @@ type shellDescription = {
      *)
     args :  string list ; [@dft []]
   }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 (**
  * Options to be passed to the external program or shell
@@ -382,7 +383,7 @@ type commandOptions = {
    *)
   shell: shellDescription option ;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type baseTaskConfiguration = {
   (**
@@ -428,9 +429,9 @@ type baseTaskConfiguration = {
    * The configuration of the available tasks. A tasks.json file can either
    * contain a global problemMatcher property or a tasks property but not both.
    *)
-  (* TODO tasks: taskDescription list; [@dft []] *)
+  tasks: taskDescription list; [@dft []]
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 type taskConfiguration = {
   base : baseTaskConfiguration ; [@merge]
@@ -454,6 +455,7 @@ type taskConfiguration = {
    *)
   linux: baseTaskConfiguration option;
 }
-[@@deriving json_encoding]
+[@@deriving json_encoding,show]
 
 let encoding = taskConfiguration_enc
+let pp = pp_taskConfiguration

--- a/src/vscode/vscode-package-json/main.ml
+++ b/src/vscode/vscode-package-json/main.ml
@@ -17,6 +17,9 @@ let read = ref false
 let print_result f file =
   read := true;
   match f file with
+  | exception exn ->
+    Printf.eprintf "File %s: exception %s\n%!" file
+      ( Printexc.to_string exn)
   | [], [] ->
     Printf.eprintf "File %s checked OK\n%!" file
   | warnings, [] ->
@@ -31,15 +34,77 @@ let print_result f file =
       Printf.eprintf "  Warnings also found\n%!";
       List.iter (fun s -> Printf.eprintf "      %s\n%!" s) warnings
 
+type kind =
+  | MANIFEST
+  | TASKS
+  | SNIPPET
+  | GRAMMAR
+  | LANGUAGE
+
 let () =
+  let verbose = ref false in
+  let kind = ref MANIFEST in
+  let parse file =
+    print_result
+      (match !kind with
+       | TASKS ->
+         Vscode_json.Main.check_file
+           Vscode_json.Tasks.encoding
+           Vscode_json.Tasks.pp
+       | SNIPPET ->
+         Vscode_json.Main.check_file
+           Vscode_json.Snippets.snippets_enc
+           Vscode_json.Snippets.pp_snippets
+       | GRAMMAR ->
+           Vscode_json.Main.check_file
+            Vscode_json.Grammar.grammar_enc
+            Vscode_json.Grammar.pp_grammar
+       | LANGUAGE ->
+           Vscode_json.Main.check_file
+            Vscode_json.Language.language_enc
+            Vscode_json.Language.pp_language
+       | MANIFEST ->
+         Vscode_json.Main.check_project ~verbose:!verbose
+      ) file
+  in
   Arg.parse [
+    "-v", Arg.Set verbose, "Set verbose mode";
     "--tasks",
-    Arg.String
-      (print_result (Vscode_json.Main.check_file Vscode_json.Tasks.encoding)),
-    "FILE Parse file FILE as a tasks.json file";
+    Arg.String (fun file ->
+        kind := TASKS;
+        parse file
+      ),
+    "FILE Parse file FILE as a .vscode/tasks.json file";
+
+    "--snippet",
+    Arg.String (fun file ->
+        kind := SNIPPET ;
+        parse file),
+    "FILE Parse file FILE as a snippets/*.json file";
+
+    "--grammar",
+    Arg.String (fun file ->
+        kind := GRAMMAR ;
+        parse file
+      ),
+    "FILE Parse file FILE as a syntaxes/*.json file";
+
+    "--language",
+    Arg.String (fun file ->
+        kind := LANGUAGE ;
+        parse file
+      ),
+    "FILE Parse file FILE as a language *.json file";
+
+    "--manifest",
+    Arg.String (fun file ->
+        kind := MANIFEST ;
+        parse file
+      ),
+    "FILE Parse file FILE as a package.json file";
 
   ]
-    (print_result Vscode_json.Main.check_project)
+    parse
     "package-json [FILES]: parse files or generate file" ;
 
   if not !read then

--- a/src/vscode/vscode-package-json/project.ml
+++ b/src/vscode/vscode-package-json/project.ml
@@ -42,7 +42,7 @@ let package =
     ~homepage: "https://ocamlpro.com/cobol"
     ~author: {
       author_name = "OCamlPro SAS" ;
-      author_email = "contact@ocamlpro.com"
+      author_email = Some "contact@ocamlpro.com"
     }
     ~keywords: [ "cobol" ; "gnucobol" ]
     ~main: "./out/superbol_vscode_platform.bc.js"


### PR DESCRIPTION
* Support for comments in JSON files, using a patched version of Ezjsonm
* New options to parse various JSON files (grammars, languages, snippets, etc.)
* Print the content of JSON files in OCaml format to be able to easily integrate them in our modes