### PR TITLE
Depend on `ez_api.encoding` instead of the whole of `ez_api`

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-b24521fe678343acf73ace7777589648:.
+4894c46a834176a4a440b4f2b72d8eb0:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -406,7 +406,7 @@ eab335ce600887c59f1baf9b0983d0ac:src/lsp/ezr_toml/dune
 
 # begin context for src/lsp/superbol_free_lib/dune
 # file src/lsp/superbol_free_lib/dune
-7982e4cd1f6beb57ea34b6afa6b1fdf9:src/lsp/superbol_free_lib/dune
+7e1eaceee64532039bff9a99e6d8da09:src/lsp/superbol_free_lib/dune
 # end context for src/lsp/superbol_free_lib/dune
 
 # begin context for src/lsp/superbol_free_lib/version.mlt

--- a/src/lsp/superbol_free_lib/dune
+++ b/src/lsp/superbol_free_lib/dune
@@ -5,7 +5,7 @@
   (public_name superbol_free_lib)
   (wrapped true)
   ; use field 'dune-libraries' to add libraries without opam deps
-  (libraries vscode-json lwt ez_toml ez_file ez_cmdliner ez_api cobol_typeck cobol_parser cobol_lsp cobol_indent cobol_common )
+  (libraries vscode-json lwt ez_toml ez_file ez_cmdliner ez_api.encoding cobol_typeck cobol_parser cobol_lsp cobol_indent cobol_common )
   ; use field 'dune-flags' to set this value
   (flags (:standard))
   ; use field 'dune-stanzas' to add more stanzas here

--- a/src/lsp/superbol_free_lib/package.toml
+++ b/src/lsp/superbol_free_lib/package.toml
@@ -61,7 +61,7 @@ cobol_typeck = "version"
 ez_file = ">=0.3"
 ez_cmdliner = "0.3.0"
 vscode-json = "version"
-ez_api = "2.0"
+ez_api = { version = "2.0", libname = "ez_api.encoding" }
 ez_toml = "version"
 
 # We only depend on `lwt` via `ez_api` (and we don't even use any bit


### PR DESCRIPTION
This shall help avoid (indirectly) depending on `lwt` (and therefore, `threads`).