### PR TITLE
Use minimal diffs for the indenter

### DIFF
--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -16,61 +16,9 @@ module Type = Indent_type
 (*return the result of indentation. use user-defined indent_config*)
 let indent_range = Indenter.indent_range
 
-(** [apply s rdl] applies the changes in [rdl] to the text in [s]. [rdl] is
-    expected to have been computed by calling [indent_range ~contents:s]. *)
-let apply : string -> Type.indent_record list -> string =
-  (*
-    [irs] contains a list of {!Type.indent_record} entries describing how to
-     modify the indentation.  They must be sorted in increasing order, and there
-     must be at most one record per line.
-
-    [buf] is a {!Buffer.t} into which we are writing the indented content.
-
-    [s] is the original content to indent as a {!string}.
-
-    [line] is the current line, which starts at offset [bol] in the string [s].
-
-    [start] is an offset in [s], less than or equal to [bol], that must be
-    preserved as-is. This allows copying large unmodified chunks of text (lines
-    that are already properly indented) using a single call to
-    {!Buffer.add_substring} for reduced overhead.
-  *)
-  let rec aux ~start (irs : Type.indent_record list) buf s line bol =
-    (* Note: this can raise [Invalid_argument] if the modifications do not
-       cleanly apply to the input string, which include cases where there are
-       modifications on lines past the end of the input, modifications that are
-       not sorted, etc. -- we can call [invalid_arg] ourselves, but
-       [String.index_from] can also raise [Invalid_argument] in these
-       conditions. *)
-    match irs with
-    | [] when start = 0 -> s
-    | [] ->
-      Buffer.add_substring buf s start (String.length s - start);
-      Buffer.contents buf
-    | { lnum; offset_orig; offset_modif } :: irs when line = lnum - 1 ->
-      let eol =
-        try String.index_from s bol '\n' + 1 with Not_found -> String.length s
-      in
-      let delta = offset_modif - offset_orig in
-      if delta > 0 then (
-        Buffer.add_substring buf s start (bol + offset_orig - start);
-        for _ = 0 to delta - 1 do
-          Buffer.add_char buf ' '
-        done;
-      ) else (
-        Buffer.add_substring buf s start (bol - start + offset_orig + delta);
-      );
-      aux ~start:(bol + offset_orig) irs buf s (line + 1) eol
-    | _ :: _ ->
-      match String.index_from s bol '\n' + 1 with
-      | eol -> aux ~start irs buf s (line + 1) eol
-      | exception Not_found ->
-        (* Modifications on lines past the end of the input. *)
-        invalid_arg "Cobol_indent.apply"
-  in
-  fun s rdl ->
-    try
-      let buf = Buffer.create (String.length s) in
-      aux ~start:0 (List.rev rdl) buf s 0 0
-    with Invalid_argument _ ->
-      Fmt.failwith "Could not indent: internal error"
+let indent_range_str
+  ~dialect ~source_format ~indent_config ~range ~filename ~contents
+=
+indent_range
+  ~dialect ~source_format ~indent_config ~range ~filename ~contents
+|> Indent_util.apply contents

--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -18,7 +18,7 @@ let indent_range = Indenter.indent_range
 
 (** [apply s rdl] applies the changes in [rdl] to the text in [s]. [rdl] is
     expected to have been computed by calling [indent_range ~contents:s]. *)
-let apply =
+let apply : string -> Type.indent_record list -> string =
   (*
     [irs] contains a list of {!Type.indent_record} entries describing how to
      modify the indentation.  They must be sorted in increasing order, and there
@@ -43,17 +43,16 @@ let apply =
        [String.index_from] can also raise [Invalid_argument] in these
        conditions. *)
     match irs with
+    | [] when start = 0 -> s
     | [] ->
-      if start = 0 then s else (
-        Buffer.add_substring buf s start (String.length s - start);
-        Buffer.contents buf
-      )
+      Buffer.add_substring buf s start (String.length s - start);
+      Buffer.contents buf
     | { lnum; offset_orig; offset_modif } :: irs when line = lnum - 1 ->
       let eol =
         try String.index_from s bol '\n' + 1 with Not_found -> String.length s
       in
       let delta = offset_modif - offset_orig in
-      if delta > 0 || true then (
+      if delta > 0 then (
         Buffer.add_substring buf s start (bol + offset_orig - start);
         for _ = 0 to delta - 1 do
           Buffer.add_char buf ' '

--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -16,10 +16,62 @@ module Type = Indent_type
 (*return the result of indentation. use user-defined indent_config*)
 let indent_range = Indenter.indent_range
 
-(*indent the whole file and print*)
-let indent_file ~dialect ~source_format ~file ~indent_config =
-  let contents = Ez_file.V1.EzFile.read_file file in
-  indent_range
-    ~dialect ~source_format ~range:None ~indent_config
-    ~filename:file ~contents
-  |> Fmt.pr "%s"
+(** [apply s rdl] applies the changes in [rdl] to the text in [s]. [rdl] is
+    expected to have been computed by calling [indent_range ~contents:s]. *)
+let apply =
+  (*
+    [irs] contains a list of {!Type.indent_record} entries describing how to
+     modify the indentation.  They must be sorted in increasing order, and there
+     must be at most one record per line.
+
+    [buf] is a {!Buffer.t} into which we are writing the indented content.
+
+    [s] is the original content to indent as a {!string}.
+
+    [line] is the current line, which starts at offset [bol] in the string [s].
+
+    [start] is an offset in [s], less than or equal to [bol], that must be
+    preserved as-is. This allows copying large unmodified chunks of text (lines
+    that are already properly indented) using a single call to
+    {!Buffer.add_substring} for reduced overhead.
+  *)
+  let rec aux ~start (irs : Type.indent_record list) buf s line bol =
+    (* Note: this can raise [Invalid_argument] if the modifications do not
+       cleanly apply to the input string, which include cases where there are
+       modifications on lines past the end of the input, modifications that are
+       not sorted, etc. -- we can call [invalid_arg] ourselves, but
+       [String.index_from] can also raise [Invalid_argument] in these
+       conditions. *)
+    match irs with
+    | [] ->
+      if start = 0 then s else (
+        Buffer.add_substring buf s start (String.length s - start);
+        Buffer.contents buf
+      )
+    | { lnum; offset_orig; offset_modif } :: irs when line = lnum - 1 ->
+      let eol =
+        try String.index_from s bol '\n' + 1 with Not_found -> String.length s
+      in
+      let delta = offset_modif - offset_orig in
+      if delta > 0 || true then (
+        Buffer.add_substring buf s start (bol + offset_orig - start);
+        for _ = 0 to delta - 1 do
+          Buffer.add_char buf ' '
+        done;
+      ) else (
+        Buffer.add_substring buf s start (bol - start + offset_orig + delta);
+      );
+      aux ~start:(bol + offset_orig) irs buf s (line + 1) eol
+    | _ :: _ ->
+      match String.index_from s bol '\n' + 1 with
+      | eol -> aux ~start irs buf s (line + 1) eol
+      | exception Not_found ->
+        (* Modifications on lines past the end of the input. *)
+        invalid_arg "Cobol_indent.apply"
+  in
+  fun s rdl ->
+    try
+      let buf = Buffer.create (String.length s) in
+      aux ~start:0 (List.rev rdl) buf s 0 0
+    with Invalid_argument _ ->
+      Fmt.failwith "Could not indent: internal error"

--- a/src/lsp/cobol_indent/indent_config.ml
+++ b/src/lsp/cobol_indent/indent_config.ml
@@ -62,9 +62,11 @@ let () =
       "SECTION", 0 ]
 
 let set_config ~indent_config =
-  let str = Ez_file.V1.EzFile.read_file indent_config in
-  let strlist = String.split_on_char '\n' str in
-  build_table strlist offset_table
+  match Ez_file.V1.EzFile.read_file indent_config with
+  | str ->
+    let strlist = String.split_on_char '\n' str in
+    build_table strlist offset_table
+  | exception Sys_error _ -> ()
 
 let offset_of_keyword keyword =
   match keyword with

--- a/src/lsp/cobol_indent/indent_config.ml
+++ b/src/lsp/cobol_indent/indent_config.ml
@@ -61,6 +61,13 @@ let () =
       "DECLARATIVES", 0;
       "SECTION", 0 ]
 
+(* FIXME: This should be temporary, and the config for the indenter should come
+   as a pre-filled record for the cobol_indent library (typically,
+   indent_config.ml, bound as Cobol_indent.Config, would only define the type of
+   this record).
+
+   See: https://github.com/OCamlPro/superbol-studio-oss/issues/46
+ *)
 let set_config ~indent_config =
   match Ez_file.V1.EzFile.read_file indent_config with
   | str ->

--- a/src/lsp/cobol_indent/indent_type.ml
+++ b/src/lsp/cobol_indent/indent_type.ml
@@ -145,13 +145,7 @@ ex.
 type indent_record =
   { lnum:int;
     offset_orig:int;
-    offset_modif: int;
-    src_format: Cobol_preproc.Src_format.any
-      (** This is the source format for the change. Ideally, this information
-      should not have to be recorded here, but could be obtained from the line
-      number -- however, we don't have the infrastructure for that currently.
-      *)
-  }
+    offset_modif: int}
 
 type range = {start_line:int;
               end_line  :int  }

--- a/src/lsp/cobol_indent/indent_util.ml
+++ b/src/lsp/cobol_indent/indent_util.ml
@@ -17,7 +17,6 @@ open Indent_type
 open Indent_keywords
 
 let check_pos
-  (src_format : Cobol_preproc.Src_format.any)
   (pos:Lexing.position)
   (offset:int)
   (ind_recds:indent_record list)
@@ -34,8 +33,7 @@ let check_pos
       end;
     {lnum = pos.pos_lnum;
      offset_orig = real_offset;
-     offset_modif = offset;
-     src_format }
+     offset_modif = offset}
     :: ind_recds
     end
   else
@@ -48,8 +46,16 @@ let check_pos src_format srcloc offset ind_recds ifcheck =
   match src_format with
   | Cobol_preproc.Src_format.SF (NoIndic, FreePaging) when ifcheck ->
     let pos = start_pos srcloc in
-    check_pos src_format pos offset ind_recds
-  | _ -> ind_recds
+    check_pos pos offset ind_recds
+  | _ ->
+    (* Indenting temporarily disabled in fixed format
+        https://github.com/OCamlPro/superbol-studio-oss/issues/52
+
+        Support must be improved before enabling again, in particular to
+        avoid pushing content into the margin.
+        https://github.com/OCamlPro/superbol-studio-oss/issues/45
+      *)
+    ind_recds
 
 let failure_msg loc =
   let pos = start_pos loc in

--- a/src/lsp/cobol_indent/indent_util.ml
+++ b/src/lsp/cobol_indent/indent_util.ml
@@ -161,3 +161,67 @@ let rec phrase_termination_until keyword context =
     when is_phrase key && key <> keyword ->
       phrase_termination_until keyword context
   | _ -> context
+
+
+(** [apply s rdl] applies the changes in [rdl] to the text in [s]. [rdl] is
+    expected to have been computed by calling [indent_range ~contents:s].
+
+    Note: this function is currently untested. It is only used by the command
+    `superbol indent`. The main way to interact with the indenter is through LSP
+    requests, which are tested in lsp_formatting.ml *)
+let apply : string -> indent_record list -> string =
+  (*
+    [irs] contains a list of {!indent_record} entries describing how to
+     modify the indentation.  They must be sorted in increasing order, and there
+     must be at most one record per line.
+
+    [buf] is a {!Buffer.t} into which we are writing the indented content.
+
+    [s] is the original content to indent as a {!string}.
+
+    [line] is the current line, which starts at offset [bol] in the string [s].
+
+    [start] is an offset in [s], less than or equal to [bol], that must be
+    preserved as-is. This allows copying large unmodified chunks of text (lines
+    that are already properly indented) using a single call to
+    {!Buffer.add_substring} for reduced overhead.
+  *)
+  let rec aux ~start (irs : indent_record list) buf s line bol =
+    (* Note: this can raise [Invalid_argument] if the modifications do not
+       cleanly apply to the input string, which include cases where there are
+       modifications on lines past the end of the input, modifications that are
+       not sorted, etc. -- we can call [invalid_arg] ourselves, but
+       [String.index_from] can also raise [Invalid_argument] in these
+       conditions. *)
+    match irs with
+    | [] when start = 0 -> s
+    | [] ->
+      Buffer.add_substring buf s start (String.length s - start);
+      Buffer.contents buf
+    | { lnum; offset_orig; offset_modif } :: irs when line = lnum - 1 ->
+      let eol =
+        try String.index_from s bol '\n' + 1 with Not_found -> String.length s
+      in
+      let delta = offset_modif - offset_orig in
+      if delta > 0 then (
+        Buffer.add_substring buf s start (bol + offset_orig - start);
+        for _ = 0 to delta - 1 do
+          Buffer.add_char buf ' '
+        done;
+      ) else (
+        Buffer.add_substring buf s start (bol - start + offset_orig + delta);
+      );
+      aux ~start:(bol + offset_orig) irs buf s (line + 1) eol
+    | _ :: _ ->
+      match String.index_from s bol '\n' + 1 with
+      | eol -> aux ~start irs buf s (line + 1) eol
+      | exception Not_found ->
+        (* Modifications on lines past the end of the input. *)
+        invalid_arg "Cobol_indent.apply"
+  in
+  fun s rdl ->
+    try
+      let buf = Buffer.create (String.length s) in
+      aux ~start:0 (List.rev rdl) buf s 0 0
+    with Invalid_argument _ ->
+      Fmt.failwith "Could not indent: internal error"

--- a/src/lsp/cobol_indent/indent_util.mli
+++ b/src/lsp/cobol_indent/indent_util.mli
@@ -48,3 +48,11 @@ val imp_scope_termination: context -> context
 val phrase_termination: context -> context
 
 val phrase_termination_until: context_kind -> context -> context
+
+(** [apply s rdl] applies the changes in [rdl] to the text in [s]. [rdl] is
+    expected to have been computed by calling [indent_range ~contents:s].
+
+    Note: this function is currently untested. It is only used by the command
+    `superbol indent`. The main way to interact with the indenter is through LSP
+    requests, which are tested in lsp_formatting.ml *)
+val apply : string -> indent_record list -> string

--- a/src/lsp/cobol_indent/indenter.mli
+++ b/src/lsp/cobol_indent/indenter.mli
@@ -19,4 +19,4 @@ val indent_range
   -> range:Indent_type.range option
   -> filename:string
   -> contents:string
-  -> string
+  -> Indent_type.indent_record list

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -149,6 +149,19 @@ let handle_references state (params: ReferenceParams.t) =
   try_with_document_data state params.textDocument
     ~f:(fun ~doc:_ -> lookup_references_in_doc params)
 
+let lsp_text_edit (ir : Cobol_indent.Type.indent_record) =
+  match ir with { lnum; offset_orig; offset_modif } ->
+  let delta = offset_modif - offset_orig in
+  let position = Position.create ~line:(lnum - 1) ~character:offset_orig in
+  let range = Range.create ~start:position ~end_:position in
+  if delta > 0 then
+    TextEdit.create ~newText:(String.make delta ' ') ~range
+  else
+    let start =
+      Position.create ~line:(lnum - 1) ~character:(offset_orig + delta)
+    in
+    let range = Range.create ~start ~end_:position in
+    TextEdit.create ~newText:"" ~range
 
 (*Remark:
     The first line of the text selected to RangeFormatting must be
@@ -168,16 +181,7 @@ let handle_range_formatting registry params =
       end_line = end_.line + 1
     }
   in
-  (*the range must contain the whole lines*)
-  let range =
-    (*TODO:find a simple method to get the number of letters of one line
-           (the code below use 1000 as the upperbound)                   *)
-    Range.{
-      start = Position.create ~line:start.line ~character:0;
-      end_ = Position.create ~line:end_.line ~character:1000;
-    }
-  in
-  let newText =
+  let editList =
     Cobol_indent.indent_range
       ~dialect:(Cobol_config.dialect project.config.cobol_config)
       ~source_format:project.config.source_format
@@ -186,23 +190,14 @@ let handle_range_formatting registry params =
       ~contents:(Lsp.Text_document.text textdoc)
       ~range:(Some range_to_indent)
   in
-  Some [TextEdit.create ~newText ~range]
+  Some (List.map lsp_text_edit editList)
 
 let handle_formatting registry params =
   let DocumentFormattingParams.{ textDocument = doc; _ } = params in
   let Lsp_document.{ project; textdoc; _ } =
     Lsp_server.find_document doc registry in
-  let lines = String.split_on_char '\n' (Lsp.Text_document.text textdoc) in
-  let length = List.length lines - 1 in
-  (* TODO: formatting on empty files will break here *)
-  let width = String.length @@ List.hd @@ List.rev lines in
-  let edit_range =
-    Range.create
-      ~start:(Position.create ~character:0 ~line:0)
-      ~end_:(Position.create ~character:width ~line:length)
-  in
   try
-    let newText =
+    let editList =
       Cobol_indent.indent_range
         ~dialect:(Cobol_config.dialect project.config.cobol_config)
         ~source_format:project.config.source_format
@@ -211,7 +206,7 @@ let handle_formatting registry params =
         ~contents:(Lsp.Text_document.text textdoc)
         ~range:None
     in
-    Some [TextEdit.create ~newText ~range:edit_range]
+    Some (List.map lsp_text_edit editList)
   with Failure msg ->
     internal_error "Formatting error: %s" msg
 

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -181,7 +181,7 @@ let handle_range_formatting registry params =
       end_line = end_.line + 1
     }
   in
-  let editList =
+  let edit_list =
     Cobol_indent.indent_range
       ~dialect:(Cobol_config.dialect project.config.cobol_config)
       ~source_format:project.config.source_format
@@ -190,7 +190,7 @@ let handle_range_formatting registry params =
       ~contents:(Lsp.Text_document.text textdoc)
       ~range:(Some range_to_indent)
   in
-  Some (List.map lsp_text_edit editList)
+  Some (List.map lsp_text_edit edit_list)
 
 let handle_formatting registry params =
   let DocumentFormattingParams.{ textDocument = doc; _ } = params in

--- a/src/lsp/superbol_free_lib/command_indent_file.ml
+++ b/src/lsp/superbol_free_lib/command_indent_file.ml
@@ -25,7 +25,7 @@ let action { preproc_options = { source_format; config; _ } ; _ }
     let contents = Ez_file.V1.EzFile.read_file file in
     indent_range
       ~source_format ~filename:file ~contents ~indent_config ~range:None
-      ~dialect:Config.dialect |> Fmt.pr "%s")
+      ~dialect:Config.dialect |> apply contents |> Fmt.pr "%s")
 
 let cmd =
   let files = ref [] in

--- a/src/lsp/superbol_free_lib/command_indent_file.ml
+++ b/src/lsp/superbol_free_lib/command_indent_file.ml
@@ -23,9 +23,9 @@ let action { preproc_options = { source_format; config; _ } ; _ }
   List.to_seq files
   |> Seq.map (fun file ->
     let contents = Ez_file.V1.EzFile.read_file file in
-    indent_range
+    indent_range_str
       ~source_format ~filename:file ~contents ~indent_config ~range:None
-      ~dialect:Config.dialect |> apply contents |> Fmt.pr "%s")
+      ~dialect:Config.dialect |> Fmt.pr "%s")
 
 let cmd =
   let files = ref [] in

--- a/src/lsp/superbol_free_lib/command_indent_range.ml
+++ b/src/lsp/superbol_free_lib/command_indent_range.ml
@@ -21,8 +21,8 @@ let action { preproc_options = { source_format; config; _ }; _ } ~file ~range
     ~indent_config =
   let module Config = (val config) in
   let contents = Ez_file.V1.EzFile.read_file file in
-  indent_range ~source_format ~filename:file ~contents ~range ~indent_config
-    ~dialect:Config.dialect |> apply contents |> Fmt.pr "%s"
+  indent_range_str ~source_format ~filename:file ~contents ~range ~indent_config
+    ~dialect:Config.dialect |> Fmt.pr "%s"
 
 let cmd =
   let file = ref "" in

--- a/src/lsp/superbol_free_lib/command_indent_range.ml
+++ b/src/lsp/superbol_free_lib/command_indent_range.ml
@@ -22,7 +22,7 @@ let action { preproc_options = { source_format; config; _ }; _ } ~file ~range
   let module Config = (val config) in
   let contents = Ez_file.V1.EzFile.read_file file in
   indent_range ~source_format ~filename:file ~contents ~range ~indent_config
-    ~dialect:Config.dialect |> Fmt.pr "%s"
+    ~dialect:Config.dialect |> apply contents |> Fmt.pr "%s"
 
 let cmd =
   let file = ref "" in

--- a/test/lsp/lsp_formatting.ml
+++ b/test/lsp/lsp_formatting.ml
@@ -56,6 +56,29 @@ let%expect_test "simple-formatting-request" =
                 DISPLAY "HELLO"
                 STOP RUN. |}]
 
+let doc = {cobol|
+       PROGRAM-ID. HELLO.
+                   PROCEDURE DIVISION.
+                                   para-1.
+                                                                   DISPLAY "HELLO"
+                                                                                       STOP RUN.
+  |cobol};;
+
+let%expect_test "unindent-formatting-request" =
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
+  | None -> Pretty.out "formatting error"
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+           PROGRAM-ID. HELLO.
+           PROCEDURE DIVISION.
+            para-1.
+                DISPLAY "HELLO"
+                STOP RUN. |}]
+
 
 let doc = {cobol|
         para-1.

--- a/test/lsp/lsp_formatting.ml
+++ b/test/lsp/lsp_formatting.ml
@@ -20,6 +20,19 @@ let make_free_format_project () =
     source-format = "free"
   |toml}
 
+let format_doc doc =
+  let { projdir; end_with_postproc }, server = make_free_format_project () in
+  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
+  let params =
+    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
+    DocumentFormattingParams.create ~options ~textDocument:prog ()
+  in
+  let doc = (LSP.Types.URIMap.find prog.uri server.docs).textdoc in
+  let formatted = LSP.Request.formatting server params in
+  Option.map (fun edits ->
+    Lsp.Text_document.apply_text_document_edits doc edits |> Lsp.Text_document.text
+  ) formatted, end_with_postproc
+
 let doc = {cobol|
        PROGRAM-ID. HELLO.
        PROCEDURE DIVISION.
@@ -29,17 +42,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "simple-formatting-request" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -63,17 +70,11 @@ let doc = {cobol|
         move 1 to x.  |cobol};;
 
 let%expect_test "formatting-request-nested-if" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":14,"line":1},"start":{"character":8,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -104,17 +105,11 @@ let doc = {cobol|
         value 999.              |cobol};;
 
 let%expect_test "formatting-request-data" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect{|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":23,"line":1},"start":{"character":8,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -176,17 +171,11 @@ let doc = {cobol|
         |cobol};;
 
 let%expect_test "formatting-request-nested-program" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect{|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -233,17 +222,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-alignment-argument" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":11,"line":1},"start":{"character":7,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -264,17 +247,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-else-if" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":10,"line":1},"start":{"character":8,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -381,17 +358,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-whole-program" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     misc_sections_visitor.ml:0:
@@ -506,17 +477,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-on-exception" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect{|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":11,"line":1},"start":{"character":7,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
@@ -540,17 +505,11 @@ let doc = {cobol|
   |cobol};;
 
 let%expect_test "formatting-request-perform" =
-  let { projdir; end_with_postproc }, server = make_free_format_project () in
-  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
-  let params =
-    let options = FormattingOptions.create ~insertSpaces:true ~tabSize:2 () in
-    DocumentFormattingParams.create ~options ~textDocument:prog ()
-  in
-  begin match LSP.Request.formatting server params with
+  let doc', end_with_postproc = format_doc doc in
+  begin match doc' with
   | None -> Pretty.out "formatting error"
-  | Some l ->
-      List.iter (fun TextEdit.{newText;_} -> Pretty.out "%s" newText) l
-    end;
+  | Some doc' -> Pretty.out "%s" doc'
+  end;
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[{"message":"Invalid syntax","range":{"end":{"character":16,"line":1},"start":{"character":7,"line":1}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}


### PR DESCRIPTION
Internally, the indenter computes a diff (in terms of offsets) for each line that needs to change. Then, all the diffs are applied to the document, and a single edit that rewrites the full document is sent to the editor.

This PR changes the behavior to send small text edits that either add or remove whitespace instead.