### PR TITLE
Substitute `npx yarn` for plain `yarn`

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -27,6 +27,8 @@ SUPERBOL_LSP = superbol-free-$(TARGET_SPEC)$(DOT_EXE)
 SUPERBOL_LSPs = $(wildcard superbol-free-*-*)
 SUPERBOL_LSP_BUILT = ${DUNE_BUILD_SRCDIR}/lsp/superbol-free/main.exe
 
+YARN = npx --yes yarn 
+
 VSCE_ARGS = --yarn -t $(TARGET_SPEC)
 
 # Emacs lsp-mode source directory (https://github.com/emacs-lsp/lsp-mode):
@@ -68,7 +70,7 @@ build-debug:
 yarn-debug: package.json
 yarn-debug: _out/superbol-vscode-platform-bundle.js	\
 	    _out/superbol-vscode-gdb.js
-	yarn esbuild $(filter %.js, $+) \
+	$(YARN) esbuild $(filter %.js, $+) \
                 --bundle \
                 --external:vscode \
                 --outdir=_dist \
@@ -90,7 +92,7 @@ build-release:
 yarn-release: package.json
 yarn-release: _out/superbol-vscode-platform-bundle.js	\
 	      _out/superbol-vscode-gdb.js
-	yarn esbuild $(filter %.js, $+) \
+	$(YARN) esbuild $(filter %.js, $+) \
                 --bundle \
                 --external:vscode \
                 --outdir=_dist \
@@ -130,7 +132,7 @@ vsix-package:
 #	needs 'make build-debug' or 'make build-release' before
 	rm -f _dist/superbol-free-*-*
 	$(CP) $(SUPERBOL_LSP_BUILT) _dist/$(SUPERBOL_LSP)
-	yarn vsce package $(VSCE_ARGS)		\
+	$(YARN) vsce package $(VSCE_ARGS)		\
 		--no-git-tag-version		\
 		--no-update-package-json	\
 		--out $(TARGET_VSIX) $(VERSION)
@@ -159,10 +161,10 @@ vsix-clean: clean
 # publishing (requires vsce/ovsx login)
 
 deploy-vsce:
-	yarn vsce publish $(VSCE_ARGS) --packagePath $(TARGET_VSIX)
+	$(YARN) vsce publish $(VSCE_ARGS) --packagePath $(TARGET_VSIX)
 
 deploy-ovsx:
-	yarn ovsx publish --yarn
+	$(YARN) ovsx publish --yarn
 
 .PHONY: clean-execs
 clean-execs:
@@ -170,6 +172,11 @@ clean-execs:
 
 distclean: clean-execs vsix-clean
 clean: clean-execs
+
+.PHONY: node-setup
+node-setup:
+	$(YARN) install
+build-deps: node-setup
 
 # ---
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,8 @@ server and the VSCode extension from sources.
 
    [^drom-version]: Current version is 0.9.2~dev3 (commit 63a5770).
 
-3. To build the VSCode extension, you also need to have
-   [node.js](https://nodejs.org/), and install `yarn` via:
-
-   ```bash
-   npm install -g yarn
-   yarn install
-   ```
+3. Install [node.js](https://nodejs.org/) (version >=5.2.0) if it
+   is not already installed.
 
 4. You can then install all remaining dependencies, and compile the
    LSP server along with the VSCode extension:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ server and the VSCode extension from sources.
    [node.js](https://nodejs.org/), and install `yarn` via:
 
    ```bash
-   npm install yarn
+   npm install -g yarn
    yarn install
    ```
 

--- a/sphinx/building-superbol.rst
+++ b/sphinx/building-superbol.rst
@@ -21,13 +21,7 @@ to install a few external dependencies.
    
       opam pin add https://github.com/OCamlPro/drom.git
 
-3. To build the VSCode extension, you also need to have `node.js`_,
-   and install and initialize `yarn` via:
-
-   .. code-block:: shell
-   
-      npm install -g yarn
-      yarn install
+3. Install `node.js`_ (version >=5.2.0) if it is not already installed.
 
 4. You can then install all remaining dependencies, and compile the
    LSP server along with the VSCode extension:

--- a/sphinx/building-superbol.rst
+++ b/sphinx/building-superbol.rst
@@ -26,7 +26,7 @@ to install a few external dependencies.
 
    .. code-block:: shell
    
-      npm install yarn
+      npm install -g yarn
       yarn install
 
 4. You can then install all remaining dependencies, and compile the


### PR DESCRIPTION
The `-g` option in `npm install -g yarn` is necessary in order to be able to use the `yarn install` command.