### PR TITLE
 Only enable indenter on free format 

### DIFF
--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -14,19 +14,12 @@
 module Type = Indent_type
 
 (*return the result of indentation. use user-defined indent_config*)
-let indent_range' = Indenter.indent_range'
+let indent_range = Indenter.indent_range
 
 (*indent the whole file and print*)
 let indent_file ~dialect ~source_format ~file ~indent_config =
   let contents = Ez_file.V1.EzFile.read_file file in
-  indent_range'
+  indent_range
     ~dialect ~source_format ~range:None ~indent_config
-    ~filename:file ~contents
-  |> Fmt.pr "%s"
-
-(*indent a range of file and print*)
-let indent_range ~dialect ~source_format ~file ~range ~indent_config =
-  let contents = Ez_file.V1.EzFile.read_file file in
-  indent_range' ~dialect ~source_format ~range ~indent_config
     ~filename:file ~contents
   |> Fmt.pr "%s"

--- a/src/lsp/cobol_indent/indent_type.ml
+++ b/src/lsp/cobol_indent/indent_type.ml
@@ -154,6 +154,7 @@ type context = (context_kind * int) list
 
 type indent_state =
     {
+      src_format: Cobol_preproc.Src_format.any;
       scope: context_kind; (*indicate where the current code is*)
       context: context;    (*the stack of (context_kind, offset)*)
       acc: indent_record list;

--- a/src/lsp/cobol_indent/indenter.ml
+++ b/src/lsp/cobol_indent/indenter.ml
@@ -73,14 +73,10 @@ let indenter ~source_format (str:string) (rdl:indent_record list) range =
 
 (*indent a range of file, with the default indent_config*)
 let indent_range ~dialect ~source_format ~range ~filename ~contents =
-  let src_format =
-    (* Note: this value doesn't actually matter, it will be overriden
-       immediately by [fold_source_lines] calling [on_initial_source_format]
-       below. *)
-    match source_format with
-    | Cobol_config.Auto -> Cobol_preproc.Src_format.from_config SFFixed
-    | SF source_format -> Cobol_preproc.Src_format.from_config source_format
-  in
+  (* Note: this value doesn't actually matter, it will be overriden
+      immediately by [fold_source_lines] calling [on_initial_source_format]
+      below. *)
+  let src_format = Cobol_preproc.Src_format.from_config SFFixed in
   let state =
     Cobol_preproc.fold_source_lines ~dialect ~source_format
       ~on_initial_source_format:(fun src_format st -> { st with src_format })

--- a/src/lsp/cobol_indent/indenter.ml
+++ b/src/lsp/cobol_indent/indenter.ml
@@ -62,7 +62,7 @@ let indenter ~source_format (str:string) (rdl:indent_record list) range =
   String.concat "\n" strl
 
 (*indent a range of file, with the default indent_config*)
-let indent_range' ~dialect ~source_format ~range ~filename ~contents =
+let indent_range ~dialect ~source_format ~range ~filename ~contents =
   let state =
     Cobol_preproc.fold_source_lines ~dialect ~source_format
       ~skip_compiler_directives_text:true
@@ -75,9 +75,9 @@ let indent_range' ~dialect ~source_format ~range ~filename ~contents =
   indenter ~source_format contents ind_recds state.result.range
 
 (*indent a range of file, with the user-defined indent_config*)
-let indent_range' ~dialect ~source_format ~indent_config ~range ~filename ~contents =
+let indent_range ~dialect ~source_format ~indent_config ~range ~filename ~contents =
   begin match indent_config with
     | Some indent_config -> Indent_config.set_config ~indent_config
     | None -> ()
   end;
-  indent_range' ~dialect ~source_format ~range ~filename ~contents
+  indent_range ~dialect ~source_format ~range ~filename ~contents

--- a/src/lsp/cobol_indent/indenter.ml
+++ b/src/lsp/cobol_indent/indenter.ml
@@ -27,14 +27,21 @@ let indenter ~source_format (str:string) (rdl:indent_record list) range =
     let str = List.nth strl (lnum - 1) in
     let newstr =
       match source_format with
-      | Cobol_config.SF SFFree ->
+      | Cobol_preproc.Src_format.SF (NoIndic, FreePaging) ->
         if offset > 0 then
           let space = String.make offset ' ' in
           space^str
         else
           String.sub str (-offset) (String.length str + offset)
-      (*TODO: must change if Auto <> SF SFFixed once*)
-      | SF SFFixed | Auto ->
+      | SF (FixedIndic, FixedWidth _) ->
+        (* Indenting temporarily disabled in fixed format
+           https://github.com/OCamlPro/superbol-studio-oss/issues/52
+
+           Support must be improved before enabling again, in particular to
+           avoid pushing content into the margin.
+           https://github.com/OCamlPro/superbol-studio-oss/issues/45
+          *)
+        if true then str else
         let len = String.length str in
         let str1 = String.sub str 0 7 in
         let str = String.sub str 7 (len-7) in
@@ -46,8 +53,11 @@ let indenter ~source_format (str:string) (rdl:indent_record list) range =
             String.sub str (-offset) (String.length str + offset)
           in
         str1^str
-      (*TODO*)
-      | _ -> str
+      (* TODO *)
+      | SF (XOpenIndic, FixedWidth _) -> str
+      | SF (CRTIndic, FixedWidth _) -> str
+      | SF (TrmIndic, FixedWidth _) -> str
+      | SF (CBLXIndic, FixedWidth _) -> str
     in
     List.mapi (fun i str -> if i = lnum - 1 then newstr else str) (strl)
   in
@@ -63,16 +73,31 @@ let indenter ~source_format (str:string) (rdl:indent_record list) range =
 
 (*indent a range of file, with the default indent_config*)
 let indent_range ~dialect ~source_format ~range ~filename ~contents =
+  let src_format =
+    (* Note: this value doesn't actually matter, it will be overriden
+       immediately by [fold_source_lines] calling [on_initial_source_format]
+       below. *)
+    match source_format with
+    | Cobol_config.Auto -> Cobol_preproc.Src_format.from_config SFFixed
+    | SF source_format -> Cobol_preproc.Src_format.from_config source_format
+  in
   let state =
     Cobol_preproc.fold_source_lines ~dialect ~source_format
+      ~on_initial_source_format:(fun src_format st -> { st with src_format })
+      ~on_compiler_directive:(fun _ { payload = cd;  _} st ->
+        match cd with
+        | CDirSource { payload = src_format; _ } -> { st with src_format }
+        | _ -> st
+      )
       ~skip_compiler_directives_text:true
       ~f:(fun _lnum line acc -> Indent_check.check_indentation line acc)
       (String { filename; contents })
-      { scope = BEGIN; context  = []; acc = []; range }
+      { src_format; scope = BEGIN; context  = []; acc = []; range }
   in
   (* NB: note here we ignore diagnostics *)
   let ind_recds = state.result.acc in
-  indenter ~source_format contents ind_recds state.result.range
+  indenter
+    ~source_format:state.result.src_format contents ind_recds state.result.range
 
 (*indent a range of file, with the user-defined indent_config*)
 let indent_range ~dialect ~source_format ~indent_config ~range ~filename ~contents =

--- a/src/lsp/cobol_indent/indenter.mli
+++ b/src/lsp/cobol_indent/indenter.mli
@@ -12,7 +12,7 @@
 (**************************************************************************)
 
 (*indent a range of file, with the user-defined or default indent_config*)
-val indent_range'
+val indent_range
   : dialect: Cobol_config.dialect
   -> source_format:Cobol_config.source_format_spec
   -> indent_config:string option

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -178,7 +178,7 @@ let handle_range_formatting registry params =
     }
   in
   let newText =
-    Cobol_indent.indent_range'
+    Cobol_indent.indent_range
       ~dialect:(Cobol_config.dialect project.cobol_config)
       ~source_format:project.source_format
       ~indent_config:None
@@ -203,7 +203,7 @@ let handle_formatting registry params =
   in
   try
     let newText =
-      Cobol_indent.indent_range'
+      Cobol_indent.indent_range
         ~dialect:(Cobol_config.dialect project.cobol_config)
         ~source_format:project.source_format
         ~indent_config:None

--- a/src/lsp/superbol_free_lib/command_indent_file.ml
+++ b/src/lsp/superbol_free_lib/command_indent_file.ml
@@ -17,11 +17,15 @@ open Cobol_indent
 
 open Common_args
 
-let action { preproc_options = { source_format; _ } ; _ } ~indent_config
-    files =
+let action { preproc_options = { source_format; config; _ } ; _ }
+    ~indent_config files =
+  let module Config = (val config) in
   List.to_seq files
   |> Seq.map (fun file ->
-      indent_file ~source_format ~file ~indent_config)
+    let contents = Ez_file.V1.EzFile.read_file file in
+    indent_range
+      ~source_format ~filename:file ~contents ~indent_config ~range:None
+      ~dialect:Config.dialect |> Fmt.pr "%s")
 
 let cmd =
   let files = ref [] in

--- a/src/lsp/superbol_free_lib/command_indent_range.ml
+++ b/src/lsp/superbol_free_lib/command_indent_range.ml
@@ -20,8 +20,9 @@ open Common_args
 let action { preproc_options = { source_format; config; _ }; _ } ~file ~range
     ~indent_config =
   let module Config = (val config) in
-  indent_range ~source_format ~file ~range ~indent_config
-    ~dialect:Config.dialect
+  let contents = Ez_file.V1.EzFile.read_file file in
+  indent_range ~source_format ~filename:file ~contents ~range ~indent_config
+    ~dialect:Config.dialect |> Fmt.pr "%s"
 
 let cmd =
   let file = ref "" in

--- a/test/lsp/lsp_formatting.ml
+++ b/test/lsp/lsp_formatting.ml
@@ -23,7 +23,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "simple-formatting-request" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -58,7 +60,9 @@ let doc = {cobol|
         move 1 to x.  |cobol};;
 
 let%expect_test "formatting-request-nested-if" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -100,7 +104,9 @@ let doc = {cobol|
         value 999.              |cobol};;
 
 let%expect_test "formatting-request-data" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -173,7 +179,9 @@ let doc = {cobol|
         |cobol};;
 
 let%expect_test "formatting-request-nested-program" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -231,7 +239,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-alignment-argument" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -263,7 +273,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-else-if" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -381,7 +393,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-whole-program" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -400,9 +414,6 @@ let%expect_test "formatting-request-whole-program" =
       implementation
     data_sections_visitor.ml:0:
       (Cobol_ptree__Data_sections_visitor.fold_file_section): missing visitor
-      implementation
-    data_sections_visitor.ml:0:
-      (Cobol_ptree__Data_sections_visitor.fold_data_clause): partial visitor
       implementation
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
             IDENTIFICATION DIVISION.
@@ -507,7 +518,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-on-exception" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
@@ -542,7 +555,9 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-perform" =
-  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  let { projdir; end_with_postproc }, server =
+    make_lsp_project ~toml:"source-format = \"free\"\n" ()
+  in
   let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
   let params =
     let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in

--- a/test/lsp/lsp_formatting.ml
+++ b/test/lsp/lsp_formatting.ml
@@ -415,6 +415,9 @@ let%expect_test "formatting-request-whole-program" =
     data_sections_visitor.ml:0:
       (Cobol_ptree__Data_sections_visitor.fold_file_section): missing visitor
       implementation
+    data_sections_visitor.ml:0:
+      (Cobol_ptree__Data_sections_visitor.fold_data_clause): partial visitor
+      implementation
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
             IDENTIFICATION DIVISION.
             PROGRAM-ID. MACESDS.


### PR DESCRIPTION
The indenter also now uses inferred formats properly.

Fixes #52

Note: Currently includes #73; do not merge before #73.