### PR TITLE
Add build instructions for SuperBOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ You can check the documentation on using the Superbol LSP with
 GNU/Emacs on [this
 page](https://ocamlpro.github.io/superbol-studio-oss/sphinx/emacs).
 
-## Building from Sources
+## Building from sources
+
+Make sure you are authenticated and update submodules:
+```bash
+git submodule update --init --recursive
+```
 
 You first need to install a few external dependencies to build the LSP
 server and the VSCode extension from sources.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ page](https://ocamlpro.github.io/superbol-studio-oss/sphinx/emacs).
 
 ## Building from sources
 
-Make sure you are authenticated and update submodules:
+If you build from a clone of the git repository, make sure to update submodules:
 ```bash
 git submodule update --init --recursive
 ```

--- a/sphinx/building-superbol.rst
+++ b/sphinx/building-superbol.rst
@@ -1,6 +1,12 @@
 Building SuperBOL from Sources
 ==============================
 
+Make sure you are authenticated and update submodules:
+
+   .. code-block:: shell
+
+     git submodule update --init --recursive
+
 To build the LSP server and the VSCode extension from source, you need
 to install a few external dependencies.
 

--- a/sphinx/building-superbol.rst
+++ b/sphinx/building-superbol.rst
@@ -1,7 +1,7 @@
 Building SuperBOL from Sources
 ==============================
 
-Make sure you are authenticated and update submodules:
+If you build from a clone of the git repository, make sure to update submodules:
 
    .. code-block:: shell
 


### PR DESCRIPTION
In order to build SuperBOL, we need to initialise and update submodules first.