### PR TITLE
Properly shut the LSP server down upon end of input stream

### DIFF
--- a/src/lsp/cobol_lsp/lsp_error.ml
+++ b/src/lsp/cobol_lsp/lsp_error.ml
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2024 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** {1 Error handling} *)
+
+(** Raises {!Jsonrpc.Response.Error.E} *)
+let error ~code fmt =
+  Pretty.string_to begin fun message ->
+    Jsonrpc.Response.Error.(raise @@ make ~code ~message ())
+  end fmt
+
+let request_failed fmt =
+  error ~code:Jsonrpc.Response.Error.Code.RequestFailed fmt
+
+let internal fmt =
+  error ~code:Jsonrpc.Response.Error.Code.InternalError fmt

--- a/src/lsp/cobol_lsp/lsp_error.mli
+++ b/src/lsp/cobol_lsp/lsp_error.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2024 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Functions that always raise {!Jsonrpc.Response.Error.E}, with customizable
+    messages. *)
+
+val request_failed: _ Pretty.func
+val internal: _ Pretty.func

--- a/src/lsp/cobol_lsp/lsp_io.ml
+++ b/src/lsp/cobol_lsp/lsp_io.ml
@@ -74,8 +74,6 @@ let read_message () : Jsonrpc.Packet.t =
       parse_error "content-type must be 'utf-8'"
   | _, None ->
       parse_error "missing content-length header"
-  | exception End_of_file ->
-      parse_error "premature end of input stream"
 
 (** [send_json json] sends out a json rpc package. *)
 let send_json json =

--- a/src/lsp/cobol_lsp/lsp_io.mli
+++ b/src/lsp/cobol_lsp/lsp_io.mli
@@ -21,7 +21,7 @@ exception Parse_error of string
 val initialize_channels: unit -> unit
 
 (** [read_message ()] tries to read a json RPC message from the standard input
-    stream. *)
+    stream.  Raises {!End_of_file} upon end of input stream. *)
 val read_message: unit -> Jsonrpc.Packet.t
 
 (** [send_response response] sends out a json RPC response on standard

--- a/src/lsp/cobol_lsp/lsp_notif.ml
+++ b/src/lsp/cobol_lsp/lsp_notif.ml
@@ -30,6 +30,7 @@ let on_notification state notif =
   | Running registry, TextDocumentDidClose params ->
       Running (Lsp_server.did_close params registry)
   | Running _, Exit ->
+      Lsp_request.shutdown state;
       Exit (Error "Received premature 'exit' notification")
   | _ ->
       state

--- a/src/lsp/cobol_lsp/lsp_project_cache.ml
+++ b/src/lsp/cobol_lsp/lsp_project_cache.ml
@@ -99,7 +99,8 @@ let save_project_cache ~config
       (* then (* read, write if commit hash or document changed *) *)
       (* else *)
       Lsp_utils.write_to cache_file (write_project_cache cached_project_record);
-      Lsp_io.pretty_notification "Wrote cache at: %s" cache_file ~type_:Info
+      Lsp_io.pretty_notification "Wrote cache at: %s" cache_file
+        ~log:true ~type_:Info
   | None ->
       ()
 

--- a/src/lsp/cobol_lsp/lsp_request.mli
+++ b/src/lsp/cobol_lsp/lsp_request.mli
@@ -12,6 +12,7 @@
 (**************************************************************************)
 
 val handle: Jsonrpc.Request.t -> (Lsp_server.state as 's) -> 's * Jsonrpc.Response.t
+val shutdown: Lsp_server.state -> unit
 
 module INTERNAL: sig
   val lookup_definition

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -101,7 +101,10 @@ let dispatch_diagnostics (Lsp_document.{ project; diags; _ } as doc) registry =
 (** {2 Management of per-project caches} *)
 
 let save_project_caches { config = { cache_config = config; _ }; docs; _ } =
-  Lsp_project_cache.save ~config docs
+  try Lsp_project_cache.save ~config docs
+  with e ->
+    Lsp_error.internal
+      "Exception@ caught@ while@ saving@ project@ caches:@ %a@." Fmt.exn e
 
 let load_project_cache ~rootdir ({ config = { project_layout = layout;
                                               cache_config = config; _ };

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -78,5 +78,6 @@ val find_document
 val jsonrpc_of_error
   : 'a error -> string -> Jsonrpc.Response.Error.t
 
+(** Note: May only raise {!Jsonrpc.Response.Error.E} *)
 val save_project_caches
   : t -> unit

--- a/src/lsp/cobol_lsp/lsp_server_loop.ml
+++ b/src/lsp/cobol_lsp/lsp_server_loop.ml
@@ -82,6 +82,9 @@ let run ~config =
     | Jsonrpc.Packet.Response _ | Batch_response _ ->
         Pretty.error "Response@ recieved@ unexpectedly@.";
         continue state
+    | exception End_of_file ->
+        Lsp_request.shutdown state;
+        Error "Premature end of input stream"                    (* exit loop *)
     | exception Lsp_io.Parse_error msg ->
         Lsp_io.pretty_notification ~type_:Error "%s" msg;
         Error msg                                                (* exit loop *)


### PR DESCRIPTION
This shall make the LSP actually save its caches when used in VS Code on windoze (on Linux, VS Code's shutdown is cleaner so caches already worked fine).