### PR TITLE
Indent text from buffer, not disk

### DIFF
--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -18,10 +18,15 @@ let indent_range' = Indenter.indent_range'
 
 (*indent the whole file and print*)
 let indent_file ~dialect ~source_format ~file ~indent_config =
-  indent_range' ~dialect ~source_format ~range:None ~indent_config ~file
+  let contents = Ez_file.V1.EzFile.read_file file in
+  indent_range'
+    ~dialect ~source_format ~range:None ~indent_config
+    ~filename:file ~contents
   |> Fmt.pr "%s"
 
 (*indent a range of file and print*)
 let indent_range ~dialect ~source_format ~file ~range ~indent_config =
-  indent_range' ~dialect ~source_format ~range ~indent_config ~file
+  let contents = Ez_file.V1.EzFile.read_file file in
+  indent_range' ~dialect ~source_format ~range ~indent_config
+    ~filename:file ~contents
   |> Fmt.pr "%s"

--- a/src/lsp/cobol_indent/indenter.mli
+++ b/src/lsp/cobol_indent/indenter.mli
@@ -17,5 +17,6 @@ val indent_range'
   -> source_format:Cobol_config.source_format_spec
   -> indent_config:string option
   -> range:Indent_type.range option
-  -> file:string
+  -> filename:string
+  -> contents:string
   -> string


### PR DESCRIPTION
When indenting a file from the LSP, use the text from the current buffer, not the last version saved to disk (otherwise changes could disappear).