### PR TITLE
Use per-project file for indent configuration

### DIFF
--- a/src/lsp/cobol_indent/cobol_indent.ml
+++ b/src/lsp/cobol_indent/cobol_indent.ml
@@ -19,6 +19,8 @@ let indent_range = Indenter.indent_range
 let indent_range_str
   ~dialect ~source_format ~indent_config ~range ~filename ~contents
 =
-indent_range
-  ~dialect ~source_format ~indent_config ~range ~filename ~contents
-|> Indent_util.apply contents
+  indent_range
+    ~dialect ~source_format ~indent_config ~range ~filename ~contents
+  |> Indent_util.apply contents
+
+let config l = Indent_config.(merge default (of_list l))

--- a/src/lsp/cobol_indent/indent_config.mli
+++ b/src/lsp/cobol_indent/indent_config.mli
@@ -11,7 +11,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(*set the indentation configuration*)
-val set_config : indent_config:string -> unit
+type t = Indent_type.indent_config
 
-val offset_of_keyword: Indent_type.context_kind -> int
+val default : t
+
+(** Merge two configs. Offsets in the second config take precedence. *)
+val merge : t -> t -> t
+
+val of_list : (string * int) list -> t
+
+val offset_of_keyword: t -> Indent_type.context_kind -> int

--- a/src/lsp/cobol_indent/indent_type.ml
+++ b/src/lsp/cobol_indent/indent_type.ml
@@ -152,9 +152,15 @@ type range = {start_line:int;
 
 type context = (context_kind * int) list
 
+(* Refrain from editing `indent_config` values directly and instead use
+   functions from the `Indent_config` module. Or don't, you're an adult, but
+   don't complain when it breaks. *)
+type indent_config = (string, int) Hashtbl.t
+
 type indent_state =
     {
       src_format: Cobol_preproc.Src_format.any;
+      indent_config: indent_config;
       scope: context_kind; (*indicate where the current code is*)
       context: context;    (*the stack of (context_kind, offset)*)
       acc: indent_record list;

--- a/src/lsp/cobol_indent/indent_util.ml
+++ b/src/lsp/cobol_indent/indent_util.ml
@@ -69,8 +69,10 @@ let offset_of_context context =
   | [] -> failwith "empty context"
   | _ -> snd @@ List.hd context
 
-let push_context key context =
-  (key, offset_of_keyword key + offset_of_context context) :: context
+let push_context state key context =
+  (key,
+   offset_of_keyword state.indent_config key + offset_of_context context)
+  :: context
 
 
 (*for DATA DECLARATION*)

--- a/src/lsp/cobol_indent/indent_util.mli
+++ b/src/lsp/cobol_indent/indent_util.mli
@@ -23,11 +23,11 @@ val check_pos:
 
 val failure_msg: Cobol_common.Srcloc.srcloc -> string
 
-val offset_of_keyword: context_kind -> int
+val offset_of_keyword: indent_config -> context_kind -> int
 
 val offset_of_context: context -> int
 
-val push_context: context_kind -> context -> context
+val push_context: indent_state -> context_kind -> context -> context
 
 val is_data_decl: string -> bool
 

--- a/src/lsp/cobol_indent/indenter.ml
+++ b/src/lsp/cobol_indent/indenter.ml
@@ -14,7 +14,8 @@
 open Indent_type
 
 (*indent a range of file, with the default indent_config*)
-let indent_range ~dialect ~source_format ~range ~filename ~contents =
+let indent_range ~dialect ~source_format ~indent_config ~range ~filename ~contents =
+  let indent_config = Option.value ~default:Indent_config.default indent_config in
   let src_format =
     (* Note: this value doesn't actually matter, it will be overriden
        immediately by [fold_source_lines] calling [on_initial_source_format]
@@ -32,15 +33,12 @@ let indent_range ~dialect ~source_format ~range ~filename ~contents =
       ~skip_compiler_directives_text:true
       ~f:(fun _lnum line acc -> Indent_check.check_indentation line acc)
       (String { filename; contents })
-      { src_format; scope = BEGIN; context  = []; acc = []; range }
+      { src_format
+      ; indent_config
+      ; scope = BEGIN
+      ; context  = []
+      ; acc = []
+      ; range }
   in
   (* NB: note here we ignore diagnostics *)
   state.result.acc
-
-(*indent a range of file, with the user-defined indent_config*)
-let indent_range ~dialect ~source_format ~indent_config ~range ~filename ~contents =
-  begin match indent_config with
-    | Some indent_config -> Indent_config.set_config ~indent_config
-    | None -> ()
-  end;
-  indent_range ~dialect ~source_format ~range ~filename ~contents

--- a/src/lsp/cobol_indent/indenter.mli
+++ b/src/lsp/cobol_indent/indenter.mli
@@ -15,7 +15,7 @@
 val indent_range
   : dialect: Cobol_config.dialect
   -> source_format:Cobol_config.source_format_spec
-  -> indent_config:string option
+  -> indent_config:Indent_config.t option
   -> range:Indent_type.range option
   -> filename:string
   -> contents:string

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -185,7 +185,7 @@ let handle_range_formatting registry params =
     Cobol_indent.indent_range
       ~dialect:(Cobol_config.dialect project.config.cobol_config)
       ~source_format:project.config.source_format
-      ~indent_config:None
+      ~indent_config:(Some (Cobol_indent.config project.config.indent_config))
       ~filename:(Lsp.Uri.to_path doc.uri)
       ~contents:(Lsp.Text_document.text textdoc)
       ~range:(Some range_to_indent)
@@ -201,7 +201,7 @@ let handle_formatting registry params =
       Cobol_indent.indent_range
         ~dialect:(Cobol_config.dialect project.config.cobol_config)
         ~source_format:project.config.source_format
-        ~indent_config:None
+        ~indent_config:(Some (Cobol_indent.config project.config.indent_config))
         ~filename:(Lsp.Uri.to_path doc.uri)
         ~contents:(Lsp.Text_document.text textdoc)
         ~range:None

--- a/src/lsp/superbol_free_lib/project_config.ml
+++ b/src/lsp/superbol_free_lib/project_config.ml
@@ -11,8 +11,27 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Ez_file.V1
+
+module DIAGS = Cobol_common.Diagnostics
+
 let layout =
   Superbol_project.{
     project_config_filename = "superbol.toml";
     relative_work_dirname = "_superbol";
   }
+
+let load_project ?(dirname = EzFile.current_dir_name) () =
+  Pretty.error "Loading project in `%s'@." dirname;
+  try
+    let rootdir = Superbol_project.rootdir_at ~dirname in
+    let project = Superbol_project.for_ ~rootdir ~layout in
+    DIAGS.show_n_forget project
+  with
+  | Superbol_project.Config.ERROR e ->
+      DIAGS.(pp Fmt.stderr @@ One.error "%a"
+               Superbol_project.Diagnostics.pp_error e);
+      exit 2
+  | Sys_error msg | Invalid_argument msg ->
+      DIAGS.(pp Fmt.stderr @@ One.error "%s" msg);
+      exit 2

--- a/src/lsp/superbol_project/project_config.mli
+++ b/src/lsp/superbol_project/project_config.mli
@@ -23,6 +23,7 @@ module TYPES: sig
     mutable libpath: path list;
     mutable copybook_extensions: string list;
     mutable copybook_if_no_extension: bool;
+    mutable indent_config: (string * int) list;
     toml_handle: Ezr_toml.toml_handle;
   }
 


### PR DESCRIPTION
The indent configuration is now exposed by the `Cobol_indent` module and loaded from the `superbol.toml` file. For the sake of simplicity, this does not change the internal representation of the indent configuration, even though it requires us to expose the configuration as a hash table in `Indent_type.ml`. Be responsible.

Fixes #46