### PR TITLE
Harden the LSP against copied source locations in pre-processor logs

### DIFF
--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -317,8 +317,11 @@ let handle_hover registry (params: HoverParams.t) =
           false
       | Replacement { matched_loc = loc; _ }
       | FileCopy { copyloc = loc; _ } ->
-          Lsp_position.is_in_lexloc params.position
-            (Cobol_common.Srcloc.lexloc_in ~filename loc)
+          try         (* Some locations in the pre-processor log may not involve
+                         [filename], so we need to catch those cases. *)
+            Lsp_position.is_in_lexloc params.position
+              (Cobol_common.Srcloc.lexloc_in ~filename loc)
+          with Invalid_argument _ -> false
     end (Cobol_preproc.Trace.events pplog)
   in
   let hover_markdown ~loc value =


### PR DESCRIPTION
Hover requests are parameterized with a position in a source file, that essentially describes where the cursor is. To determine what to answer, the LSP searches for a range in the source file that both: (i) contains the given position, and (ii) corresponds to a pre-processing operation. To do so, the LSP scans some sort of log/journal created by the pre-processor, and projects the source location that is associated with `COPY` or replacement entries onto the given file name to obtain a range in the source file. The position is then checked against this range.

The previous implementation relied on the assumption that it is always possible to project a source location against the source filename of the *main* program (which is the one on which we are hovering here). However, while this holds for locations in the parse-tree, this is actually not true for some locations in the pre-processor log. Such an invalid projection raises an `Invalid_argument` exception, and that is what we are guarding against here.

In the diff, the projection operation is the `Srcloc.lexloc_in ~filename`.