### PR TITLE
Make goto-def and find-refs return locations within copybooks

### DIFF
--- a/src/lsp/cobol_lsp/lsp_diagnostics.mli
+++ b/src/lsp/cobol_lsp/lsp_diagnostics.mli
@@ -23,13 +23,15 @@ include module type of TYPES
 type t = diagnostics
 
 val translate_one
-  : rootdir:string
-  -> uri:[< `Force of Lsp.Uri.t | `Main of Lsp.Uri.t ]
+  : ?focus_on_main_doc: bool
+  -> rootdir: string
+  -> uri: Lsp.Uri.t
   -> Cobol_common.Diagnostics.t -> diagnostics
 
 val translate
-  : rootdir:string
-  -> uri:[< `Force of Lsp.Uri.t | `Main of Lsp.Uri.t ]
+  : ?focus_on_main_doc: bool
+  -> rootdir: string
+  -> uri: Lsp.Uri.t
   -> Cobol_common.Diagnostics.Set.t -> diagnostics
 
 val publish

--- a/src/lsp/cobol_lsp/lsp_position.mli
+++ b/src/lsp/cobol_lsp/lsp_position.mli
@@ -56,8 +56,17 @@ type translator =
     location_of: 'x. 'x Cobol_common.Srcloc.with_loc -> Lsp.Types.Location.t;
   }
 
+val location_of_srcloc
+  : ?focus_on_main_doc:bool
+  -> rootdir:string
+  -> uri:Lsp.Types.DocumentUri.t
+  -> Cobol_common.Srcloc.srcloc
+  -> Lsp.Types.Location.t
+
 val loc_translator
-  : Lsp.Types.TextDocumentIdentifier.t
+  : ?focus_on_main_doc:bool
+  -> rootdir:string
+  -> Lsp.Types.TextDocumentIdentifier.t
   -> translator
 
 (* --- *)

--- a/src/lsp/cobol_lsp/lsp_project.ml
+++ b/src/lsp/cobol_lsp/lsp_project.ml
@@ -38,8 +38,9 @@ let show_n_forget_diagnostics ?(force = false) { result = project; diags } =
   if force || diags <> DIAGS.Set.none then
     Lsp_diagnostics.publish @@
     Lsp_diagnostics.translate diags
+      ~focus_on_main_doc: false
       ~rootdir:(Superbol_project.string_of_rootdir project.rootdir)
-      ~uri:(`Main (Lsp.Uri.of_path project.config_filename));
+      ~uri:(Lsp.Uri.of_path project.config_filename);
   project
 
 let on_project_config_error e ~rootdir ~layout =

--- a/src/lsp/cobol_lsp/lsp_request.mli
+++ b/src/lsp/cobol_lsp/lsp_request.mli
@@ -19,17 +19,9 @@ module INTERNAL: sig
     : Lsp_server.t
     -> Lsp.Types.DefinitionParams.t
     -> [> `Location of Lsp.Types.Location.t list ] option
-  val lookup_definition_in_doc
-    : Lsp.Types.DefinitionParams.t
-    -> Lsp_document.checked_doc
-    -> [> `Location of Lsp.Types.Location.t list ] option
   val lookup_references
     : Lsp_server.t
     -> Lsp.Types.ReferenceParams.t
-    -> Lsp.Types.Location.t list option
-  val lookup_references_in_doc
-    : Lsp.Types.ReferenceParams.t
-    -> Lsp_document.checked_doc
     -> Lsp.Types.Location.t list option
   val hover
     : Lsp_server.t

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -75,8 +75,9 @@ let dispatch_diagnostics (Lsp_document.{ project; diags; _ } as doc) registry =
   in
   if URIMap.is_empty indirect4uri then begin
     let all_diags =
-      Lsp_diagnostics.translate diags ~uri:(`Main uri)
+      Lsp_diagnostics.translate diags ~uri
         ~rootdir:(Lsp_project.string_of_rootdir rootdir)
+        ~focus_on_main_doc: false
     in
     (* Note here we may publish diagnostics for non-opened documents.  LSP
        protocol does not seem to forbid that (but some editors just ignore


### PR DESCRIPTION
Before this change, copied definitions and references were localized on the corresponding `COPY` within the main source program.