### PR TITLE
Look for bundled superbol-free executable

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -10,7 +10,8 @@ LSP_MODE_SRCDIR ?= ../lsp-mode
 all: superbol-free
 superbol-free: build
 	$(CP) _build/default/src/lsp/superbol-free/main.exe superbol-free
-	cp -f package.json package.json.prev
+	$(CP) _build/default/src/lsp/superbol-free/main.exe _dist/superbol-free
+	$(CP) package.json package.json.prev
 	./superbol-free json vscode --gen package.json
 	diff -u package.json.prev package.json && rm -f package.json.prev 
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         },
         "superbol.path": {
           "type": "string",
-          "default": "superbol-free",
-          "description": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise."
+          "default": "",
+          "description": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise. Leave empty to use the bundled `superbol-free`, if available."
         }
       }
     },

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -145,10 +145,11 @@ let contributes =
                 "If something is selected, only format the selection" ;
 
             Manifest.PROPERTY.string "superbol.path"
-              ~default:"superbol-free"
+              ~default:""
               ~description:
                 "Name of the `superbol-free` executable if available in PATH; \
-                 may be an absolute path otherwise."
+                 may be an absolute path otherwise. Leave empty to use the \
+                 bundled `superbol-free`, if available."
           ] )
     ~taskDefinitions: [
       Manifest.taskDefinition

--- a/src/vscode/node-js-stubs/node.ml
+++ b/src/vscode/node-js-stubs/node.ml
@@ -181,7 +181,9 @@ module Fs = struct
     val readFile : string -> encoding:string -> string Promise.t
       [@@js.global "fs.readFile"]
 
-    val exists : string -> bool Promise.t [@@js.global "fs.exists"]]
+    val exists : string -> bool Promise.t [@@js.global "fs.exists"]
+
+    val existsSync : string -> bool [@@js.global "fs.existsSync"]]
 
   let readDir path =
     readDir path

--- a/src/vscode/node-js-stubs/node.mli
+++ b/src/vscode/node-js-stubs/node.mli
@@ -147,6 +147,8 @@ module Fs : sig
   val readFile : string -> string Promise.t
 
   val exists : string -> bool Promise.t
+
+  val existsSync : string -> bool
 end
 
 module Net : sig

--- a/src/vscode/node-js-stubs/node_stub.js
+++ b/src/vscode/node-js-stubs/node_stub.js
@@ -5,6 +5,7 @@ joo_global_object.fs = {
   readDir: promisify(fs.readdir),
   readFile: promisify(fs.readFile),
   exists: promisify(fs.exists),
+  existsSync: fs.existsSync,
 };
 
 joo_global_object.child_process = require("child_process");

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -20,6 +20,8 @@ type t = {
 }
 
 let make () = {
+  (* If no bundled superbol is found, try superbol-free from PATH as
+     last-resort. *)
   bundled_superbol = "superbol-free";
   language_client = None
 }
@@ -38,7 +40,8 @@ let start_language_server t =
   let open Promise.Syntax in
   let* () = stop_language_server t in
   let serverOptions =
-    Superbol_languageclient.serverOptions t.bundled_superbol
+    Superbol_languageclient.serverOptions
+      ~bundled_superbol:t.bundled_superbol
   in
   let clientOptions = Superbol_languageclient.clientOptions () in
   let client = LanguageClient.make

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -19,10 +19,8 @@ type t = {
   mutable language_client: LanguageClient.t option
 }
 
-let make () = {
-  (* If no bundled superbol is found, try superbol-free from PATH as
-     last-resort. *)
-  bundled_superbol = "superbol-free";
+let make ~bundled_superbol () = {
+  bundled_superbol;
   language_client = None
 }
 
@@ -50,6 +48,3 @@ let start_language_server t =
     ~serverOptions ~clientOptions () in
   let+ () = LanguageClient.start client in
   t.language_client <- Some client
-
-let set_bundled_superbol t bundled_superbol =
-  t.bundled_superbol <- bundled_superbol

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -15,10 +15,12 @@
 open Vscode_languageclient
 
 type t = {
+  mutable bundled_superbol : string;
   mutable language_client: LanguageClient.t option
 }
 
 let make () = {
+  bundled_superbol = "superbol-free";
   language_client = None
 }
 
@@ -35,7 +37,9 @@ let stop_language_server t =
 let start_language_server t =
   let open Promise.Syntax in
   let* () = stop_language_server t in
-  let serverOptions = Superbol_languageclient.serverOptions () in
+  let serverOptions =
+    Superbol_languageclient.serverOptions t.bundled_superbol
+  in
   let clientOptions = Superbol_languageclient.clientOptions () in
   let client = LanguageClient.make
     ~id:"cobolServer"
@@ -43,3 +47,6 @@ let start_language_server t =
     ~serverOptions ~clientOptions () in
   let+ () = LanguageClient.start client in
   t.language_client <- Some client
+
+let set_bundled_superbol t bundled_superbol =
+  t.bundled_superbol <- bundled_superbol

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -14,10 +14,8 @@
 
 type t
 
-val make : unit -> t
+val make : bundled_superbol:string -> unit -> t
 
 val stop_language_server : t -> unit Promise.t
 
 val start_language_server : t -> unit Promise.t
-
-val set_bundled_superbol : t -> string -> unit

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -19,3 +19,5 @@ val make : unit -> t
 val stop_language_server : t -> unit Promise.t
 
 val start_language_server : t -> unit Promise.t
+
+val set_bundled_superbol : t -> string -> unit

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let serverOptions superbol_path =
+let serverOptions ~bundled_superbol =
   let config = Vscode.Workspace.getConfiguration () in
   let cmd_opt =
     match Vscode.WorkspaceConfiguration.get ~section:"superbol.path" config with
@@ -23,7 +23,7 @@ let serverOptions superbol_path =
       | "" -> None
       | s -> Some s
   in
-  let command = Option.value ~default:superbol_path cmd_opt in
+  let command = Option.value ~default:bundled_superbol cmd_opt in
   Vscode_languageclient.ServerOptions.create ()
     ~command
     ~args:["lsp"]

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
@@ -12,13 +12,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let serverOptions () =
+let serverOptions superbol_path =
   let config = Vscode.Workspace.getConfiguration () in
-  let command =
+  let cmd_opt =
     match Vscode.WorkspaceConfiguration.get ~section:"superbol.path" config with
-    | Some o -> Ojs.string_of_js o
-    | None -> "superbol-free"
+    | None -> None
+    | Some o when Ojs.is_null o -> None
+    | Some o ->
+      match Ojs.string_of_js o with
+      | "" -> None
+      | s -> Some s
   in
+  let command = Option.value ~default:superbol_path cmd_opt in
   Vscode_languageclient.ServerOptions.create ()
     ~command
     ~args:["lsp"]

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
@@ -12,5 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val serverOptions: unit -> Vscode_languageclient.ServerOptions.t
+val serverOptions:
+  string -> Vscode_languageclient.ServerOptions.t
 val clientOptions: unit -> Vscode_languageclient.ClientOptions.t

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
@@ -13,5 +13,6 @@
 (**************************************************************************)
 
 val serverOptions:
-  string -> Vscode_languageclient.ServerOptions.t
+  bundled_superbol:string ->
+  Vscode_languageclient.ServerOptions.t
 val clientOptions: unit -> Vscode_languageclient.ClientOptions.t

--- a/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
@@ -160,6 +160,37 @@ let indentRange
 *)
   `Value promise
 
+(* Helpers to find the bundled superbol executable *)
+let rec find_existing = function
+  | [] -> raise Not_found
+  | uri :: uris ->
+    if Node.Fs.existsSync (Vscode.Uri.fsPath uri) then uri
+    else find_existing uris
+
+(* Look for the most specific `superbol-free` executable amongst (in order):
+
+  - `superbol-free-${platform}-${arch}${suffix}`
+  - `superbol-free-${platform}${suffix}`
+  - `superbol-free${suffix}`
+
+  The `platform` and `arch` used are from the corresponding `process`
+  attributes in node.js. The `suffix` is `".exe"` on Windows, and empty
+  otherwise.
+
+  https://nodejs.org/api/process.html#processplatform
+  https://nodejs.org/api/process.html#processarch
+*)
+let find_superbol root =
+  let open Node.Process in
+  let prefix = "superbol-free" in
+  let suffix = if platform == "win32" then ".exe" else "" in
+  Vscode.Uri.fsPath @@ find_existing @@ List.map (fun name ->
+    Vscode.Uri.joinPath root ~pathSegments:[name]) @@ [
+    Format.asprintf "%s-%s-%s%s" prefix platform arch suffix;
+    Format.asprintf "%s-%s%s" prefix platform suffix;
+    Format.asprintf "%s%s" prefix suffix
+  ]
+
 let instance = Superbol_instance.make ()
 
 let activate (extension : Vscode.ExtensionContext.t) =
@@ -187,6 +218,20 @@ let activate (extension : Vscode.ExtensionContext.t) =
   in
 
   Vscode.ExtensionContext.subscribe extension ~disposable:task;
+
+  let bundled_superbol =
+    try
+      find_superbol
+          (Vscode.Uri.joinPath ~pathSegments:["_dist"]
+            (Vscode.ExtensionContext.extensionUri extension));
+    with Not_found ->
+      (* If there is no bundled executable for the current platform, fall back
+         to looking for superbol-free in the PATH *)
+      "superbol-free"
+  in
+
+  Superbol_instance.set_bundled_superbol instance
+    bundled_superbol;
 
   Superbol_commands.register_all extension instance;
   Superbol_instance.start_language_server instance

--- a/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
@@ -191,7 +191,7 @@ let find_superbol root =
     Format.asprintf "%s%s" prefix suffix
   ]
 
-let instance = Superbol_instance.make ()
+let current_instance = ref None
 
 let activate (extension : Vscode.ExtensionContext.t) =
   let providerFull = Vscode.DocumentFormattingEditProvider.create
@@ -230,14 +230,17 @@ let activate (extension : Vscode.ExtensionContext.t) =
       "superbol-free"
   in
 
-  Superbol_instance.set_bundled_superbol instance
-    bundled_superbol;
+  let instance = Superbol_instance.make ~bundled_superbol () in
+  current_instance := Some instance;
 
   Superbol_commands.register_all extension instance;
   Superbol_instance.start_language_server instance
 
 let deactivate () =
+  match !current_instance with
+  | Some instance ->
     Superbol_instance.stop_language_server instance
+  | None -> Promise.return ()
 
 (* see {{:https://code.visualstudio.com/api/references/vscode-api#Extension}
    activate() *)


### PR DESCRIPTION
This patch makes the VS Code extension look for a bundled executable in the following order (and with a `.exe` suffix on Windows):

 - `_dist/superbol-free-${platform}-${arch}`
 - `_dist/superbol-free-${platform}`
 - `_dist/superbol-free`

So for instance on x64 Linux we will look for:

 - `_dist/superbol-free-linux-x64`
 - `_dist/superbol-free-linux`
 - `_dist/superbol-free`

On recent Macs we will look for:

 - `_dist/superbol-free-darwin-arm64`
 - `_dist/superbol-free-darwin`
 - `_dist/superbol-free`

And on Windows we will look for

 - `_dist/superbol-free-win32-x64.exe`
 - `_dist/superbol-free-win32.exe`
 - `_dist/superbol-free.exe`

This will also allow tackling #76 once we actually put the executables in the extension. It also allows some flexibility between making "slim" per-platform extensions or "fat" multiplatform extensions with many executables.