### PR TITLE
Prevent drom from generating main.ml

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-3b1faf25344f4faae93ba95094d29269:.
+663f90017e3c5790a062517820a3e6ad:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -30,7 +30,7 @@ d00f73c835ae4a1589d55ebda4ab381b:CHANGES.md
 
 # begin context for Makefile
 # file Makefile
-d71d6060ee4fa0a89488a6d4c0178158:Makefile
+312a3b90d7157dcdb12c1fdfe4e1ad8e:Makefile
 # end context for Makefile
 
 # begin context for README.md
@@ -80,7 +80,7 @@ c8281f46ba9a11d0b61bc8ef67eaa357:docs/style.css
 
 # begin context for dune-project
 # file dune-project
-de3add436687f5413eb9cb4563b6e570:dune-project
+0789670db0bdf3e661b3515a9d8dfa3b:dune-project
 # end context for dune-project
 
 # begin context for opam/cobol_ast.opam
@@ -270,7 +270,7 @@ a4431c32911b7499fbdc49e2e62932d2:sphinx/about.rst
 
 # begin context for sphinx/conf.py
 # file sphinx/conf.py
-0f6a35278b93d5d9ceca6431677766e6:sphinx/conf.py
+ccc62713dbcdd2c46d19abc75e68f8f9:sphinx/conf.py
 # end context for sphinx/conf.py
 
 # begin context for sphinx/index.rst
@@ -425,7 +425,7 @@ eab335ce600887c59f1baf9b0983d0ac:src/lsp/ezr_toml/dune
 
 # begin context for src/lsp/superbol-free/linking_flags.sh
 # file src/lsp/superbol-free/linking_flags.sh
-4481ce2bc21d3553716a7914d2cc015a:src/lsp/superbol-free/linking_flags.sh
+7d3dc8d16165ef74c2866a6d0c42bec4:src/lsp/superbol-free/linking_flags.sh
 # end context for src/lsp/superbol-free/linking_flags.sh
 
 # begin context for src/lsp/superbol_free_lib/dune
@@ -510,7 +510,7 @@ ffef64c84976f7655b4dd57e795d7097:src/lsp/superbol_free_lib/dune
 
 # begin context for src/vscode/superbol-vscode-platform/dune
 # file src/vscode/superbol-vscode-platform/dune
-664342638a68e3f2f79d39343772e32f:src/vscode/superbol-vscode-platform/dune
+00f2c3534d6e97da83741e1e1b94374c:src/vscode/superbol-vscode-platform/dune
 # end context for src/vscode/superbol-vscode-platform/dune
 
 # begin context for src/vscode/superbol-vscode-platform/version.mlt

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: all build build-deps fmt fmt-check install dev-deps test
 .PHONY: clean distclean
 
-DEV_DEPS := merlin ocamlformat odoc
+DEV_DEPS := merlin ocamlformat odoc ppx_expect ppx_inline_test
 
 
 SPHINX_TARGET:=_drom/docs/sphinx
@@ -25,7 +25,7 @@ build:
 
 build-deps:
 	if ! [ -e _opam ]; then \
-	   opam switch create . 4.14.1 --no-install ; \
+	   opam switch create . 4.14.1 ; \
 	fi
 	opam install ./opam/*.opam --deps-only
 

--- a/drom.toml
+++ b/drom.toml
@@ -33,7 +33,7 @@ of the superbol-studio-oss OCaml project
 """
 
 [project]
-skip = ["@test", "@ocamlformat", "@ocp-indent", "README.md", "sphinx/about.rst", "LICENSE.md", "sphinx/index.rst"]
+skip = ["@test", "@ocamlformat", "@ocp-indent", "README.md", "sphinx/about.rst", "LICENSE.md", "sphinx/index.rst", "src/lsp/pretty/main.ml", "src/lsp/cobol_typeck/main.ml", "src/lsp/cobol_ptree/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_data/main.ml", "src/lsp/cobol_indent/main.ml", "src/testing/superbol_testutils/main.ml"]
 
 # project-wide library dependencies (not for package-specific deps)
 [dependencies]

--- a/drom.toml
+++ b/drom.toml
@@ -33,7 +33,7 @@ of the superbol-studio-oss OCaml project
 """
 
 [project]
-skip = ["@test", "@ocamlformat", "@ocp-indent", "README.md", "sphinx/about.rst", "LICENSE.md", "sphinx/index.rst", "src/lsp/pretty/main.ml", "src/lsp/cobol_typeck/main.ml", "src/lsp/cobol_ptree/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_data/main.ml", "src/lsp/cobol_indent/main.ml", "src/testing/superbol_testutils/main.ml"]
+skip = ["@test", "@ocamlformat", "@ocp-indent", "README.md", "sphinx/about.rst", "LICENSE.md", "sphinx/index.rst", "src/lsp/pretty/main.ml", "src/lsp/cobol_typeck/main.ml", "src/lsp/cobol_ptree/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_lsp/main.ml", "src/lsp/cobol_data/main.ml", "src/lsp/cobol_indent/main.ml", "src/testing/superbol_testutils/main.ml", "src/lsp/ezr_toml/main.ml", "src/lsp/superbol_project/main.ml"]
 
 # project-wide library dependencies (not for package-specific deps)
 [dependencies]

--- a/dune-project
+++ b/dune-project
@@ -3,6 +3,7 @@
 
 (cram enable)
 (name superbol-vscode-platform)
+(allow_approximate_merlin)
 (generate_opam_files false)
 (version 0.1.0)
 (formatting (enabled_for ocaml reason))

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# superbol documentation build configuration file, created by
+# superbol-vscode-platform documentation build configuration file, created by
 # sphinx-quickstart.
 #
 # This file is execfile()d with the current directory set to its
@@ -50,7 +50,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = 'superbol'
+project = 'superbol-vscode-platform'
 copyright = 'OCamlPro SAS'
 author = 'Nicolas Berthier <nicolas.berthier@ocamlpro.com> & David Declerck <david.declerck@ocamlpro.com> & Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com> & Emilien Lemaire <emilien.lemaire@ocamlpro.com>'
 
@@ -167,7 +167,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'superbol.tex', 'superbol Documentation',
+    (master_doc, 'superbol-vscode-platform.tex', 'superbol-vscode-platform Documentation',
      'author', 'manual'),
 ]
 
@@ -177,7 +177,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'superbol', 'superbol Documentation',
+    (master_doc, 'superbol-vscode-platform', 'superbol-vscode-platform Documentation',
      [author], 1)
 ]
 
@@ -188,8 +188,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'superbol', 'superbol Documentation',
-     author, 'superbol', 'One line description of project.',
+    (master_doc, 'superbol-vscode-platform', 'superbol-vscode-platform Documentation',
+     author, 'superbol-vscode-platform', 'One line description of project.',
      'Miscellaneous'),
 ]
 
@@ -220,4 +220,4 @@ epub_exclude_files = ['search.html']
 
 # entry point for setup
 def setup(app):
-    app.add_css_file('css/fixes.css')
+    app.add_stylesheet('css/fixes.css')

--- a/src/vscode/superbol-vscode-platform/dune
+++ b/src/vscode/superbol-vscode-platform/dune
@@ -5,9 +5,6 @@
   (libraries vscode-languageclient-js-stubs vscode-js-stubs promise_jsoo polka-js-stubs ocplib_stuff node-js-stubs jsonoo js_of_ocaml gen_js_api )
   (modes js)
   (preprocess (pps gen_js_api.ppx))
-   (js_of_ocaml (flags --source-map --pretty))
- (enabled_if (= %{context_name} "default"))
-
   )
 
 (install


### PR DESCRIPTION
Not sure why it is generating main.ml for library projects, but I don't want them, so I add them to the `skip` field in `drom.toml` as instructed by the generated files themselves.

(Using drom 0.9.0)