### PR TITLE
Some improvements while debugging the LSP

### DIFF
--- a/src/lsp/cobol_lsp/lsp_debug.ml
+++ b/src/lsp/cobol_lsp/lsp_debug.ml
@@ -1,0 +1,54 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let debug = ref None
+
+let () =
+  match Sys.getenv "SUPERBOL_LSP_DEBUG" with
+  | exception Not_found -> ()
+  | file ->
+    let oc = open_out file in
+    debug := Some oc
+
+module LSP_IO = struct
+
+  let read_line line =
+    match !debug with
+    | None -> ()
+    | Some oc ->
+      Printf.fprintf oc "==>LINE: %s\n%!" line
+
+  let read_bytes buf i n =
+    match !debug with
+    | None -> ()
+    | Some oc ->
+      Printf.fprintf oc "==>[%d]: %s\n%!" n (Bytes.sub_string buf i n)
+
+  let write s =
+    match !debug with
+    | None -> ()
+    | Some oc ->
+      let lines = String.split_on_char '\n' s in
+      let s = String.concat "\n<== " lines in
+      Printf.fprintf oc "<== %s\n%!" s
+end
+
+let message fmt =
+  Printf.ksprintf (fun s ->
+    match !debug with
+    | None -> ()
+    | Some oc ->
+      let lines = String.split_on_char '\n' s in
+      let s = String.concat "\nMSGCONT: " lines in
+      Printf.fprintf oc       "MESSAGE: %s\n%!" s
+    ) fmt

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -172,8 +172,11 @@ let lookup_references_in_doc
     Cobol_typeck.Outputs.{ group; artifacts = { references }; _ }
   =
   match Lsp_lookup.element_at_position ~uri:doc.uri position group with
-  | { element_at_position = None; _ }
+  | { element_at_position = None; _ } ->
+    Lsp_debug.message "Lsp_request.lookup_references_in_doc: element_at_position = None";
+    None
   | { enclosing_compilation_unit_name = None; _ } ->
+    Lsp_debug.message "Lsp_request.lookup_references_in_doc: enclosing_compilation_unit_name = None";
       None
   | { element_at_position = Some qn;
       enclosing_compilation_unit_name = Some cu_name } ->
@@ -198,13 +201,17 @@ let lookup_references_in_doc
           match qn with
           | Data_full_name qn
           | Data_item { full_qn = Some qn; _ } ->
+            Lsp_debug.message "Lsp_request.lookup_references_in_doc: Data_full_name...";
               data_refs qn
           | Data_item { full_qn = None; _ } ->
+            Lsp_debug.message "Lsp_request.lookup_references_in_doc: Data_item...";
               []
           | Data_name qn ->
+            Lsp_debug.message "Lsp_request.lookup_references_in_doc: Data_name...";
               Option.fold ~none:[] ~some:data_refs @@
               find_full_qn qn ~&cu.unit_data.data_items.named ~kind:"data-name"
           | Proc_name { qn; in_section } ->
+            Lsp_debug.message "Lsp_request.lookup_references_in_doc: Proc_name...";
               Option.fold ~none:[] ~some:proc_refs @@
               find_proc_qn qn ?in_section ~&cu ~kind:"procedure-name"
         with Not_found -> []
@@ -447,9 +454,11 @@ let on_request
     | WillDeleteFiles  (* DeleteFilesParams.t.t *) _
     | WillRenameFiles  (* RenameFilesParams.t.t *) _
       ->
-        Error (UnhandledRequest client_req)
+      Lsp_debug.message "Lsp_request: unhandled request";
+      Error (UnhandledRequest client_req)
     | UnknownRequest { meth; _ } ->
-        Error (UnknownRequest meth)
+      Lsp_debug.message "Lsp_request. unknown request";
+      Error (UnknownRequest meth)
 
 let handle (Jsonrpc.Request.{ id; _ } as req) state =
   match Lsp.Client_request.of_jsonrpc req with


### PR DESCRIPTION
Add a Lsp_debug module that logs the exchanges between the editor and the LSP server in a file specified by the env SUPERBOL_LSP_DEBUG

(I split the PR into multiple ones to easy merging)