### PR TITLE
Add new argument to specify the directory for storing cache files

### DIFF
--- a/sphinx/commands.rst
+++ b/sphinx/commands.rst
@@ -273,6 +273,12 @@ Start a COBOL LSP server
 Where options are:
 
 
+* :code:`--caching`   Enable caching (enabled by default)
+
+* :code:`--no-caching`   Disable caching (enabled by default)
+
+* :code:`--storage-directory DIR`   Directory under which to store cache data --- prevents the creation of a "_superbol" storage directory at the root of project trees.
+
 
 main.exe pp
 ~~~~~~~~~~~~~

--- a/src/lsp/cobol_lsp/lsp_project.mli
+++ b/src/lsp/cobol_lsp/lsp_project.mli
@@ -44,8 +44,8 @@ val in_existing_dir: string -> layout:layout -> t
 
 (** [rootdir_for ~uri ~layout] locates the project directory (that contains a
     file with given name [layout.project_config_filename]) for a file at the
-    given URI.  Returns the name of the directory that contains the file at URI
-    if no project file is found. *)
+    given URI.  The behavior when no such file is found is that of
+    {!Superbol_project.rootdir_for}. *)
 val rootdir_for: uri:Lsp.Uri.t -> layout:layout -> rootdir
 
 (** [libpath_for ~uri project] constructs a list of directory names where

--- a/src/lsp/cobol_lsp/lsp_project_cache.mli
+++ b/src/lsp/cobol_lsp/lsp_project_cache.mli
@@ -14,15 +14,27 @@
 open Lsp_imports
 
 module TYPES: sig
+  type storage =
+    | No_storage
+    | Store_in_file of
+        {
+          (** Name of cache file, relative to project root directory. *)
+          relative_filename: string;
+        }
+    | Store_in_shared_dir of
+        {
+          dirname: string;
+        }
+
   type config =
     {
-      (** Name of cache file, relative to project root directory. *)
-      cache_relative_filename: string;
+      cache_storage: storage;
       cache_verbose: bool;
     }
 end
 include module type of TYPES
-  with type config = TYPES.config
+  with type storage = TYPES.storage
+   and type config = TYPES.config
 
 (** [save ~config docs] saves the caches of all the given document's
     projects.

--- a/src/lsp/superbol_free_lib/arg_utils.ml
+++ b/src/lsp/superbol_free_lib/arg_utils.ml
@@ -14,14 +14,30 @@
 open Ezcmd.V2
 open EZCMD.TYPES
 
-let en'dis'able_switch ~name ~default =
+let switch (kind: [`enable_disable | `with_without | `boolean]) ~name ~default =
   let switch = ref default in
-  let default = if default then "enabled" else "disabled" in
+  let set, unset = match kind with
+    | `enable_disable -> "Enable", "Disable"
+    | `with_without   -> "With", "Without"
+    | `boolean        -> "Set", "Clear"
+  in
+  let arg_set, arg_unset = match kind with
+    | `enable_disable | `boolean -> name, "no-"^name
+    | `with_without -> "with-"^name, "without-"^name
+  in
+  let default = match kind with
+    | `enable_disable when default -> "enabled"
+    | `enable_disable              -> "disabled"
+    | `with_without when default   -> "with"
+    | `with_without                -> "without"
+    | `boolean when default        -> "true"
+    | `boolean                     -> "false"
+  in
   switch,
   [
-    [name], Arg.Set switch,
-    Pretty.string_to EZCMD.info "Enable %s (%s by default)" name default;
+    [arg_set], Arg.Set switch,
+    Pretty.string_to EZCMD.info "%s %s (%s by default)" set name default;
 
-    ["no-"^name], Arg.Clear switch,
-    Pretty.string_to EZCMD.info "Disable %s (%s by default)" name default;
+    [arg_unset], Arg.Clear switch,
+    Pretty.string_to EZCMD.info "%s %s (%s by default)" unset name default;
   ]

--- a/src/lsp/superbol_free_lib/arg_utils.ml
+++ b/src/lsp/superbol_free_lib/arg_utils.ml
@@ -11,13 +11,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val config
-  : project_layout: Superbol_project.layout
-  -> ?enable_caching: bool
-  -> ?fallback_storage_directory: string
-  -> unit
-  -> Lsp_server.config
+open Ezcmd.V2
+open EZCMD.TYPES
 
-val run
-  : config: Lsp_server.config
-  -> Lsp_server.exit_status
+let en'dis'able_switch ~name ~default =
+  let switch = ref default in
+  let default = if default then "enabled" else "disabled" in
+  switch,
+  [
+    [name], Arg.Set switch,
+    Pretty.string_to EZCMD.info "Enable %s (%s by default)" name default;
+
+    ["no-"^name], Arg.Clear switch,
+    Pretty.string_to EZCMD.info "Disable %s (%s by default)" name default;
+  ]

--- a/src/lsp/superbol_free_lib/arg_utils.mli
+++ b/src/lsp/superbol_free_lib/arg_utils.mli
@@ -11,13 +11,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val config
-  : project_layout: Superbol_project.layout
-  -> ?enable_caching: bool
-  -> ?fallback_storage_directory: string
-  -> unit
-  -> Lsp_server.config
-
-val run
-  : config: Lsp_server.config
-  -> Lsp_server.exit_status
+val en'dis'able_switch
+  : name: string
+  -> default: bool
+  -> bool ref * Ezcmd.V2.EZCMD.TYPES.arg_list

--- a/src/lsp/superbol_free_lib/arg_utils.mli
+++ b/src/lsp/superbol_free_lib/arg_utils.mli
@@ -11,7 +11,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val en'dis'able_switch
-  : name: string
+(** [switch kind ~name ~default] returns a Boolean flag [flg] and specifications
+    of arguments for setting/unsetting [flg].  The flag has default value
+    [default], and the phrasing of the documentation for arguments depends on
+    the [kind] of switch: [`enable_disable] and [`with_without] are
+    self-explanatory; [`boolean] uses "Set" and "Clear" verbs. *)
+val switch
+  : [ `enable_disable | `with_without | `boolean ]
+  -> name: string
   -> default: bool
   -> bool ref * Ezcmd.V2.EZCMD.TYPES.arg_list

--- a/src/lsp/superbol_free_lib/command_lsp.ml
+++ b/src/lsp/superbol_free_lib/command_lsp.ml
@@ -12,19 +12,41 @@
 (**************************************************************************)
 
 open Ezcmd.V2
+open EZCMD.TYPES
 
-let lsp_config =
-  Cobol_lsp.config ~project_layout:Project.layout
 
-let run_lsp () =
+let run_lsp ~enable_caching ~storage =
+  let project_layout, fallback_storage_directory =
+    match storage with
+    | None ->
+        Project.layout, None
+    | Some dir ->
+        Project.{ layout with relative_work_dirname = None }, Some dir
+  in
+  let lsp_config =
+    Cobol_lsp.config ()
+      ~enable_caching ~project_layout ?fallback_storage_directory
+  in
   match Cobol_lsp.run ~config:lsp_config with
   | Ok () -> ()
   | Error exit_msg -> Pretty.error "%s@." exit_msg; exit 1
 
+
 let cmd =
+  let caching, caching_args =
+    Arg_utils.en'dis'able_switch ~name:"caching" ~default:true
+  in
+  let storage = ref None in
   EZCMD.sub "lsp"
-    run_lsp
+    (fun () ->
+       run_lsp ~enable_caching:!caching ~storage:!storage)
     ~doc:"run LSP server"
+    ~args: (caching_args @ [
+        ["storage-directory"], Arg.String (fun s -> storage := Some s),
+        EZCMD.info ~docv:"DIR"
+          "Directory under which to store cache data --- prevents the creation \
+           of a \"_superbol\" storage directory at the root of project trees.";
+      ])
     ~man:[
       `S "DESCRIPTION";
       `Blocks [

--- a/src/lsp/superbol_free_lib/command_lsp.ml
+++ b/src/lsp/superbol_free_lib/command_lsp.ml
@@ -34,7 +34,7 @@ let run_lsp ~enable_caching ~storage =
 
 let cmd =
   let caching, caching_args =
-    Arg_utils.en'dis'able_switch ~name:"caching" ~default:true
+    Arg_utils.switch `enable_disable ~name:"caching" ~default:true
   in
   let storage = ref None in
   EZCMD.sub "lsp"

--- a/src/lsp/superbol_free_lib/project.ml
+++ b/src/lsp/superbol_free_lib/project.ml
@@ -18,7 +18,8 @@ module DIAGS = Cobol_common.Diagnostics
 let layout =
   Superbol_project.{
     project_config_filename = "superbol.toml";
-    relative_work_dirname = "_superbol";
+    relative_work_dirname = Some "_superbol";
+    rootdir_fallback_policy = Same_as_file_directory;
   }
 
 let try_load ~f arg =

--- a/test/lsp/lsp_testing.ml
+++ b/test/lsp/lsp_testing.ml
@@ -35,7 +35,7 @@ let layout =
   Superbol_free_lib.Project.layout;
 and cache_config =
   LSP.Project_cache.{
-    cache_relative_filename = "lsp-cache";
+    cache_storage = No_storage;
     cache_verbose = false;
   }
 


### PR DESCRIPTION
When provided, `--storage-directory=DIR` forces cache files to reside inside the given directory; this prevents the creation of `_superbol` directories at the root of project trees.

Side changes include enhancements to the description of project layouts, and command-line flags to enable or disable caching.

Preliminary steps to address #107