### PR TITLE
Instruct github about some more auto-generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+dune             linguist-generated
+linking_flags.sh linguist-generated
+/.drom           linguist-generated
+/Makefile        linguist-generated
+/dune-project    linguist-generated
+/sphinx/conf.py  linguist-generated
+/package.json    linguist-generated


### PR DESCRIPTION
Github shows changes to many files that are actually generated by `drom`. The new `.gitattributes` instructs it to hide the diffs by default.

Note: some of the generated files might still be relevant for review, and some others might be missing. So suggestions are welcome.