### PR TITLE
Clear source overlay cache upon parser rewind

### DIFF
--- a/src/lsp/cobol_parser/grammar_utils.ml
+++ b/src/lsp/cobol_parser/grammar_utils.ml
@@ -20,7 +20,7 @@ open Cobol_ptree
 module Overlay_manager =
   Cobol_preproc.Src_overlay.New_manager (struct
     let name = __MODULE__
-  end)
+  end) ()
 
 let relation_condition ~neg (binrel: binary_relation) = function
   | None ->

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -562,6 +562,7 @@ let rec rewind_n_parse
       let pp = pp_rewind ~new_position:event.preproc_position pp in
       let ps = { ps with preproc = { ps.preproc with pp } } in
       let ps, tokens = produce_tokens ps in
+      Option.iter Overlay_manager.restart_at ps.prev_limit;
       { rwps with stage = Trans (ps, tokens, env); store }
     with Not_found ->                     (* rewinding before first checkpoint *)
       let pp = pp_rewind rwps.init.preproc.pp in

--- a/src/lsp/cobol_preproc/preproc_engine.ml
+++ b/src/lsp/cobol_preproc/preproc_engine.ml
@@ -79,7 +79,7 @@ let preprocessor input = function
   | `WithOptions { libpath; verbose; source_format;
                    config = (module Config) } ->
       let module Om_name = struct let name = __MODULE__ end in
-      let module Om = Src_overlay.New_manager (Om_name) in
+      let module Om = Src_overlay.New_manager (Om_name) () in
       let module Pp = Preproc_grammar.Make (Config) (Om) in
       let source_format = source_format_config source_format in
       {

--- a/src/lsp/cobol_preproc/src_overlay.mli
+++ b/src/lsp/cobol_preproc/src_overlay.mli
@@ -15,13 +15,11 @@
     of lexing tokens that can be fed to parsers so as to tag ASTs with complex
     source locations. *)
 
-(* For now, it does not seem worth making this generic in
-   `Cobol_common.Srcloc.srcloc` via an additional functor. *)
-
-(** Source overlay limits, that MUST be considered abstract and whose contents
-    must not be inspected nor relied upon outside of this module.  Such limits
-    are to be fed to parsers, that usually expect lexing positons, so
-    unfortunately we can neither make this type abstract nor private.  *)
+(** Source overlay limits, that {e MUST} be considered abstract and whose
+    contents must not be inspected nor relied upon outside of this module.  Such
+    limits are to be fed to menhir-generated parsers, that expect lexing
+    positons from the {!Stdlib.Lexing} module, so unfortunately we can neither
+    make this type abstract nor private.  *)
 type limit = (* private *) Lexing.position
 
 (** Manager of source overlay limits.  Includes some mutable state. *)
@@ -48,7 +46,12 @@ module type MANAGER = sig
       but not given to {!link_limits} below. *)
   val dummy_limit: limit
 
+  (** [restart_at limit] instructs the manager that limits on the right of (but
+      not including) [limit] are now outdated and should not be relied upon.  At
+      the moment this just clears an internal cache. *)
+  val restart_at: limit -> unit
+
 end
 
 (** Nanager module instantiation *)
-module New_manager: functor (Id: sig val name: string end) -> MANAGER
+module New_manager: functor (Id: sig val name: string end) () -> MANAGER


### PR DESCRIPTION
This fixes a potential undefined behavior (infinite loop) in cache lookup, that may occur when rewinding tokens that are involved in composed source locations.