### PR TITLE
Bugfix: upon rewind, clear source overlay locations cache earlier

### DIFF
--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -544,7 +544,7 @@ let rec rewind_n_parse
       let pp = ps.preproc.pp in
       let pp = pp_rewind ~new_position:event.preproc_position pp in
       let ps = { ps with preproc = { ps.preproc with pp } } in
-      Option.iter (fun at -> Overlay_manager.restart ~at ()) ps.prev_limit;
+      Overlay_manager.restart ();
       let ps, tokens = produce_tokens ps in
       { rwps with stage = Trans (ps, tokens, env); store }
     with Not_found ->                     (* rewinding before first checkpoint *)

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -544,8 +544,8 @@ let rec rewind_n_parse
       let pp = ps.preproc.pp in
       let pp = pp_rewind ~new_position:event.preproc_position pp in
       let ps = { ps with preproc = { ps.preproc with pp } } in
-      let ps, tokens = produce_tokens ps in
       Option.iter Overlay_manager.restart_at ps.prev_limit;
+      let ps, tokens = produce_tokens ps in
       { rwps with stage = Trans (ps, tokens, env); store }
     with Not_found ->                     (* rewinding before first checkpoint *)
       let pp = pp_rewind rwps.init.preproc.pp in

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -544,7 +544,7 @@ let rec rewind_n_parse
       let pp = ps.preproc.pp in
       let pp = pp_rewind ~new_position:event.preproc_position pp in
       let ps = { ps with preproc = { ps.preproc with pp } } in
-      Option.iter Overlay_manager.restart_at ps.prev_limit;
+      Option.iter (fun at -> Overlay_manager.restart ~at ()) ps.prev_limit;
       let ps, tokens = produce_tokens ps in
       { rwps with stage = Trans (ps, tokens, env); store }
     with Not_found ->                     (* rewinding before first checkpoint *)

--- a/src/lsp/cobol_preproc/src_overlay.ml
+++ b/src/lsp/cobol_preproc/src_overlay.ml
@@ -25,7 +25,7 @@ module type MANAGER = sig
   val link_limits: limit -> limit -> unit
   val join_limits: limit * limit -> srcloc
   val dummy_limit: limit
-  val restart_at: limit -> unit
+  val restart: ?at:limit -> unit -> unit
 end
 
 (** Overlay limits (internal) *)
@@ -162,7 +162,7 @@ let join_limits: manager -> limit * limit -> srcloc = fun ctx (s, e) ->
   with Not_found ->
     join_failure (s, e)
 
-let restart_at ctx _limit =
+let restart ?at:_ ctx =
   Links.clear ctx.cache
 
 module New_manager (Id: sig val name: string end) () : MANAGER = struct
@@ -172,5 +172,5 @@ module New_manager (Id: sig val name: string end) () : MANAGER = struct
   let link_limits = link_limits ctx
   let join_limits = join_limits ctx
   let dummy_limit = Lexing.dummy_pos
-  let restart_at = restart_at ctx
+  let restart ?at () = restart ?at ctx
 end

--- a/src/lsp/cobol_preproc/src_overlay.ml
+++ b/src/lsp/cobol_preproc/src_overlay.ml
@@ -91,8 +91,9 @@ let limits: manager -> srcloc -> limit * limit = fun ctx loc ->
     | Some lexloc -> lexloc
     | _ -> Limit.make_virtual (), Limit.make_virtual ()
   in
-  Links.replace ctx.right_of s (loc, e);  (* Replace to deal with duplicates. *)
-  Links.remove ctx.cache s;               (* Manually remove from cache. *)
+  Links.replace ctx.right_of s (loc, e); (* Replace to deal with duplicates. *)
+  Links.remove ctx.over_right_gap s;     (* `s' could have been a right-limit *)
+  Links.remove ctx.cache s;              (* Manually remove from cache. *)
   s, e
 
 (** Links token limits *)

--- a/src/lsp/cobol_preproc/src_overlay.ml
+++ b/src/lsp/cobol_preproc/src_overlay.ml
@@ -25,7 +25,7 @@ module type MANAGER = sig
   val link_limits: limit -> limit -> unit
   val join_limits: limit * limit -> srcloc
   val dummy_limit: limit
-  val restart: ?at:limit -> unit -> unit
+  val restart: unit -> unit
 end
 
 (** Overlay limits (internal) *)
@@ -165,10 +165,10 @@ let join_limits: manager -> limit * limit -> srcloc = fun ctx (s, e) ->
   with Not_found ->
     join_failure (s, e)
 
-let restart ?at:_ ctx =
+let restart ctx =
   (* CHECKME: recursively traversing and emptying `right_of` and
-     `over_right_gap` from `at` may allow us to remove one or two calls ito
-     `Links.remove` in `limits` above. *)
+     `over_right_gap` from a given limit may allow us to remove one or two calls
+     ito `Links.remove` in `limits` above. *)
   Links.clear ctx.cache
 
 module New_manager (Id: sig val name: string end) () : MANAGER = struct
@@ -178,5 +178,5 @@ module New_manager (Id: sig val name: string end) () : MANAGER = struct
   let link_limits = link_limits ctx
   let join_limits = join_limits ctx
   let dummy_limit = Lexing.dummy_pos
-  let restart ?at () = restart ?at ctx
+  let restart () = restart ctx
 end

--- a/src/lsp/cobol_preproc/src_overlay.mli
+++ b/src/lsp/cobol_preproc/src_overlay.mli
@@ -29,7 +29,12 @@ module type MANAGER = sig
   val id: string
 
   (** [limits loc] creates and returns the left- and right-limit to the given
-      location. *)
+      location.
+
+      Note: if [loc] overlaps with locations that have already been fed to this
+      function, then {!restart_at} must first be called with a limit that is
+      strictly at the left of [loc] ({i i.e,} that comes earlier in the stream
+      of tokens). *)
   val limits: Cobol_common.Srcloc.srcloc -> limit * limit
 
   (** [link_limits left right] links the right limit of a token [t] to the left

--- a/src/lsp/cobol_preproc/src_overlay.mli
+++ b/src/lsp/cobol_preproc/src_overlay.mli
@@ -32,7 +32,7 @@ module type MANAGER = sig
       location.
 
       Note: if [loc] overlaps with locations that have already been fed to this
-      function, then {!restart_at} must first be called with a limit that is
+      function, then {!restart} must first be called with a limit that is
       strictly at the left of [loc] ({i i.e,} that comes earlier in the stream
       of tokens). *)
   val limits: Cobol_common.Srcloc.srcloc -> limit * limit
@@ -51,10 +51,11 @@ module type MANAGER = sig
       but not given to {!link_limits}. *)
   val dummy_limit: limit
 
-  (** [restart_at limit] instructs the manager that limits on the right of (but
-      not including) [limit] are now outdated and should not be relied upon.  At
+  (** [restart ~at ()] instructs the manager that limits on the right of (but
+      not including) [at] are now outdated and should not be relied upon.  If
+      [at] is not provided, a restart from the left-most limit is assumed.  At
       the moment this just clears an internal cache. *)
-  val restart_at: limit -> unit
+  val restart: ?at:limit -> unit -> unit
 
 end
 

--- a/src/lsp/cobol_preproc/src_overlay.mli
+++ b/src/lsp/cobol_preproc/src_overlay.mli
@@ -32,9 +32,9 @@ module type MANAGER = sig
       location.
 
       Note: if [loc] overlaps with locations that have already been fed to this
-      function, then {!restart} must first be called with a limit that is
-      strictly at the left of [loc] ({i i.e,} that comes earlier in the stream
-      of tokens). *)
+      function, then {!restart} must first be called, possibly with a limit that
+      is strictly at the left of [loc] ({i i.e,} that comes earlier in the
+      stream of tokens). *)
   val limits: Cobol_common.Srcloc.srcloc -> limit * limit
 
   (** [link_limits left right] links the right limit of a token [t] to the left
@@ -53,8 +53,10 @@ module type MANAGER = sig
 
   (** [restart ~at ()] instructs the manager that limits on the right of (but
       not including) [at] are now outdated and should not be relied upon.  If
-      [at] is not provided, a restart from the left-most limit is assumed.  At
-      the moment this just clears an internal cache. *)
+      [at] is not provided, a restart from the left-most limit is assumed.
+
+      At the moment, [at] is unused, and this function just clears an internal
+      cache. *)
   val restart: ?at:limit -> unit -> unit
 
 end

--- a/src/lsp/cobol_preproc/src_overlay.mli
+++ b/src/lsp/cobol_preproc/src_overlay.mli
@@ -32,9 +32,7 @@ module type MANAGER = sig
       location.
 
       Note: if [loc] overlaps with locations that have already been fed to this
-      function, then {!restart} must first be called, possibly with a limit that
-      is strictly at the left of [loc] ({i i.e,} that comes earlier in the
-      stream of tokens). *)
+      function, then {!restart} must first be called. *)
   val limits: Cobol_common.Srcloc.srcloc -> limit * limit
 
   (** [link_limits left right] links the right limit of a token [t] to the left
@@ -51,13 +49,9 @@ module type MANAGER = sig
       but not given to {!link_limits}. *)
   val dummy_limit: limit
 
-  (** [restart ~at ()] instructs the manager that limits on the right of (but
-      not including) [at] are now outdated and should not be relied upon.  If
-      [at] is not provided, a restart from the left-most limit is assumed.
-
-      At the moment, [at] is unused, and this function just clears an internal
-      cache. *)
-  val restart: ?at:limit -> unit -> unit
+  (** [restart ()] instructs the manager that (a subset of) the limits
+      previously created are now outdated and should not be relied upon. *)
+  val restart: unit -> unit
 
 end
 

--- a/src/lsp/cobol_preproc/text_supplier.ml
+++ b/src/lsp/cobol_preproc/text_supplier.ml
@@ -99,6 +99,7 @@ let cdtoks_of_text_supplier text =
     ~endlimit:(fun () -> Lexing.dummy_pos)
 
 let pptoks_of_text_supplier (module Om: Src_overlay.MANAGER) text =
+  Om.restart ();
   let prev_limit = ref None in
   ondemand_list_supplier ~eoi:Preproc_tokens.EOL ~pp:pptoks_of_chstr text
     ~decompose:begin fun y ->


### PR DESCRIPTION
This avoids a potential infinite loop in cache lookup by the source overlay manager. Before this change, new tokens and location limits were produced before the cache was cleared, which could led to an infinite loop during lookup in the cache.