### PR TITLE
Default superbol.path option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
           "description": "If something is selected, only format the selection"
         },
         "superbol.path": {
-          "default": "",
+          "default": "superbol-free",
           "description": "Path to the `superbol` command"
         }
       }

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -144,7 +144,7 @@ let contributes =
                 "If something is selected, only format the selection" ;
 
             Manifest.PROPERTY.string "superbol.path"
-              ~default: ""
+              ~default:"superbol-free"
               ~description: "Path to the `superbol` command"
           ] )
     ~taskDefinitions: [


### PR DESCRIPTION
This PR sets the default value `superbol.path` to the executable name. This works when the `PATH` environment variable already points to the executable. This probably is not cross-compatible though.