### PR TITLE
Fix lookup when `COPY <text-name> IN/OF <relative path>` is used

### DIFF
--- a/src/lsp/cobol_common/copybook.ml
+++ b/src/lsp/cobol_common/copybook.ml
@@ -13,6 +13,8 @@
 
 open Ez_file.V1
 
+type fileloc = [ `Word of string | `Alphanum of string ]
+
 type lookup_info =
   {
     libname: string;
@@ -22,12 +24,23 @@ type lookup_info =
 (** Filename extensions that we should treat as copybooks and not main
     programs. *)
 let copybook_extensions =  (* this must be a subset of {!libfile_extensions}. *)
-  [".CPY"; ".cpy"; ".cbx"]
+  [".CPY"; ".cpy";
+   ".CBX"; ".cbx"]
 
 let libfile_extensions =
-  [".CPY"; ".CBL"; ".COB"; ".cpy"; ".cbl"; ".cob"; ""; ".cbx"]
+  [".CPY"; ".CBL"; ".COB"; ".CBX";
+   ".cpy"; ".cbl"; ".cob"; ".cbx"; ""]
 
-let find_lib ~libpath libname : _ result =
+let find_lib ~libpath ?fromfile ?libname textname : _ result =
+  let libpath = match libname, fromfile with
+    | None, _ ->
+        libpath
+    | Some (`Word d | `Alphanum d), Some file
+      when EzFile.is_relative d ->
+        EzFile.[concat (dirname file) d]
+    | Some (`Word d | `Alphanum d), _ ->
+        [d]
+  in
   let rec try_file base = function
     | [] ->
         Error { libname = base; libpath }
@@ -35,10 +48,10 @@ let find_lib ~libpath libname : _ result =
         try Ok (EzFile.find_in_path libpath (base ^ suff))
         with Not_found -> try_file base tl
   in
-  match libname with
-  | `Alphanum, w ->
+  match textname with
+  | `Alphanum w ->                       (* assume no more filename extension  *)
       try_file w [""]
-  | `Word, w ->
+  | `Word w ->
       match try_file w libfile_extensions with
       | Ok lib -> Ok lib
       | Error _ ->

--- a/src/lsp/cobol_common/copybook.mli
+++ b/src/lsp/cobol_common/copybook.mli
@@ -11,7 +11,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val copybook_extensions: string list
+type fileloc = [ `Word of string | `Alphanum of string ]
 
 type lookup_info =
   {
@@ -19,9 +19,26 @@ type lookup_info =
     libpath: string list;
   }
 
+(* --- *)
+
+val copybook_extensions: string list
+
 val pp_lookup_error: lookup_info Pretty.printer
 
+(** [find_lib ~libpath ?fromfile ?libname txtname] attempts to locate a file
+    containing the copybook [txtname], which is a file named [txtname], possibly
+    appended with an extension from {[".CPY"; ".CBL"; ".COB"; ".CBX"; ".cpy";
+    ".cbl"; ".cob"; ".cbx"]} (considered in order), {e unless} [txtname] is
+    given as an alphanumeric literal ({i e.g, [txtname = `Alphanum filname] ---
+    in which case no extension is assumed).
+
+    If [libname] is not provided, then the file is searched within the
+    directories listed in [libpath] (considered in order).  Otherwise, a single
+    directory [libname] is considered; if [libname] is a relative path, it is
+    interpreted relative to the directory that contains [fromfile]. *)
 val find_lib
   : libpath:string list
-  -> [< `Alphanum | `Word ] * string
+  -> ?fromfile:string
+  -> ?libname:fileloc
+  -> fileloc
   -> (string, lookup_info) result

--- a/src/lsp/cobol_preproc/preproc_directives.ml
+++ b/src/lsp/cobol_preproc/preproc_directives.ml
@@ -37,10 +37,10 @@ and replace_statement =
       }
 and library =
   {
-    libname: fileloc with_loc;
-    cbkname: fileloc with_loc option;
+    txtname: fileloc with_loc;
+    libname: fileloc with_loc option;
   }
-and fileloc = [`Word | `Alphanum] * string
+and fileloc = Cobol_common.Copybook.fileloc
 and replacing =
   | ReplaceExact of
       {

--- a/src/lsp/cobol_preproc/preproc_engine.mli
+++ b/src/lsp/cobol_preproc/preproc_engine.mli
@@ -60,7 +60,7 @@ val lex_lib
   -> source_format: Cobol_config.source_format_spec
   -> libpath:string list
   -> ?ppf:Format.formatter
-  -> [< `Alphanum | `Word ] * string
+  -> Cobol_common.Copybook.fileloc
   -> unit Cobol_common.Diagnostics.with_diags
 
 (** [fold_source_lines ~dialect ~source_format ~skip_compiler_directives_text

--- a/src/lsp/cobol_preproc/preproc_grammar.mly
+++ b/src/lsp/cobol_preproc/preproc_grammar.mly
@@ -55,7 +55,7 @@ let copy_statement_ :=
         diags } }
 
 let copy_lib :=
-  | l = fileloc; c = pf(or_(OF, IN),fileloc)?; { { libname = l; cbkname = c } }
+  | l = fileloc; c = pf(or_(OF, IN),fileloc)?; { { txtname = l; libname = c } }
 
 let copy_suppress_printing :=
   | { false }
@@ -131,8 +131,8 @@ let text_word ==                                    (* text-word with position *
   | ~ = loc(TEXT_WORD); < >
 
 let fileloc :=
-  | t = text_word; { (`Word, ~&t) &@<- t }
-  | a = loc(ALPHANUM); { (`Alphanum, fst ~&a) &@<- a }
+  | t = text_word; { (`Word ~&t) &@<- t }
+  | a = loc(ALPHANUM); { (`Alphanum (fst ~&a)) &@<- a }
 
 (* --- Misc ----------------------------------------------------------------- *)
 

--- a/src/lsp/cobol_preproc/src_input.ml
+++ b/src/lsp/cobol_preproc/src_input.ml
@@ -21,9 +21,11 @@ let string ~filename contents =
 let channel ~filename ic =
   Channel { ic; filename }
 
+(** [from ~filename ~f] feeds [f] with the contents of a file named [filename];
+    uses [stdin] if [filename = ""]. *)
 let from ~filename ~f =
-  if filename = "-"
-  then f (Channel { ic = stdin; filename })          (* filename = "(stdin)"? *)
+  if filename = ""
+  then f (Channel { ic = stdin; filename = "" })
   else let ic = open_in_bin filename in
     try let res = f (Channel { ic; filename }) in close_in ic; res
     with e -> close_in_noerr ic; raise e

--- a/src/lsp/cobol_preproc/src_reader.ml
+++ b/src/lsp/cobol_preproc/src_reader.ml
@@ -26,6 +26,7 @@ type t = Plx: 'k reader -> t                                           [@@unboxe
 
 let diags (Plx (pl, _)) = Src_lexing.diagnostics pl
 let position (Plx (_, lexbuf)) = lexbuf.Lexing.lex_curr_p
+let input_file r = match (position r).pos_fname with "" -> None | s -> Some s
 let source_format (Plx (pl, _)) = Src_format.SF (Src_lexing.source_format pl)
 let rev_comments (Plx (pl, _)) = Src_lexing.rev_comments pl
 let rev_ignored (Plx (pl, _)) = Src_lexing.rev_ignored pl

--- a/src/lsp/cobol_preproc/src_reader.mli
+++ b/src/lsp/cobol_preproc/src_reader.mli
@@ -26,6 +26,7 @@ val from
 
 val diags: t -> Cobol_common.Diagnostics.Set.t
 val position: t -> Lexing.position
+val input_file: t -> string option
 val source_format: t -> Src_format.any
 val rev_comments: t -> Text.comments
 val rev_ignored: t -> lexloc list

--- a/test/output-tests/syn_copy.expected
+++ b/test/output-tests/syn_copy.expected
@@ -7,7 +7,7 @@ syn_copy.at-112-prog.cob:6.7-6.30:
 ----          ^^^^^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `copy.inc' not found in search path (search path: SUB)
+>> Error: Library `copy.inc' not found in search path (search path: ./SUB)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:113:0
 syn_copy.at-113-prog2.cob:6.7-6.30:
@@ -18,7 +18,7 @@ syn_copy.at-113-prog2.cob:6.7-6.30:
 ----          ^^^^^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `copy.inc' not found in search path (search path: SUB)
+>> Error: Library `copy.inc' not found in search path (search path: ./SUB)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:114:0
 syn_copy.at-114-prog3.cob:6.7-6.31:
@@ -29,7 +29,7 @@ syn_copy.at-114-prog3.cob:6.7-6.31:
 ----          ^^^^^^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `copy.inc' not found in search path (search path: sub2)
+>> Error: Library `copy.inc' not found in search path (search path: ./sub2)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:115:0
 syn_copy.at-115-prog4.cob:6.7-6.23:
@@ -51,7 +51,7 @@ syn_copy.at-116-prog5.cob:6.7-6.30:
 ----          ^^^^^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `copy.inc' not found in search path (search path: CBD)
+>> Error: Library `copy.inc' not found in search path (search path: ./CBD)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:163:0
 Fatal: syn_copy.at-163-SUB/prog.cob: No such file or directory
@@ -86,7 +86,7 @@ syn_copy.at-249-prog3.cob:6.7-6.29:
 ----          ^^^^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `sub.inc' not found in search path (search path: SUB)
+>> Error: Library `sub.inc' not found in search path (search path: ./SUB)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:250:0
 syn_copy.at-250-prog4.cob:6.7-6.25:
@@ -97,7 +97,7 @@ syn_copy.at-250-prog4.cob:6.7-6.25:
 ----          ^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `sub' not found in search path (search path: SUB)
+>> Error: Library `sub' not found in search path (search path: ./SUB)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:251:0
 syn_copy.at-251-prog5.cob:6.7-6.26:
@@ -108,7 +108,7 @@ syn_copy.at-251-prog5.cob:6.7-6.26:
 ----          ^^^^^^^^^^^^^^^^^^^
    7          PROCEDURE        DIVISION.
    8              DISPLAY TEST-VAR.
->> Error: Library `sub' not found in search path (search path: ..)
+>> Error: Library `sub' not found in search path (search path: ./..)
 
 Considering: import/gnucobol/tests/testsuite.src/syn_copy.at:252:0
 syn_copy.at-252-prog6.cob:6.7-6.18:

--- a/test/output-tests/used_binaries.expected
+++ b/test/output-tests/used_binaries.expected
@@ -19,7 +19,7 @@ used_binaries.at-254-prog.cob:12.8-12.28:
 ----           ^^^^^^^^^^^^^^^^^^^^
   13           EX.
   14               STOP RUN.
->> Error: Library `PROCE' not found in search path (search path: sub)
+>> Error: Library `PROCE' not found in search path (search path: ./sub)
 
 Considering: import/gnucobol/tests/testsuite.src/used_binaries.at:277:0
 Fatal: used_binaries.at-277-sub/copy/PROC.cpy: No such file or directory


### PR DESCRIPTION
Before these changes, a `COPY something OF "."` interpreted "." w.r.t the current working directory.  Now, the "." is interpreted w.r.t the directory name of the file where the `COPY` statement is found.

This allows the LSP to properly handle one of the NIST-COBOL85 tests, whatever the project directory (from which every relative path is interpreted).