### PR TITLE
Add "Superbol: Restart Language Server" command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
         "language": "COBOL"
       }
     ],
+    "commands": [
+      {
+        "command": "superbol.server.restart",
+        "title": "Restart Language Server",
+        "category": "Superbol"
+      }
+    ],
     "configuration": {
       "title": "Superbol COBOL",
       "properties": {

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -229,6 +229,12 @@ let contributes =
         ~severity:"info"
         ~source:"GnuCOBOL";
     ]
+    ~commands:[
+      Manifest.command ()
+        ~command:"superbol.server.restart"
+        ~title:"Restart Language Server"
+        ~category:"Superbol"
+    ]
 
 let manifest =
   Manifest.vscode

--- a/src/vscode/superbol-vscode-platform/superbol_commands.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_commands.mli
@@ -12,5 +12,5 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val serverOptions: unit -> Vscode_languageclient.ServerOptions.t
-val clientOptions: unit -> Vscode_languageclient.ClientOptions.t
+val register_all :
+  Vscode.ExtensionContext.t -> Superbol_instance.t -> unit

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -12,5 +12,34 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val serverOptions: unit -> Vscode_languageclient.ServerOptions.t
-val clientOptions: unit -> Vscode_languageclient.ClientOptions.t
+open Vscode_languageclient
+
+type t = {
+  mutable language_client: LanguageClient.t option
+}
+
+let make () = {
+  language_client = None
+}
+
+let stop_language_server t =
+  match t.language_client with
+  | None -> Promise.return ()
+  | Some client ->
+    t.language_client <- None;
+    if LanguageClient.isRunning client then
+      LanguageClient.stop client
+    else
+      Promise.return ()
+
+let start_language_server t =
+  let open Promise.Syntax in
+  let* () = stop_language_server t in
+  let serverOptions = Superbol_languageclient.serverOptions () in
+  let clientOptions = Superbol_languageclient.clientOptions () in
+  let client = LanguageClient.make
+    ~id:"cobolServer"
+    ~name:"Cobol Server"
+    ~serverOptions ~clientOptions () in
+  let+ () = LanguageClient.start client in
+  t.language_client <- Some client

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -12,5 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val serverOptions: unit -> Vscode_languageclient.ServerOptions.t
-val clientOptions: unit -> Vscode_languageclient.ClientOptions.t
+type t
+
+val make : unit -> t
+
+val stop_language_server : t -> unit Promise.t
+
+val start_language_server : t -> unit Promise.t

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
@@ -12,9 +12,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let config = Vscode.Workspace.getConfiguration ()
-
-let serverOptions =
+let serverOptions () =
+  let config = Vscode.Workspace.getConfiguration () in
   let command =
     match Vscode.WorkspaceConfiguration.get ~section:"superbol.path" config with
     | Some o -> Ojs.string_of_js o
@@ -24,7 +23,7 @@ let serverOptions =
     ~command
     ~args:["lsp"]
 
-let clientOptions =
+let clientOptions () =
   Vscode_languageclient.ClientOptions.create ()
     ~documentSelector:[|
       `Filter (Vscode_languageclient.DocumentFilter.createLanguage ()

--- a/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
@@ -160,7 +160,7 @@ let indentRange
 *)
   `Value promise
 
-let client = ref None
+let instance = Superbol_instance.make ()
 
 let activate (extension : Vscode.ExtensionContext.t) =
   let providerFull = Vscode.DocumentFormattingEditProvider.create
@@ -188,25 +188,14 @@ let activate (extension : Vscode.ExtensionContext.t) =
 
   Vscode.ExtensionContext.subscribe extension ~disposable:task;
 
-  client :=
-    Some (Vscode_languageclient.LanguageClient.make
-            ~id:"cobolServer"
-            ~name:"Cobol Server"
-            ~serverOptions:Superbol_languageclient.serverOptions
-            ~clientOptions:Superbol_languageclient.clientOptions
-            ());
-  match !client with
-  | Some client -> Vscode_languageclient.LanguageClient.start client
-  | None -> Promise.return ()
+  Superbol_commands.register_all extension instance;
+  Superbol_instance.start_language_server instance
 
 let deactivate () =
-  match !client with
-  | None -> Promise.return ()
-  | Some client -> Vscode_languageclient.LanguageClient.stop client
+    Superbol_instance.stop_language_server instance
 
 (* see {{:https://code.visualstudio.com/api/references/vscode-api#Extension}
    activate() *)
 let () =
   Js_of_ocaml.Js.(export "activate" (wrap_callback activate));
   Js_of_ocaml.Js.(export "deactivate" (wrap_callback deactivate))
-


### PR DESCRIPTION
Add a command to restart the language server. This will pick up changes to the `superbol.path` configuration option.

Fixes #88

Note that this allows a manual solution to #81 (making it possible to start the restart language server after changing `superbol.path` without having to reload the whole extension).