### PR TITLE
Fix form for customizing `superbol.path`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
           "description": "If something is selected, only format the selection"
         },
         "superbol.path": {
+          "type": "string",
           "default": "superbol-free",
           "description": "Path to the `superbol` command"
         }

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -145,7 +145,9 @@ let contributes =
 
             Manifest.PROPERTY.string "superbol.path"
               ~default:"superbol-free"
-              ~description: "Path to the `superbol` command"
+              ~description:
+              "Name of the `superbol` command; path can be relative (deprecated) or \
+               absolute."
           ] )
     ~taskDefinitions: [
       Manifest.taskDefinition

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -146,7 +146,7 @@ let contributes =
             Manifest.PROPERTY.string "superbol.path"
               ~default:"superbol-free"
               ~description:
-              "Name of the `superbol` excutable if available in PATH; \
+              "Name of the `superbol` executable if available in PATH; \
                otherwise may be an absolute path."
           ] )
     ~taskDefinitions: [

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -146,8 +146,8 @@ let contributes =
             Manifest.PROPERTY.string "superbol.path"
               ~default:"superbol-free"
               ~description:
-              "Name of the `superbol` command; path can be relative (deprecated) or \
-               absolute."
+              "Name of the `superbol` excutable if available in PATH; \
+               otherwise may be an absolute path."
           ] )
     ~taskDefinitions: [
       Manifest.taskDefinition

--- a/src/vscode/vscode-json/manifest.ml
+++ b/src/vscode/vscode-json/manifest.ml
@@ -217,7 +217,7 @@ type property = {
   prop_markdownDescription : string option ;
   prop_deprecationMessage : string option ;
 
-  prop_type : any; [@dft `String "string"] (* "array", "boolean", "number", "object", "string" *)
+  prop_type : any; (* "array", "boolean", "number", "object", "string" *)
   prop_default : any option ; (* from type *)
   prop_description : string option ;
 


### PR DESCRIPTION
This PR fixes the `superbol.path` form that was not displayed because of a type error.