### PR TITLE
Better config UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
         "command": "superbol.server.restart",
         "title": "Restart Language Server",
         "category": "SuperBOL"
+      },
+      {
+        "command": "superbol.write.project.config",
+        "title": "Write Project Configuration",
+        "category": "SuperBOL"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,10 @@
     "configuration": {
       "title": "SuperBOL COBOL",
       "properties": {
-        "superbol.cobol.copybooks": {
-          "title": "Copybook paths",
-          "type": "array",
-          "description": "List of copybooks paths"
-        },
         "superbol.cobol.dialect": {
+          "markdownDescription": "Default COBOL dialect; \"default\" is equivalent to \"gnucobol\".\n\n*(May be overriden in project-specific `superbol.toml` files)*.",
           "type": "string",
           "default": "default",
-          "description": "Default COBOL dialect; \"default\" is equivalent to \"gnucobol\"",
           "items": "string",
           "enum": [
             "default",
@@ -63,9 +58,9 @@
           ]
         },
         "superbol.cobol.source-format": {
+          "markdownDescription": "Default source reference-format.\n\n*(May be overriden in project-specific `superbol.toml` files)*.",
           "type": "string",
           "default": "auto",
-          "description": "Default source reference-format",
           "items": "string",
           "enum": [
             "auto",
@@ -79,6 +74,31 @@
             "terminal",
             "cobolx"
           ]
+        },
+        "superbol.cobol.copybooks": {
+          "title": "Copybook paths",
+          "markdownDescription": "List of copybooks paths.\n\n*(May be overriden in project-specific `superbol.toml` files)*.",
+          "type": "array",
+          "default": [
+            {
+              "dir": "."
+            }
+          ],
+          "items": {
+            "type": "object",
+            "required": [
+              "dir"
+            ],
+            "properties": {
+              "dir": {
+                "type": "string",
+                "description": "Path to copybooks"
+              },
+              "file-relative": {
+                "type": "boolean"
+              }
+            }
+          }
         },
         "superbol.lsp-path": {
           "title": "SuperBOL executable",

--- a/src/lsp/cobol_lsp/lsp_document.ml
+++ b/src/lsp/cobol_lsp/lsp_document.ml
@@ -158,6 +158,10 @@ let first_change_pos changes =
   in
   Cobol_parser.Indexed { line; char }
 
+let reload doc =
+  try reparse_and_analyze doc
+  with e -> raise @@ Internal_error (doc, e, Printexc.get_raw_backtrace ())
+
 let update ({ textdoc; _ } as doc) changes =
   let position = first_change_pos changes in
   let doc =

--- a/src/lsp/cobol_lsp/lsp_error.ml
+++ b/src/lsp/cobol_lsp/lsp_error.ml
@@ -22,5 +22,8 @@ let error ~code fmt =
 let request_failed fmt =
   error ~code:Jsonrpc.Response.Error.Code.RequestFailed fmt
 
+let invalid_params fmt =
+  error ~code:Jsonrpc.Response.Error.Code.InvalidParams fmt
+
 let internal fmt =
   error ~code:Jsonrpc.Response.Error.Code.InternalError fmt

--- a/src/lsp/cobol_lsp/lsp_error.mli
+++ b/src/lsp/cobol_lsp/lsp_error.mli
@@ -15,4 +15,5 @@
     messages. *)
 
 val request_failed: _ Pretty.func
+val invalid_params: _ Pretty.func
 val internal: _ Pretty.func

--- a/src/lsp/cobol_lsp/lsp_io.ml
+++ b/src/lsp/cobol_lsp/lsp_io.ml
@@ -106,6 +106,10 @@ let send_json json =
 let send_response response =
   send_json @@ Jsonrpc.Response.yojson_of_t response
 
+(** [send_request request] sends out a json RPC request on standard output. *)
+let send_request request =
+  send_json @@ Jsonrpc.Request.yojson_of_t request
+
 (** [send_notification notif] sends out a json RPC notification on standard
     output. *)
 let send_notification notif =

--- a/src/lsp/cobol_lsp/lsp_io.ml
+++ b/src/lsp/cobol_lsp/lsp_io.ml
@@ -118,13 +118,12 @@ let send_diagnostics ~uri diagnostics =
   let notif = Lsp.Server_notification.PublishDiagnostics params in
   send_notification @@ Lsp.Server_notification.to_jsonrpc notif
 
-(** [pretty_notification ~log ~type_ fmt ...] formats any number of arguments
+(** [pretty_message ~log ~type_ fmt ...] formats any number of arguments
     according to the format string [fmt], and sends the result via a json RPC
     notification for log or direct display (depending on the flag [log], false
-    by default).  Also prints the result on stderr (for now). *)
-let pretty_notification ?(log = false) ~type_ fmt =
+    by default). *)
+let pretty_message ?(log = false) ~type_ fmt =
   Pretty.string_to begin fun message ->
-    (* Pretty.error "Notif: %s@." message; *)
     let notif =
       if log
       then Lsp.(Server_notification.LogMessage
@@ -134,3 +133,17 @@ let pretty_notification ?(log = false) ~type_ fmt =
     in
     send_notification (Lsp.Server_notification.to_jsonrpc notif)
   end ("%t@[<h>"^^fmt^^"@]") Pretty.blast_margin
+
+let pretty_log ~type_ fmt = pretty_message ~log:true ~type_ fmt
+let log = pretty_log
+let log_error fmt = log ~type_:Error fmt
+let log_warn fmt = log ~type_:Warning fmt
+let log_info fmt = log ~type_:Info fmt
+let log_debug fmt = log ~type_:Log fmt
+
+let pretty_notification ~type_ fmt =
+  pretty_message ~log:false ~type_ fmt
+let notification = pretty_notification
+let notify_error fmt = pretty_notification ~type_:Error fmt
+let notify_warn fmt = pretty_notification ~type_:Warning fmt
+let notify_info fmt = pretty_notification ~type_:Info fmt

--- a/src/lsp/cobol_lsp/lsp_io.mli
+++ b/src/lsp/cobol_lsp/lsp_io.mli
@@ -28,6 +28,9 @@ val read_message: unit -> Jsonrpc.Packet.t
     output. *)
 val send_response: Jsonrpc.Response.t -> unit
 
+(** [send_request required] sends out a json RPC request on standard output. *)
+val send_request: Jsonrpc.Request.t -> unit
+
 (** [send_notification notif] sends out a json RPC notification on standard
     output. *)
 val send_notification: Jsonrpc.Notification.t -> unit

--- a/src/lsp/cobol_lsp/lsp_io.mli
+++ b/src/lsp/cobol_lsp/lsp_io.mli
@@ -36,10 +36,29 @@ val send_notification: Jsonrpc.Notification.t -> unit
     pertain to the given URI. *)
 val send_diagnostics: uri:Lsp.Uri.t -> Lsp.Types.Diagnostic.t list -> unit
 
-(** [pretty_notification ~log ~type_ fmt ...] formats any number of arguments
+(** [pretty_message ~log ~type_ fmt ...] formats any number of arguments
     according to the format string [fmt], and sends the result via a json RPC
-    notification.  Also prints the result on stderr (for now). *)
-val pretty_notification
+    notification. *)
+val pretty_message
   : ?log:bool
   -> type_:Lsp.Types.MessageType.t
   -> ('a, Format.formatter, unit) format -> 'a
+
+(** [pretty_log ~type_ fmt ...] formats any number of arguments according to the
+    format string [fmt], and sends the result as a log message via a json RPC
+    notification. *)
+val pretty_log: type_:Lsp.Types.MessageType.t -> _ Pretty.proc
+val log: type_:Lsp.Types.MessageType.t -> _ Pretty.proc
+val log_error: _ Pretty.proc
+val log_warn: _ Pretty.proc
+val log_info: _ Pretty.proc
+val log_debug: _ Pretty.proc
+
+(** [pretty_notification ~type_ fmt ...] formats any number of arguments
+    according to the format string [fmt], and sends the result as a user
+    notification message via a json RPC notification. *)
+val pretty_notification: type_:Lsp.Types.MessageType.t -> _ Pretty.proc
+val notification: type_:Lsp.Types.MessageType.t -> _ Pretty.proc
+val notify_error: _ Pretty.proc
+val notify_warn: _ Pretty.proc
+val notify_info: _ Pretty.proc

--- a/src/lsp/cobol_lsp/lsp_notif.ml
+++ b/src/lsp/cobol_lsp/lsp_notif.ml
@@ -21,8 +21,8 @@ let on_notification state notif =
       ShuttingDown
   | NotInitialized _ | Exit _ as state, _ ->
       state                   (* spec indicate notif should just be discarded *)
-  | Initialized config, Initialized ->
-      Running (Lsp_server.init ~config)
+  | Initialized params, Initialized ->
+      Running (Lsp_server.init ~params)
   | Running registry, TextDocumentDidOpen params ->
       Running (Lsp_server.did_open params registry)
   | Running registry, TextDocumentDidChange params ->

--- a/src/lsp/cobol_lsp/lsp_notif.ml
+++ b/src/lsp/cobol_lsp/lsp_notif.ml
@@ -23,6 +23,8 @@ let on_notification state notif =
       state                   (* spec indicate notif should just be discarded *)
   | Initialized params, Initialized ->
       Running (Lsp_server.init ~params)
+  | Running registry, ChangeConfiguration _ ->
+      Running (Lsp_server.on_client_config_change registry)
   | Running registry, TextDocumentDidOpen params ->
       Running (Lsp_server.did_open params registry)
   | Running registry, TextDocumentDidChange params ->

--- a/src/lsp/cobol_lsp/lsp_notif.ml
+++ b/src/lsp/cobol_lsp/lsp_notif.ml
@@ -38,7 +38,7 @@ let on_notification state notif =
 let handle notif state =
   match Lsp.Client_notification.of_jsonrpc notif with
   | Error str ->
-      Lsp_io.pretty_notification ~type_:Error "Invalid@ notification:@ %s" str;
+      Lsp_io.log_error "Invalid@ notification:@ %s" str;
       state
   | Ok notif ->
       try on_notification state notif with

--- a/src/lsp/cobol_lsp/lsp_notif.ml
+++ b/src/lsp/cobol_lsp/lsp_notif.ml
@@ -23,8 +23,8 @@ let on_notification state notif =
       state                   (* spec indicate notif should just be discarded *)
   | Initialized params, Initialized ->
       Running (Lsp_server.init ~params)
-  | Running registry, ChangeConfiguration _ ->
-      Running (Lsp_server.on_client_config_change registry)
+  | Running registry, ChangeConfiguration { settings = changes } ->
+      Running (Lsp_server.on_client_config_changes ~changes registry)
   | Running registry, DidChangeWatchedFiles { changes } ->
       Running (Lsp_server.on_watched_file_changes changes registry)
   | Running registry, TextDocumentDidOpen params ->

--- a/src/lsp/cobol_lsp/lsp_project.mli
+++ b/src/lsp/cobol_lsp/lsp_project.mli
@@ -80,6 +80,7 @@ module MAP: Map.S with type key = t
 
 (** Config *)
 
+val reload_project_config: t -> bool
 val update_project_config: (string * Yojson.Safe.t) list -> t -> bool
 
 (** Miscellaneous *)

--- a/src/lsp/cobol_lsp/lsp_project.mli
+++ b/src/lsp/cobol_lsp/lsp_project.mli
@@ -78,9 +78,14 @@ module SET: sig
 end
 module MAP: Map.S with type key = t
 
+(** Config *)
+
+val update_project_config: (string * Yojson.Safe.t) list -> t -> bool
+
 (** Miscellaneous *)
 
 val rootdir: t -> rootdir
+val rooturi: t -> Lsp.Uri.t
 val config: t -> Superbol_project.Config.t
 val string_of_rootdir: rootdir -> string
 val relative_path_for: uri:Lsp.Uri.t -> t -> string

--- a/src/lsp/cobol_lsp/lsp_project.mli
+++ b/src/lsp/cobol_lsp/lsp_project.mli
@@ -73,6 +73,7 @@ val of_cache: rootdir:rootdir -> layout:layout -> cached -> t
 
 module SET: sig
   include Set.S with type elt = t
+  val for_: uri:Lsp.Uri.t -> t -> elt
   val for_rootdir: rootdir:rootdir -> t -> elt
   val mem_rootdir: rootdir:rootdir -> t -> bool
 end
@@ -82,6 +83,7 @@ module MAP: Map.S with type key = t
 
 val reload_project_config: t -> bool
 val update_project_config: (string * Yojson.Safe.t) list -> t -> bool
+val get_project_config: ?flat:bool -> t -> Yojson.Safe.t
 
 (** Miscellaneous *)
 

--- a/src/lsp/cobol_lsp/lsp_project_cache.ml
+++ b/src/lsp/cobol_lsp/lsp_project_cache.ml
@@ -99,8 +99,7 @@ let save_project_cache ~config
       (* then (* read, write if commit hash or document changed *) *)
       (* else *)
       Lsp_utils.write_to cache_file (write_project_cache cached_project_record);
-      Lsp_io.pretty_notification "Wrote cache at: %s" cache_file
-        ~log:true ~type_:Info
+      Lsp_io.log_info "Wrote cache at: %s" cache_file
   | None ->
       ()
 
@@ -123,18 +122,18 @@ let load_project ~rootdir ~layout ~config { cached_project; cached_docs; _ } =
     try
       let doc = Lsp_document.of_cache ~project cached_doc in
       if config.cache_verbose then
-        Lsp_io.pretty_notification "Successfully read cache for %s"
-          (Lsp.Uri.to_string @@ Lsp_document.uri doc) ~log:true ~type_:Info;
+        Lsp_io.log_info "Successfully@ read@ cache@ for@ %s"
+          (Lsp.Uri.to_string @@ Lsp_document.uri doc);
       add_doc doc docs
     with
     | Failure msg | Sys_error msg ->
         if config.cache_verbose then
-          Lsp_io.pretty_notification "Failed to read cache for %s: %s"
-            cached_doc.doc_cache_filename msg ~log:true ~type_:Info;
+          Lsp_io.log_info "Failed@ to@ read@ cache@ for@ %s:@ %s"
+            cached_doc.doc_cache_filename msg;
         docs
     | e ->
-        Lsp_io.pretty_notification "Failed to read cache for %s: %a"
-          cached_doc.doc_cache_filename Fmt.exn e ~log:true ~type_:Warning;
+        Lsp_io.log_warn "Failed@ to@ read@ cache@ for@ %s:@ %a"
+          cached_doc.doc_cache_filename Fmt.exn e;
         docs
   end cached_docs URIMap.empty
 
@@ -143,8 +142,8 @@ let load ~rootdir ~layout ~config =
   let load_cache cache_file =
     let cached_project = Lsp_utils.read_from cache_file read_project_cache in
     let project = load_project ~rootdir ~layout ~config cached_project in
-    Lsp_io.pretty_notification "Successfully read cache for %s"
-      (Lsp_project.string_of_rootdir rootdir) ~log:true ~type_:Info;
+    Lsp_io.log_info "Successfully@ read@ cache@ for@ %s"
+      (Lsp_project.string_of_rootdir rootdir);
     project
   in
   match cache_filename ~config ~rootdir with
@@ -154,15 +153,13 @@ let load ~rootdir ~layout ~config =
       try load_cache cache_file with
       | Sys_error msg ->
           if config.cache_verbose then
-            Lsp_io.pretty_notification "Failed to read cache: %s"
-              msg ~log:true ~type_:Info;
+            Lsp_io.log_info "Failed@ to@ read@ cache:@ %s" msg;
           fallback
       | Failure msg ->
           if config.cache_verbose then
-            Lsp_io.pretty_notification "Failed to read cache %s: %s"
-              cache_file msg ~log:true ~type_:Info;
+            Lsp_io.log_info "Failed@ to@ read@ cache@ %s:@ %s" cache_file msg;
           fallback
       | e ->
-          Lsp_io.pretty_notification "Failed to read cache %s: %a"
-            cache_file Fmt.exn e ~log:true ~type_:Warning;
+          Lsp_io.log_warn "Failed@ to@ read@ cache@ %s:@ %a\
+                          " cache_file Fmt.exn e;
           fallback

--- a/src/lsp/cobol_lsp/lsp_project_cache.ml
+++ b/src/lsp/cobol_lsp/lsp_project_cache.ml
@@ -117,22 +117,24 @@ let save ~config docs =
 (** (Internal) *)
 let load_project ~rootdir ~layout ~config { cached_project; cached_docs; _ } =
   let project = Lsp_project.of_cache ~rootdir ~layout cached_project in
+  Lsp_io.log_info "Successfully@ read@ project@ cache@ for@ %s"
+    Lsp.Uri.(to_string @@ Lsp_project.rooturi project);
   let add_doc doc docs = URIMap.add (Lsp_document.uri doc) doc docs in
   CACHED_DOCS.fold begin fun cached_doc docs ->
     try
       let doc = Lsp_document.of_cache ~project cached_doc in
       if config.cache_verbose then
-        Lsp_io.log_info "Successfully@ read@ cache@ for@ %s"
+        Lsp_io.log_info "Successfully@ read@ document@ cache@ for@ %s"
           (Lsp.Uri.to_string @@ Lsp_document.uri doc);
       add_doc doc docs
     with
     | Failure msg | Sys_error msg ->
         if config.cache_verbose then
-          Lsp_io.log_info "Failed@ to@ read@ cache@ for@ %s:@ %s"
+          Lsp_io.log_info "Failed@ to@ read@ document@ cache@ for@ %s:@ %s"
             cached_doc.doc_cache_filename msg;
         docs
     | e ->
-        Lsp_io.log_warn "Failed@ to@ read@ cache@ for@ %s:@ %a"
+        Lsp_io.log_warn "Failed@ to@ read@ document@ cache@ for@ %s:@ %a"
           cached_doc.doc_cache_filename Fmt.exn e;
         docs
   end cached_docs URIMap.empty
@@ -141,10 +143,7 @@ let load ~rootdir ~layout ~config =
   let fallback = URIMap.empty in
   let load_cache cache_file =
     let cached_project = Lsp_utils.read_from cache_file read_project_cache in
-    let project = load_project ~rootdir ~layout ~config cached_project in
-    Lsp_io.log_info "Successfully@ read@ cache@ for@ %s"
-      (Lsp_project.string_of_rootdir rootdir);
-    project
+    load_project ~rootdir ~layout ~config cached_project
   in
   match cache_filename ~config ~rootdir with
   | None ->

--- a/src/lsp/cobol_lsp/lsp_project_cache.ml
+++ b/src/lsp/cobol_lsp/lsp_project_cache.ml
@@ -152,12 +152,17 @@ let load ~rootdir ~layout ~config =
       fallback
   | Some cache_file ->
       try load_cache cache_file with
-      | Failure msg | Sys_error msg ->
+      | Sys_error msg ->
           if config.cache_verbose then
             Lsp_io.pretty_notification "Failed to read cache: %s"
               msg ~log:true ~type_:Info;
           fallback
+      | Failure msg ->
+          if config.cache_verbose then
+            Lsp_io.pretty_notification "Failed to read cache %s: %s"
+              cache_file msg ~log:true ~type_:Info;
+          fallback
       | e ->
-          Lsp_io.pretty_notification "Failed to read cache: %a"
-            Fmt.exn e ~log:true ~type_:Warning;
+          Lsp_io.pretty_notification "Failed to read cache %s: %a"
+            cache_file Fmt.exn e ~log:true ~type_:Warning;
           fallback

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -52,17 +52,20 @@ let initialize ~config (params: InitializeParams.t) =
     | Some Some (_ :: _ as l) -> List.map (fun x -> x.WorkspaceFolder.uri) l
     | _ -> Option.to_list root_uri
   in
-  Pretty.error "Initializing for workspace folders: %a@."
-    Pretty.(list string)
+  Lsp_io.log_info "Initializing@ for@ workspace@ folders:@ %a@."
+    Pretty.(list ~fopen:"@[" ~fclose:"@]" string)
     (List.map (fun x -> DocumentUri.to_path x) workspace_folders);
+  let capabilities = Lsp_capabilities.reply params.capabilities in
   let result =
     InitializeResult.create ()
       ~serverInfo:(InitializeResult.create_serverInfo ()
                      ~name:"SuperBOL LSP Server"
                      ~version:Version.version)
-      ~capabilities:(Lsp_capabilities.reply params.capabilities)
+      ~capabilities
   in
-  Ok (result, Initialized { root_uri; workspace_folders; config })
+  let with_semantic_tokens = capabilities.semanticTokensProvider <> None in
+  Ok (result, Initialized { root_uri; workspace_folders; config;
+                            with_semantic_tokens })
 
 (** {3 Shutdown} *)
 

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -406,7 +406,7 @@ let handle_hover registry (params: HoverParams.t) =
     Some (Hover.create () ~contents:(`MarkupContent content) ~range)
   in
   try_doc registry params.textDocument
-    ~f:begin fun ~doc:{ project; artifacts = { pplog; _ }; _ } ->
+    ~f:begin fun ~doc:{ artifacts = { pplog; _ }; _ } ->
       match find_hovered_pplog_event pplog with
       | Some Replacement { matched_loc = loc;
                            replacement_text; _ } ->
@@ -415,13 +415,7 @@ let handle_hover registry (params: HoverParams.t) =
       | Some FileCopy { copyloc = loc;
                         status = CopyDone lib | CyclicCopy lib } ->
           let text = EzFile.read_file lib in
-          (* TODO: grab source-format from preprocessor state? *)
-          let module Config = (val project.config.cobol_config) in
-          let mdlang = match Config.format#value with
-            | SF (SFFree | SFVariable | SFCOBOLX) -> "cobolfree"
-            | SF _ | Auto -> "cobol"
-          in
-          Pretty.string_to (hover_markdown ~loc) "```%s\n%s\n```" mdlang text
+          Pretty.string_to (hover_markdown ~loc) "```cobol\n%s\n```" text
       | Some FileCopy { status = MissingCopy _; _ }
       | Some Replace _
       | Some CompilerDirective _

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -348,6 +348,9 @@ let init ~params : registry =
   maybe_start_watching_client_config
 
 
+(** {3 Configuration} *)
+
+
 let extract_docs_of ~project registry =
   let out_of_date_docs, docs =
     URIMap.partition begin fun _ doc ->
@@ -446,6 +449,20 @@ let create_or_retrieve_project_promise ~uri registry =
     if registry.params.config.enable_client_configs
     then request_n_use_client_config_for ~project
     else now project
+
+
+let on_write_project_config_command uri registry =
+  let write_project_config project registry =
+    Lsp_io.log_info "Saving@ configuration@ for@ project@ of@ document@ at@ %s"
+      (Lsp.Uri.to_string uri);
+    Superbol_project.save_config ~verbose:true project;
+    registry
+  in
+  perform write_project_config
+    ~after:(create_or_retrieve_project_promise ~uri registry)
+
+
+(** {2 Handling of document notifications} *)
 
 
 let add (DidOpenTextDocumentParams.{ textDocument = { uri; _ }; _ } as doc)

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -20,21 +20,25 @@ module TYPES: sig
     cache_config: Lsp_project_cache.config;
   }
 
+  type params = {
+    config: config;
+    root_uri: Lsp.Types.DocumentUri.t option;
+    workspace_folders: Lsp.Types.DocumentUri.t list;     (* includes root_uri *)
+  }
+
   type registry = private {
     projects: Lsp_project.SET.t;
     docs: Lsp_document.t URIMap.t;
-    indirect_diags: Lsp_diagnostics.t URIMap.t; (* diagnostics for other URIs
-                                                   mentioned by docs in
-                                                   `docs` *)
-    config: config;
+    indirect_diags: Lsp_diagnostics.t URIMap.t;
+    params: params;
   }
 
   type state =
-    | NotInitialized of config   (* At startup and until "initialize" request *)
-    | Initialized of config (* After "initialize" and before "initialized" notif *)
-    | Running of registry   (* After "initialized" and before "shutdown" *)
-    | ShuttingDown          (* From "shuntdown" until "exit" notif *)
-    | Exit of exit_status   (* After "exit" notif *)
+    | NotInitialized of config
+    | Initialized of params
+    | Running of registry
+    | ShuttingDown
+    | Exit of exit_status
 
   and exit_status = (unit, string) result
 
@@ -48,6 +52,7 @@ module TYPES: sig
 end
 include module type of TYPES
   with type config = TYPES.config
+   and type params = TYPES.params
    and type registry = TYPES.registry
    and type state = TYPES.state
    and type exit_status = TYPES.exit_status
@@ -56,7 +61,7 @@ include module type of TYPES
 type t = registry                                                    (* alias *)
 
 val init
-  : config:config
+  : params: params
   -> t
 
 (** When given, [copybook] indicates whether the document is a copybook (in

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -34,11 +34,13 @@ module TYPES: sig
     projects: Lsp_project.SET.t;
     docs: Lsp_document.t URIMap.t;
     indirect_diags: Lsp_diagnostics.t URIMap.t;
-    pending_tasks: delayed_continuations;
+    pending_tasks: pending_tasks;
+    sub_state: sub_state;
     params: params;
   }
 
-  and delayed_continuations
+  and sub_state
+  and pending_tasks
 
   type state =
     | NotInitialized of config
@@ -60,7 +62,8 @@ end
 include module type of TYPES
   with type config = TYPES.config
    and type params = TYPES.params
-   and type delayed_continuations = TYPES.delayed_continuations
+   and type sub_state = TYPES.sub_state
+   and type pending_tasks = TYPES.pending_tasks
    and type registry = TYPES.registry
    and type state = TYPES.state
    and type exit_status = TYPES.exit_status
@@ -94,14 +97,17 @@ val jsonrpc_of_error
 val on_response
   : int -> Lsp.Import.Json.t -> t -> t
 
-val on_client_config_change
-  : t -> t
+val on_client_config_changes
+  : ?changes:Yojson.Safe.t -> t -> t
 
 val on_watched_file_changes
   : Lsp.Types.FileEvent.t list -> t -> t
 
 val on_write_project_config_command
   : Lsp.Uri.t -> t -> t
+
+val get_project_config_command
+  : Lsp.Uri.t -> t -> Yojson.Safe.t
 
 (** Note: May only raise {!Jsonrpc.Response.Error.E} *)
 val save_project_caches

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -26,6 +26,8 @@ module TYPES: sig
     root_uri: Lsp.Types.DocumentUri.t option;
     workspace_folders: Lsp.Types.DocumentUri.t list;     (* includes root_uri *)
     with_semantic_tokens: bool;
+    with_client_config_watcher: bool;
+    with_client_file_watcher: bool;
   }
 
   type registry = private {
@@ -94,6 +96,9 @@ val on_response
 
 val on_client_config_change
   : t -> t
+
+val on_watched_file_changes
+  : Lsp.Types.FileEvent.t list -> t -> t
 
 (** Note: May only raise {!Jsonrpc.Response.Error.E} *)
 val save_project_caches

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -100,6 +100,9 @@ val on_client_config_change
 val on_watched_file_changes
   : Lsp.Types.FileEvent.t list -> t -> t
 
+val on_write_project_config_command
+  : Lsp.Uri.t -> t -> t
+
 (** Note: May only raise {!Jsonrpc.Response.Error.E} *)
 val save_project_caches
   : t -> unit

--- a/src/lsp/ezr_toml/ezr_toml.ml
+++ b/src/lsp/ezr_toml/ezr_toml.ml
@@ -102,6 +102,8 @@ let save ?(verbose = false) filename toml =
     if verbose then
       Pretty.error "Updated file `%s'@." filename;
     toml.checksum <- Digest.string s
+  else if verbose then
+    Pretty.error "Leaving `%s' as is@." filename
 
 (* --- *)
 

--- a/src/lsp/ezr_toml/ezr_toml.ml
+++ b/src/lsp/ezr_toml/ezr_toml.ml
@@ -113,7 +113,9 @@ let save ?(verbose = false) filename toml =
       ) false toml.update_hooks
   in
 
-  if modified then
+  if modified || (* force if file does not exist anymore (removed since load): *)
+     not (Sys.file_exists filename)
+  then
     let s = TOML.to_string toml.toml in
     File_utils.write_file ~mkdir:true filename s;
     if verbose then

--- a/src/lsp/ezr_toml/ezr_toml.mli
+++ b/src/lsp/ezr_toml/ezr_toml.mli
@@ -76,6 +76,11 @@ val add_section_update: toml_handle -> string -> (name: string -> section) -> un
     [Sys_error] if the file exists but is not readable. *)
 val load: ?verbose: bool -> string -> toml_handle
 
+(** [reload ~verbose filename handle] reloads the TOML file [filename].  Resets
+    the handle to an empty TOML if [filename] does not exit.  Raises [Sys_error]
+    if the file exists but is not readable. *)
+val reload: ?verbose: bool -> string -> toml_handle -> unit
+
 (** [save ~verbose filename handle] triggers update hooks (that update the TOML
     representation), and save it in [filename] if the representation has been
     modified. *)

--- a/src/lsp/pretty/pretty.ml
+++ b/src/lsp/pretty/pretty.ml
@@ -173,6 +173,8 @@ let vfield ?(label = Fmt.(styled `Yellow string)) ?(sep = Fmt.any ": ")
 
 let record ?(opening = Fmt.any "{@;<1 2>") ?(closing = Fmt.any "@;}") fields =
   Fmt.(opening ++ record fields ++ closing)
+let delayed_record ?opening ?closing fields ppf =
+  record ?opening ?closing fields ppf ()
 
 type 'a conditional_field =
   | T of 'a printer

--- a/src/lsp/pretty/pretty.mli
+++ b/src/lsp/pretty/pretty.mli
@@ -53,6 +53,11 @@ val record
   -> ?closing:'a printer
   -> 'a printer list
   -> 'a printer
+val delayed_record
+  : ?opening:unit printer
+  -> ?closing:unit printer
+  -> unit printer list
+  -> delayed
 val vfield
   : ?label: string printer
   -> ?sep: unit printer

--- a/src/lsp/superbol_free_lib/command_lsp.ml
+++ b/src/lsp/superbol_free_lib/command_lsp.ml
@@ -29,7 +29,10 @@ let run_lsp ~enable_caching ~storage =
   in
   let lsp_config =
     Cobol_lsp.config ()
-      ~enable_caching ~project_layout ?fallback_storage_directory
+      ~enable_caching
+      ~enable_client_configs:true
+      ~project_layout
+      ?fallback_storage_directory
   in
   match Cobol_lsp.run ~config:lsp_config with
   | Ok () -> ()

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -263,22 +263,48 @@ let contributes =
       Manifest.breakpoint "cobol";
     ]
     ~configuration:
-      (Manifest.configuration ~title:"SuperBOL COBOL"
+      (let with_superbol_toml_note md =
+         md ^ "\n\n*(May be overriden in project-specific `superbol.toml` files)*."
+       in
+       Manifest.configuration ~title:"SuperBOL COBOL"
          [
-           Manifest.PROPERTY.array "superbol.cobol.copybooks"
-             ~title:"Copybook paths"
-             ~description:"List of copybooks paths";
-
            Manifest.PROPERTY.enum "superbol.cobol.dialect"
              ~cases:Cobol_config.DIALECT.all_canonical_names
-             ~description: "Default COBOL dialect; \"default\" is equivalent to \
-                            \"gnucobol\""
+             ~markdownDescription:
+               (with_superbol_toml_note
+                  "Default COBOL dialect; \"default\" is equivalent to \
+                   \"gnucobol\".")
              ~default:(`String Cobol_config.(DIALECT.to_string Default));
 
            Manifest.PROPERTY.enum "superbol.cobol.source-format"
-             ~description: "Default source reference-format"
+             ~markdownDescription:
+               (with_superbol_toml_note "Default source reference-format.")
              ~cases:Cobol_config.Options.all_format_names
              ~default:(`String "auto");
+
+           Manifest.PROPERTY.array "superbol.cobol.copybooks"
+             ~title:"Copybook paths"
+             ~items:(`O [
+                 "type", `String "object";
+                 "required", `A [`String "dir"];
+                 "properties", `O [
+                   "dir", `O [
+                     "type", `String "string";
+                     "description", `String "Path to copybooks";
+                   ];
+                   "file-relative", `O [
+                     "type", `String "boolean";
+                   ];
+                 ];
+               ])
+             ~default:(`A [                 (* Should match `default_libpath` in
+                                               `superbol_project/project_config.ml` *)
+                 `O [
+                   "dir", `String ".";
+                 ];
+               ])
+             ~markdownDescription:
+               (with_superbol_toml_note "List of copybooks paths.");
 
            (* Paths *)
 

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -397,7 +397,12 @@ let contributes =
       Manifest.command ()
         ~command:"superbol.server.restart"
         ~title:"Restart Language Server"
+        ~category:"SuperBOL";
+      Manifest.command ()
+        ~command:"superbol.write.project.config"
+        ~title:"Write Project Configuration"
         ~category:"SuperBOL"
+        (* ~enablement:"!inDebugMode" *);
     ]
 
 let manifest =

--- a/src/lsp/superbol_project/project.ml
+++ b/src/lsp/superbol_project/project.ml
@@ -108,8 +108,8 @@ let absolute_path_for ~filename { rootdir; _ } =
   then filename       (* in case the file is not within its project directory *)
   else rootdir // filename
 
-let save_config { config_filename; config; _ } =
-  Project_config.save ~config_filename config
+let save_config ?verbose { config_filename; config; _ } =
+  Project_config.save ?verbose ~config_filename config
 
 (* Caching *)
 
@@ -134,7 +134,9 @@ let of_cache ~rootdir ~layout cached =
 module M = struct
   type nonrec t = t
   let compare { rootdir = d1; _ } { rootdir = d2; _ } = String.compare d1 d2
+  let equal { rootdir = d1; _ } { rootdir = d2; _ } = String.equal d1 d2
 end
+let have_same_rootdirs = M.equal
 
 module SET = struct
   include Set.Make (M)

--- a/src/lsp/superbol_project/project.ml
+++ b/src/lsp/superbol_project/project.ml
@@ -111,6 +111,9 @@ let absolute_path_for ~filename { rootdir; _ } =
 let save_config ?verbose { config_filename; config; _ } =
   Project_config.save ?verbose ~config_filename config
 
+let reload_config ?verbose { config_filename; config; _ } =
+  Project_config.reload ?verbose ~config_filename config
+
 (* Caching *)
 
 (** Persistent representation (for caching) *)

--- a/src/lsp/superbol_project/project.mli
+++ b/src/lsp/superbol_project/project.mli
@@ -112,15 +112,18 @@ val of_cache: rootdir:rootdir -> layout:layout -> cached -> t with_diags
 
 val config: t -> Project_config.t
 
-(** [save_config project] dumps the current configuration of [project] into a
-    TOML file.
+(** [save_config ~verbose project] dumps the current configuration of [project]
+    into a TOML file.  Prints some informative message on [stderr] if [verbose]
+    is set.
 
     The name of the configuration file is determined via the [layout] argument
     given to (the first call to) {!for_} or {!of_cache} with [project]'s root
     directory. *)
-val save_config: t -> unit
+val save_config: ?verbose:bool -> t -> unit
 
 (** {1 Collections} *)
+
+val have_same_rootdirs: t -> t -> bool
 
 module SET: sig
   include Set.S with type elt = t

--- a/src/lsp/superbol_project/project.mli
+++ b/src/lsp/superbol_project/project.mli
@@ -129,6 +129,7 @@ val have_same_rootdirs: t -> t -> bool
 
 module SET: sig
   include Set.S with type elt = t
+  val for_: filename:string -> t -> elt
   val for_rootdir: rootdir:rootdir -> t -> elt
   val mem_rootdir: rootdir:rootdir -> t -> bool
 end

--- a/src/lsp/superbol_project/project.mli
+++ b/src/lsp/superbol_project/project.mli
@@ -121,6 +121,8 @@ val config: t -> Project_config.t
     directory. *)
 val save_config: ?verbose:bool -> t -> unit
 
+val reload_config: ?verbose:bool -> t -> diagnostics
+
 (** {1 Collections} *)
 
 val have_same_rootdirs: t -> t -> bool

--- a/src/lsp/superbol_project/project_config.ml
+++ b/src/lsp/superbol_project/project_config.ml
@@ -125,7 +125,7 @@ let config_repr config ~name =
 
 let config_section_name = "cobol"
 
-let config_from_dialect_name dialect_name =
+let cobol_config_from_dialect_name dialect_name =
   try Cobol_config.(from_dialect @@ DIALECT.of_string dialect_name) with
   | Invalid_argument e ->
       raise @@ ERROR (Unknown_dialect e)
@@ -164,7 +164,7 @@ let load_file ?verbose config_filename =
   let load_section keys toml =
     let section = TOML.get keys toml in
     DIAGS.map_result
-      (config_from_dialect_name @@ get_dialect section)
+      (cobol_config_from_dialect_name @@ get_dialect section)
       ~f:(fun cobol_config ->
           { default with
             cobol_config;

--- a/src/lsp/superbol_project/project_config.mli
+++ b/src/lsp/superbol_project/project_config.mli
@@ -38,6 +38,10 @@ type t = config
 
 val new_default: unit -> t
 
+val cobol_config_from_dialect_name
+  : string
+  -> Cobol_config.t Cobol_common.Diagnostics.with_diags
+
 (** [load_file ~verbose config_filename] loads the given project configuration
     file.  Raises {!ERROR} or [Sys_error] in case of failure. *)
 val load_file

--- a/src/lsp/superbol_project/project_config.mli
+++ b/src/lsp/superbol_project/project_config.mli
@@ -55,6 +55,12 @@ val save
   -> t
   -> unit
 
+val reload
+  : ?verbose:bool
+  -> config_filename:string
+  -> t
+  -> Cobol_common.Diagnostics.diagnostics
+
 (** [libpath_for ~filename project] constructs a list of directory names where
     copybooks are looked up, for a given source file name, in a project with the
     given configuration. *)

--- a/src/lsp/superbol_project/project_diagnostics.ml
+++ b/src/lsp/superbol_project/project_diagnostics.ml
@@ -16,6 +16,7 @@ open Ez_toml.V1
 type error =
   | Invalid_toml of { loc: TOML.Types.location; error: TOML.Types.error }
   | Unknown_dialect of string
+  | Unknown_source_format of string
   | Cobol_config_error of Cobol_config.Diagnostics.error
 
 let pp_error ppf = function
@@ -24,5 +25,7 @@ let pp_error ppf = function
         (TOML.string_of_location loc) (TOML.string_of_error error)
   | Unknown_dialect name ->
       Pretty.print ppf "Unknown@ dialect: `%s'" name
+  | Unknown_source_format name ->
+      Pretty.print ppf "Unknown@ reference@ source-format: `%s'" name
   | Cobol_config_error e ->
       Cobol_config.Diagnostics.pp_error ppf e

--- a/src/vscode/superbol-vscode-platform/superbol_commands.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_commands.ml
@@ -15,10 +15,18 @@
 open Vscode
 
 type t =
-  { id : string ;
-    handler : Superbol_instance.t -> args:Ojs.t list -> unit
-    (* Intended for partial application of [handler instance] *)
-}
+  {
+    id: string;
+    handler:
+      [ `Basic of
+          (args:Ojs.t list -> unit)
+      | `Instance of (* Intended for partial application of [handler
+                        instance] *)
+          (Superbol_instance.t -> args:Ojs.t list -> unit)
+      | `Text of
+          (Superbol_instance.t -> textEditor:TextEditor.t ->
+           edit:TextEditorEdit.t -> args:Ojs.t list -> unit) ]
+  }
 
 let commands = ref []
 
@@ -28,16 +36,44 @@ let command id handler =
   command
 
 let _restart_language_server =
-  command "superbol.server.restart" @@
-  fun instance ~args:_ ->
-  let (_ : unit Promise.t) =
-    Superbol_instance.start_language_server instance
-  in ()
+  command "superbol.server.restart" @@ `Instance
+    begin fun instance ~args:_ ->
+      let (_ : unit Promise.t) =
+        Superbol_instance.start_language_server instance
+      in ()
+    end
+
+let _write_project_config =
+  command "superbol.write.project.config" @@ `Text
+    begin fun instance ~textEditor ~edit:_ ~args:_ ->
+      match Superbol_instance.client instance with
+      | None ->                                      (* ignore; TODO; message? *)
+          ()
+      | Some client ->
+          let document = TextEditor.document textEditor in
+          let uri = TextDocument.uri document in
+          let (_ : _ Promise.t) =
+            Vscode_languageclient.LanguageClient.sendRequest client ()
+              ~meth:"superbol/writeProjectConfiguration"
+              ~data:(Jsonoo.Encode.(object_ [
+                  "uri", string @@ Uri.toString uri ();
+                ]))
+          in ()
+    end
 
 let register extension instance { id; handler } =
-  let callback = handler instance in
-  ExtensionContext.subscribe extension
-    ~disposable:(Commands.registerCommand ~command:id ~callback)
+  match handler with
+  | `Basic callback ->
+      ExtensionContext.subscribe extension
+        ~disposable:(Commands.registerCommand ~command:id ~callback)
+  | `Instance callback ->
+      let callback = callback instance in
+      ExtensionContext.subscribe extension
+        ~disposable:(Commands.registerCommand ~command:id ~callback)
+  | `Text callback ->
+      let callback = callback instance in
+      ExtensionContext.subscribe extension
+        ~disposable:(Commands.registerTextEditorCommand ~command:id ~callback)
 
 let register_all extension instance =
   List.iter (register extension instance) !commands

--- a/src/vscode/superbol-vscode-platform/superbol_commands.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_commands.ml
@@ -14,18 +14,17 @@
 
 open Vscode
 
+type handler =
+  | Instance of     (* Intended for partial application of [handler instance] *)
+      (Superbol_instance.t -> args:Ojs.t list -> unit)
+  | Text of
+      (Superbol_instance.t -> textEditor:TextEditor.t ->
+       edit:TextEditorEdit.t -> args:Ojs.t list -> unit)
+
 type t =
   {
     id: string;
-    handler:
-      [ `Basic of
-          (args:Ojs.t list -> unit)
-      | `Instance of (* Intended for partial application of [handler
-                        instance] *)
-          (Superbol_instance.t -> args:Ojs.t list -> unit)
-      | `Text of
-          (Superbol_instance.t -> textEditor:TextEditor.t ->
-           edit:TextEditorEdit.t -> args:Ojs.t list -> unit) ]
+    handler: handler;
   }
 
 let commands = ref []
@@ -36,41 +35,29 @@ let command id handler =
   command
 
 let _restart_language_server =
-  command "superbol.server.restart" @@ `Instance
+  command "superbol.server.restart" @@ Instance
     begin fun instance ~args:_ ->
-      let (_ : unit Promise.t) =
+      let _: unit Promise.t =
         Superbol_instance.start_language_server instance
-      in ()
+      in
+      ()
     end
 
 let _write_project_config =
-  command "superbol.write.project.config" @@ `Text
+  command "superbol.write.project.config" @@ Text
     begin fun instance ~textEditor ~edit:_ ~args:_ ->
-      match Superbol_instance.client instance with
-      | None ->                                      (* ignore; TODO; message? *)
-          ()
-      | Some client ->
-          let document = TextEditor.document textEditor in
-          let uri = TextDocument.uri document in
-          let (_ : _ Promise.t) =
-            Vscode_languageclient.LanguageClient.sendRequest client ()
-              ~meth:"superbol/writeProjectConfiguration"
-              ~data:(Jsonoo.Encode.(object_ [
-                  "uri", string @@ Uri.toString uri ();
-                ]))
-          in ()
+      let _: unit Promise.t =
+        Superbol_instance.write_project_config ~text_editor:textEditor instance
+      in ()
     end
 
 let register extension instance { id; handler } =
   match handler with
-  | `Basic callback ->
-      ExtensionContext.subscribe extension
-        ~disposable:(Commands.registerCommand ~command:id ~callback)
-  | `Instance callback ->
+  | Instance callback ->
       let callback = callback instance in
       ExtensionContext.subscribe extension
         ~disposable:(Commands.registerCommand ~command:id ~callback)
-  | `Text callback ->
+  | Text callback ->
       let callback = callback instance in
       ExtensionContext.subscribe extension
         ~disposable:(Commands.registerTextEditorCommand ~command:id ~callback)

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -24,6 +24,8 @@ let make ~bundled_superbol () = {
   language_client = None
 }
 
+let client { language_client; _ } = language_client
+
 let stop_language_server t =
   match t.language_client with
   | None -> Promise.return ()

--- a/src/vscode/superbol-vscode-platform/superbol_instance.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.ml
@@ -18,6 +18,7 @@ type t = {
   mutable bundled_superbol : string;
   mutable language_client: LanguageClient.t option
 }
+type client = LanguageClient.t
 
 let make ~bundled_superbol () = {
   bundled_superbol;
@@ -53,3 +54,44 @@ let start_language_server t =
   in
   let+ () = LanguageClient.start client in
   t.language_client <- Some client
+
+
+let current_document_uri ?text_editor () =
+  match
+    match text_editor with None -> Vscode.Window.activeTextEditor () | e -> e
+  with
+  | None -> None
+  | Some e -> Some (Vscode.TextDocument.uri @@ Vscode.TextEditor.document e)
+
+
+let write_project_config ?text_editor instance =
+  match client instance, current_document_uri ?text_editor () with
+  | None, _ | _, None ->                             (* ignore; TODO; message? *)
+      Promise.return ()
+  | Some client, Some uri ->
+      Vscode_languageclient.LanguageClient.sendRequest client ()
+        ~meth:"superbol/writeProjectConfiguration"
+        ~data:(Jsonoo.Encode.(object_ [
+            "uri", string @@ Vscode.Uri.toString uri ();
+          ])) |>
+      Promise.(then_ ~fulfilled:(fun _ -> return ()))
+
+
+let get_project_config instance =
+  let open Promise.Syntax in
+  match client instance, Vscode.Window.activeTextEditor () with
+  | None, _ ->
+      Promise.return @@ Error "SuperBOL client is not running"
+  | _, None ->
+      Promise.return @@ Error "Found no active text editor"
+  | Some client, Some textEditor ->
+      let document = Vscode.TextEditor.document textEditor in
+      let uri = Vscode.TextDocument.uri document in
+      let* assoc =
+        Vscode_languageclient.LanguageClient.sendRequest client ()
+          ~meth:"superbol/getProjectConfiguration"
+          ~data:(Jsonoo.Encode.(object_ [
+              "uri", string @@ Vscode.Uri.toString uri ();
+            ]))
+      in
+      Promise.Result.return @@ Jsonoo.Decode.(dict id) assoc

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -15,7 +15,7 @@
 type t
 
 val make : bundled_superbol:string -> unit -> t
+val client: t -> Vscode_languageclient.LanguageClient.t option
 
 val stop_language_server : t -> unit Promise.t
-
 val start_language_server : t -> unit Promise.t

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -13,9 +13,18 @@
 (**************************************************************************)
 
 type t
+type client = Vscode_languageclient.LanguageClient.t
 
 val make : bundled_superbol:string -> unit -> t
-val client: t -> Vscode_languageclient.LanguageClient.t option
 
 val stop_language_server : t -> unit Promise.t
 val start_language_server : t -> unit Promise.t
+
+val write_project_config
+  : ?text_editor: Vscode.TextEditor.t
+  -> t
+  -> unit Promise.t
+
+val get_project_config
+  : t
+  -> ((string, Jsonoo.t) Hashtbl.t, string) result Promise.t

--- a/src/vscode/superbol-vscode-platform/superbol_tasks.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_tasks.ml
@@ -48,59 +48,83 @@ let string_arg ?(allow_empty = false) ~mk s args =
 (*   | Some s -> string_arg ([%js.to: string] s) ?allow_empty ~mk args *)
 (*   | None -> args *)
 
-let config_string key =
-  string_arg (Superbol_workspace.string key)
+let config_string key ~config =
+  string_arg @@
+  try Jsonoo.Decode.string @@ Hashtbl.find config key
+  with Not_found -> Superbol_workspace.string key
 
 let attr_strings key ~append ~attributes args =
   match List.assoc_opt key attributes with
   | Some l -> append ([%js.to: string list] l) args
   | None -> args
 
-let config_strings key ~append args =
-  append (Superbol_workspace.string_list key) args
+(* let config_strings key ~config:_ ~append args = *)
+(*   append (Superbol_workspace.string_list key) args *)
 
-let make_args ~attributes =
-  ["-x"; "${relativeFile}"] |>
-  config_strings "cobol.copybooks"
-    ~append:(fun l args -> List.flatten (List.map (fun l -> ["-I"; l]) l) @ args) |>
-  config_string "cobol.dialect"
-    ~mk:(function "gnucobol" -> "-std=default" | s -> "-std=" ^ s) |>
-  config_string "cobol.source-format"
-    ~mk:((^) "-fformat=") |>
-  attr_bool_flag "for-debug" ~attributes
-    ~ok:(fun args -> "-fsource-location" :: "-ftraceall" ::
-                     "-g" ::
-                     "-Q" :: "--coverage" ::
-                     "-A" :: "--coverage" :: args) |>
-  attr_strings "extra-args" ~attributes
-    ~append:(fun args' args -> args @ args') |>
-  List.map (fun elt -> `String elt)
+type copybook_path =
+  {
+    dir: string;
+    file_relative: bool;
+  }
 
-let cobc_execution ~attributes =
+let copybook_path_of_jsonoo: Jsonoo.t -> copybook_path = fun j ->
+  Jsonoo.Decode.{
+    dir = field "dir" string j;
+    file_relative = (try_default false @@ field "file-relative" bool) j;
+  }
+
+let config_copybook_paths key ~config ~append =
+  append @@
+  try
+    Jsonoo.Decode.(list copybook_path_of_jsonoo) @@
+    try Hashtbl.find config key
+    with Not_found -> Jsonoo.t_of_js (Superbol_workspace.any key)
+  with Jsonoo.Decode_error _ ->
+    (* Warning: silenced decode errors for now *)
+    []
+
+let cobc_execution ?config attributes =
+  let config = match config with Some t -> t | None -> Hashtbl.create 0 in
   let cobc =
-    match List.assoc_opt "cobc-path" attributes with
-    | Some exe ->
-        [%js.to: string] exe
-    | None ->
-        match Superbol_workspace.cobc_exe () with    (* fallback to WS config *)
-        | None -> "cobc"
-        | Some s -> s
+    try [%js.to: string] @@ List.assoc "cobc-path" attributes
+    with Not_found ->                                 (* fallback to WS config *)
+      Option.value (Superbol_workspace.cobc_exe ()) ~default:"cobc"
+  in
+  let args =
+    ["-x"; "${relativeFile}"] |>
+    config_copybook_paths "cobol.copybooks" ~config
+      ~append:begin fun l args ->
+        List.flatten @@
+        List.map begin fun { dir; file_relative } ->
+          ["-I";
+           (* Note: assumes `cobc` is called from the root folder of the
+              project. *)
+           if file_relative
+           then "${relativeFileDirname}${pathSeparator}"^dir
+           else dir]
+        end l |>
+        List.append args
+      end |>
+    config_string "cobol.dialect" ~config
+      ~mk:(function "gnucobol" -> "-std=default" | s -> "-std=" ^ s) |>
+    config_string "cobol.source-format" ~config
+      ~mk:((^) "-fformat=") |>
+    attr_bool_flag "for-debug" ~attributes
+      ~ok:(fun args -> "-fsource-location" :: "-ftraceall" ::
+                       "-g" ::
+                       "-Q" :: "--coverage" ::
+                       "-A" :: "--coverage" :: args) |>
+    attr_strings "extra-args" ~attributes
+      ~append:(fun args' args -> args @ args')
   in
   `ShellExecution (ShellExecution.makeCommandArgs ()
                      ~command:(`String cobc)
-                     ~args:(make_args ~attributes))
+                     ~args:(List.map (fun elt -> `String elt) args))
 
-let cobc_build_task ?task name ~attributes =
-  let definition = match task with
-    | None -> TaskDefinition.create () ~type_ ~attributes
-    | Some def -> Task.definition def
-  in
-  Task.make ()
-    ~definition
-    ~scope:TaskScope.Workspace
-    ~name
-    ~source:(Option.fold ~none:"SuperBOL" ~some:Task.source task)
-    ~execution:(cobc_execution ~attributes)
+let make_default_cobc_task =
+  Task.make
+    ~source:"SuperBOL"
+    ~scope:Workspace
     ~problemMatchers:[
       "$gnucobol";
       "$gnucobol-warning";
@@ -108,49 +132,72 @@ let cobc_build_task ?task name ~attributes =
       "$gnucobol-note";
     ]
 
-(* --- *)
+let cobc_build_task ~task ?config attributes =
+  Promise.Option.return @@
+  make_default_cobc_task ()
+    ~name:(Task.name task)
+    ~definition:(Task.definition task)
+    ~execution:(cobc_execution ?config attributes)
 
-let provide_tasks ~token:_ =
-  let attributes =
-    List.map (fun (a, C (_, f, d)) -> a, f d) (attributes_spec ~debug:false)
-  and attributes_for_debug =
-    List.map (fun (a, C (_, f, d)) -> a, f d) (attributes_spec ~debug:true)
-  in
-  `Value (Some [
-      cobc_build_task "build"         ~attributes:attributes;
-      cobc_build_task "build (debug)" ~attributes:attributes_for_debug;
-    ])
+let define_cobc_build_task ?config ~debug name =
+  let map_attributes = List.map (fun (a, C (_, f, d)) -> a, f d) in
+  let attributes = map_attributes @@ attributes_spec ~debug in
+  make_default_cobc_task ()
+    ~name
+    ~definition:(TaskDefinition.create () ~type_ ~attributes)
+    ~execution:(cobc_execution ?config attributes)
+
+let provide_tasks instance ~token:_ =
+  let open Promise.Syntax in
+  `Promise begin
+    let* config = Superbol_instance.get_project_config instance in
+    let config = match config with
+      | Error _ -> Hashtbl.create 0
+      | Ok config -> config
+    in
+    Promise.Option.return [
+      define_cobc_build_task "build"         ~config ~debug:false;
+      define_cobc_build_task "build (debug)" ~config ~debug:true;
+    ]
+  end
 
 let resolve_task =
-  let resolve_cnt =
-    let resolve = ref 0 in
-    fun () ->
-      incr resolve;
-      !resolve
+  let oc =
+    Window.createOutputChannel
+      ~name:("SuperBOL Task Resolution")
   in
-  fun ~task ~token:_ ->
-    let oc =
-      Window.createOutputChannel
-        ~name:("Resolve" ^ string_of_int (resolve_cnt ()))
-    in
-    OutputChannel.appendLine oc ~value:"Starting resolve";
-    let definition = Task.definition task in
-    OutputChannel.appendLine oc ~value:"Got definition";
-    let attributes =
-      List.filter_map begin fun (a, C (f, t, _)) ->
-        match f (TaskDefinition.get_attribute definition a) with
-        | Some x -> Some (a, t x)
-        | _ | exception _ -> None
-      end (attributes_spec ~debug:false)
-    in
-    OutputChannel.appendLine oc ~value:"Got attributes";
-    let task = cobc_build_task ~task ~attributes (Task.name task) in
-    OutputChannel.appendLine oc ~value:"Task made";
-    `Value (Some task)
+  let open Promise.Syntax in
+  fun instance ~task ~token:_ ->
+    `Promise begin
+      OutputChannel.appendLine oc ~value:"Starting new resolution.";
+      let definition = Task.definition task in
+      let attributes =
+        List.filter_map begin fun (a, C (f, t, _)) ->
+          match f (TaskDefinition.get_attribute definition a) with
+          | Some x -> Some (a, t x)
+          | _ | exception _ -> None
+        end (attributes_spec ~debug:false)
+      in
+      let* config = Superbol_instance.get_project_config instance in
+      match config with
+      | Error value ->
+          OutputChannel.appendLine oc ~value;
+          OutputChannel.appendLine oc ~value:"Aborting task resolution.";
+          Promise.return None
+      | Ok config ->
+          OutputChannel.appendLine oc ~value:"Configuration: ";
+          Hashtbl.iter begin fun k v ->
+            OutputChannel.appendLine oc
+              ~value:(Printf.sprintf "- %s: %s" k (Jsonoo.stringify v))
+          end config;
+          let task = cobc_build_task ~task ~config attributes in
+          OutputChannel.appendLine oc ~value:"Resolution done.";
+          task
+    end
 
 (* --- *)
 
-let provider =
+let provider instance =
   TaskProvider.Default.create
-    ~provideTasks:provide_tasks
-    ~resolveTask:resolve_task
+    ~provideTasks:(provide_tasks instance)
+    ~resolveTask:(resolve_task instance)

--- a/src/vscode/superbol-vscode-platform/superbol_tasks.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_tasks.mli
@@ -14,4 +14,4 @@
 
 val type_: string
 
-val provider: Vscode.Task.t Vscode.TaskProvider.t
+val provider: Superbol_instance.t -> Vscode.Task.t Vscode.TaskProvider.t

--- a/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
@@ -44,46 +44,6 @@ let indentRange
 *)
   `Value promise
 
-let with_seconds_countdown ?timeout ~f seconds =
-  let timeout = match timeout with Some t -> t | None -> ref None in
-  let rec step seconds () =
-    f seconds;
-    if seconds > 0
-    then timeout := Option.some @@ Node.setTimeout (step @@ seconds - 1) 1000
-  in
-  step seconds ()
-
-let register_config_listener extension instance =
-  let timeout = ref None in
-  Vscode.Workspace.onDidChangeConfiguration ()
-    ~listener:begin fun event ->
-      match Superbol_instance.client instance with
-      | Some client
-        when Vscode.ConfigurationChangeEvent.affectsConfiguration event ()
-            ~section:"superbol" ->
-          Option.iter Node.clearTimeout !timeout;
-          with_seconds_countdown 3 ~timeout
-            ~f:(fun s ->
-                if s > 0 then
-                  let text = Printf.sprintf "SuperBOL: applying changes in %us…" s in
-                  Vscode.ExtensionContext.subscribe extension
-                    ~disposable:(Vscode.Window.setStatusBarMessage ()
-                                   ~text
-                                   ~hide:(`AfterTimeout 1200))
-                else begin
-                  timeout := None;
-                  let n =
-                    Vscode_languageclient.DidChangeConfiguration.t_to_js @@
-                    Vscode_languageclient.DidChangeConfiguration.create ()
-                      ~settings:Ojs.null
-                  in
-                  Vscode_languageclient.LanguageClient.sendNotification client
-                    "workspace/didChangeConfiguration" n
-                end)
-      | Some _ | None ->
-          ()
-    end
-
 (* Helpers to find the bundled superbol executable *)
 let rec find_existing = function
   | [] -> raise Not_found
@@ -156,9 +116,6 @@ let activate (extension : Vscode.ExtensionContext.t) =
 
   let instance = Superbol_instance.make ~bundled_superbol () in
   current_instance := Some instance;
-
-  Vscode.ExtensionContext.subscribe extension
-    ~disposable:(register_config_listener extension instance);
 
   Superbol_commands.register_all extension instance;
   Superbol_instance.start_language_server instance

--- a/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_vscode_platform.ml
@@ -95,14 +95,6 @@ let activate (extension : Vscode.ExtensionContext.t) =
 
   Vscode.ExtensionContext.subscribe extension ~disposable:debug;
 
-  let task =
-    Vscode.Tasks.registerTaskProvider
-      ~type_:Superbol_tasks.type_
-      ~provider:Superbol_tasks.provider
-  in
-
-  Vscode.ExtensionContext.subscribe extension ~disposable:task;
-
   let bundled_superbol =
     try
       find_superbol
@@ -116,6 +108,13 @@ let activate (extension : Vscode.ExtensionContext.t) =
 
   let instance = Superbol_instance.make ~bundled_superbol () in
   current_instance := Some instance;
+
+  let task =
+    Vscode.Tasks.registerTaskProvider
+      ~type_:Superbol_tasks.type_
+      ~provider:(Superbol_tasks.provider instance)
+  in
+  Vscode.ExtensionContext.subscribe extension ~disposable:task;
 
   Superbol_commands.register_all extension instance;
   Superbol_instance.start_language_server instance

--- a/src/vscode/superbol-vscode-platform/superbol_workspace.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_workspace.ml
@@ -52,3 +52,16 @@ let string_list ?scope key =
   | None -> []
   | Some o when Ojs.is_null o -> []
   | Some s -> Ojs.(list_of_js string_of_js) s      (* TODO: how may this fail? *)
+
+let any ?scope key =
+  let config = WS.getConfiguration ?scope ~section () in
+  match WS_CONF.get ~section:key config with
+  | None -> Ojs.null
+  | Some s -> s
+
+let any_list ?scope key =
+  let config = WS.getConfiguration ?scope ~section () in
+  match WS_CONF.get ~section:key config with
+  | None -> []
+  | Some o when Ojs.is_null o -> []                               (* required? *)
+  | Some s -> [%js.to: Ojs.t list] s

--- a/src/vscode/vscode-js-stubs/vscode.ml
+++ b/src/vscode/vscode-js-stubs/vscode.ml
@@ -976,6 +976,7 @@ module Event = struct
     -> ?disposables:Disposable.t list
     -> unit
     -> Disposable.t
+  [@@js]
 
   module Make (T : Js.T) = struct
     type t =
@@ -2241,6 +2242,19 @@ module FileSystemWatcher = struct
   include [%js: val onDidChange : t -> OnDidChange.t [@@js.get]]
 end
 
+module ConfigurationChangeEvent = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+      val affectsConfiguration
+        : t
+        -> section:string
+        -> ?scope:ConfigurationScope.t
+        -> unit
+        -> bool [@@js.call]]
+end
+
 module Workspace = struct
   module OnDidChangeWorkspaceFolders = Event.Make (WorkspaceFolder)
   module OnDidOpenTextDocument = Event.Make (TextDocument)
@@ -2284,6 +2298,9 @@ module Workspace = struct
 
     val textDocuments : unit -> TextDocument.t list
       [@@js.get "vscode.workspace.textDocuments"]
+
+    val onDidChangeConfiguration : ConfigurationChangeEvent.t Event.t
+      [@@js.global "vscode.workspace.onDidChangeConfiguration"]
 
     val onDidChangeWorkspaceFolders : OnDidChangeWorkspaceFolders.t
       [@@js.global "vscode.workspace.onDidChangeWorkspaceFolders"]

--- a/src/vscode/vscode-js-stubs/vscode.mli
+++ b/src/vscode/vscode-js-stubs/vscode.mli
@@ -1744,6 +1744,17 @@ module FileSystemWatcher : sig
   val onDidChange : t -> Uri.t Event.t
 end
 
+module ConfigurationChangeEvent : sig
+  include Ojs.T
+
+  val affectsConfiguration
+    : t
+    -> section:string
+    -> ?scope:ConfigurationScope.t
+    -> unit
+    -> bool
+end
+
 module Workspace : sig
   val workspaceFolders : unit -> WorkspaceFolder.t list
 
@@ -1764,6 +1775,8 @@ module Workspace : sig
   val onDidChangeWorkspaceFolders : WorkspaceFolder.t Event.t
 
   val onDidChangeTextDocument : TextDocumentChangeEvent.t Event.t
+
+  val onDidChangeConfiguration : ConfigurationChangeEvent.t Event.t
 
   val asRelativePath :
        pathOrUri:([ `String of string | `Uri of Uri.t ][@js.union])

--- a/src/vscode/vscode-languageclient-js-stubs/vscode_languageclient.ml
+++ b/src/vscode/vscode-languageclient-js-stubs/vscode_languageclient.ml
@@ -189,6 +189,12 @@ module StaticFeature = struct
       [@@js.builder]]
 end
 
+module DidChangeConfiguration = struct
+  include Interface.Make ()
+
+  include [%js: val create : settings:Ojs.t -> unit -> t [@@js.builder]]
+end
+
 module LanguageClient = struct
   include Class.Make ()
 
@@ -221,5 +227,7 @@ module LanguageClient = struct
       -> Jsonoo.t Promise.t
       [@@js.call]
 
-    val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]]
+    val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]
+
+    val sendNotification : t -> string -> Ojs.t -> unit [@@js.call]]
 end

--- a/src/vscode/vscode-languageclient-js-stubs/vscode_languageclient.mli
+++ b/src/vscode/vscode-languageclient-js-stubs/vscode_languageclient.mli
@@ -160,6 +160,12 @@ module StaticFeature : sig
     -> t
 end
 
+module DidChangeConfiguration : sig
+  include Ojs.T
+
+  val create : settings:Ojs.t -> unit -> t
+end
+
 module LanguageClient : sig
   include Js.T
 
@@ -190,4 +196,6 @@ module LanguageClient : sig
     -> Jsonoo.t Promise.t
 
   val registerFeature : t -> feature:StaticFeature.t -> unit
+
+  val sendNotification : t -> string -> Ojs.t -> unit
 end

--- a/test/lsp/lsp_testing.ml
+++ b/test/lsp/lsp_testing.ml
@@ -45,10 +45,13 @@ let init_temp_project ?(toml = "") () =
   EzFile.write_file toml_file toml;
   projdir
 
-let make_server () =
-  LSP.Server.init ~params:{ config = { project_layout = layout; cache_config };
+let make_server ?(with_semantic_tokens = false) () =
+  LSP.Server.init ~params:{ config = { project_layout = layout;
+                                       cache_config;
+                                       enable_client_configs = false };
                             root_uri = None;
-                            workspace_folders = [] }
+                            workspace_folders = [];
+                            with_semantic_tokens }
 
 let add_cobol_doc server ?copybook ~projdir filename text =
   let path = projdir // filename in

--- a/test/lsp/lsp_testing.ml
+++ b/test/lsp/lsp_testing.ml
@@ -51,7 +51,9 @@ let make_server ?(with_semantic_tokens = false) () =
                                        enable_client_configs = false };
                             root_uri = None;
                             workspace_folders = [];
-                            with_semantic_tokens }
+                            with_semantic_tokens;
+                            with_client_file_watcher = false;
+                            with_client_config_watcher = false }
 
 let add_cobol_doc server ?copybook ~projdir filename text =
   let path = projdir // filename in

--- a/test/lsp/lsp_testing.ml
+++ b/test/lsp/lsp_testing.ml
@@ -46,7 +46,9 @@ let init_temp_project ?(toml = "") () =
   projdir
 
 let make_server () =
-  LSP.Server.init ~config:{ project_layout = layout; cache_config }
+  LSP.Server.init ~params:{ config = { project_layout = layout; cache_config };
+                            root_uri = None;
+                            workspace_folders = [] }
 
 let add_cobol_doc server ?copybook ~projdir filename text =
   let path = projdir // filename in


### PR DESCRIPTION
Included changes mostly include:
- Early loading of project caches upon startup (when the LSP client/VS Code provides a list of workspace directories);
- Use of VS Code's settings to configure projects in the LSP server;
- A new command to save the current VS Code configuration to a `superbol.toml`, for each project directory opened in a workspace. Once this file exists, changes to VS Code's settings are ignored (but trigger a warning to the user).