### PR TITLE
Manifest improvements

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,4 +10,3 @@ _out/
 !CHANGELOG.md
 !LICENSE.md
 !package.json
-!schemas/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,4 +10,4 @@ _out/
 !CHANGELOG.md
 !LICENSE.md
 !package.json
-!astexplorer/dist/index.html
+!schemas/

--- a/package.json
+++ b/package.json
@@ -80,13 +80,15 @@
           "title": "SuperBOL executable",
           "type": "string",
           "default": "",
-          "description": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise. Leave empty to use the bundled `superbol-free`, if available."
+          "description": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise. Leave empty to use the bundled `superbol-free`, if available.",
+          "scope": "machine"
         },
         "superbol.cobc-path": {
           "title": "GnuCOBOL compiler executable",
           "type": "string",
           "default": "cobc",
-          "description": "Path to the GnuCOBOL compiler executable."
+          "description": "Path to the GnuCOBOL compiler executable.",
+          "scope": "machine-overridable"
         },
         "superbol.debugger.display-variable-attributes": {
           "type": "boolean",
@@ -98,13 +100,15 @@
           "title": "GNU debugger executable",
           "type": "string",
           "default": "gdb",
-          "description": "Path to the GNU debugger executable."
+          "description": "Path to the GNU debugger executable.",
+          "scope": "machine-overridable"
         },
         "superbol.debugger.libcob-path": {
           "title": "GnuCOBOL runtime library",
           "type": "string",
           "default": "cobc",
-          "description": "Path to the GnuCOBOL runtime library file."
+          "description": "Path to the GnuCOBOL runtime library file.",
+          "scope": "machine-overridable"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -391,6 +391,9 @@
   "extensionKind": [
     "workspace"
   ],
+  "extensionDependencies": [
+    "tamasfe.even-better-toml"
+  ],
   "name": "SuperBOL",
   "displayName": "SuperBOL Studio OSS",
   "description": "Provides a COBOL mode in VSCode, based on the SuperBOL LSP server for COBOL",

--- a/package.json
+++ b/package.json
@@ -388,6 +388,9 @@
       }
     ]
   },
+  "extensionKind": [
+    "workspace"
+  ],
   "name": "SuperBOL",
   "displayName": "SuperBOL Studio OSS",
   "description": "Provides a COBOL mode in VSCode, based on the SuperBOL LSP server for COBOL",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   },
   "activationEvents": [
     "onLanguage:cobol",
-    "onDebug"
+    "workspaceContains:**/*.[cC]{ob,OB,bl,BL,py,PY,bx,BX}",
+    "workspaceContains:{_superbol,superbol.toml}"
   ],
   "contributes": {
     "breakpoints": [
@@ -281,8 +282,7 @@
           "COBOL"
         ],
         "filenamePatterns": [
-          "*.cbl",
-          "*.cob"
+          "*.[cC]{ob,OB,bl,BL,py,PY,bx,BX}"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -279,6 +279,12 @@
         ]
       }
     ],
+    "tomlValidation": [
+      {
+        "fileMatch": "superbol.toml",
+        "url": "https://raw.githubusercontent.com/OCamlPro/superbol-studio-oss/master/schemas/superbol-schema.json"
+      }
+    ],
     "languages": [
       {
         "id": "cobol",

--- a/schemas/superbol-schema.json
+++ b/schemas/superbol-schema.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://get-superbol.com/superbol-schema.json",
+    "title": "Schema for superbol.toml files",
+    "description": "Configuration file for SuperBOL Studio",
+    "type": "object",
+    "properties": {
+	"cobol": {
+	    "type": "object",
+	    "required": ["dialect", "source-format"],
+	    "properties": {
+		"dialect": {
+		    "description": "Default COBOL dialect; \"default\" is equivalent to \"gnucobol\"",
+		    "enum": [
+			"default",
+			"gnucobol",
+			"cobol85",
+			"cobol2002",
+			"cobol2014",
+			"acu",
+			"acu-strict",
+			"bs2000",
+			"bs2000-strict",
+			"gcos",
+			"gcos-strict",
+			"ibm",
+			"ibm-strict",
+			"mf",
+			"mf-strict",
+			"mvs",
+			"mvs-strict",
+			"realia",
+			"realia-strict",
+			"rm",
+			"rm-strict",
+			"xopen"
+		    ]
+		},
+		"source-format": {
+		    "description": "Source reference format.",
+		    "enum": [
+			"auto",
+			"fixed",
+			"free",
+			"cobol85",
+			"variable",
+			"xopen",
+			"xcard",
+			"crt",
+			"terminal",
+			"cobolx"
+		    ]
+		},
+		"copybooks": {
+		    "type": "array",
+		    "description": "List of copybooks paths",
+		    "items": {
+			"type": "object",
+			"required": ["dir"],
+			"properties": {
+			    "dir": {
+				"description": "Path to copybooks",
+				"type": "string"
+			    },
+			    "file-relative": {
+				"type": "boolean"
+			    }
+			}
+		    }
+		}
+	    }
+	}
+    }
+}

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -404,6 +404,12 @@ let contributes =
         ~title:"Restart Language Server"
         ~category:"SuperBOL"
     ]
+    ~tomlValidation: [
+      Manifest.tomlValidation
+        ~fileMatch:"superbol.toml"
+        (* TODO: change this address to a more permanent one; also, substitute `master` for a version tag *)
+        ~url:"https://raw.githubusercontent.com/OCamlPro/superbol-studio-oss/master/schemas/superbol-schema.json";
+    ]
 
 let manifest =
   Manifest.vscode

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -428,4 +428,8 @@ let manifest =
     ~extensionKind: [
       "workspace";                                 (* <- run on the workspace *)
     ]
+    ~extensionDependencies: [
+      "tamasfe.even-better-toml"; (* <- to edit `superbol.toml`; actually just a
+                                     suggestion *)
+    ]
     ~contributes

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -89,12 +89,13 @@ let package =
       "@types/node", "^20.3.2";
     ]
 
+let cob_extensions_pattern = "[cC]{ob,OB,bl,BL,py,PY,bx,BX}"
 let contributes =
   Manifest.contributes ()
     ~languages: [
       Manifest.language "cobol"
         ~aliases: [ "COBOL" ]
-        ~filenamePatterns: [ "*.cbl"; "*.cob" ]
+        ~filenamePatterns: [ "*." ^ cob_extensions_pattern ]
     ]
     ~debuggers: [
       Manifest.debugger "gdb"
@@ -406,7 +407,12 @@ let manifest =
     ~marketplace
     ~engines: ("^" ^ vscode_engine)
     ~activationEvents: [
-      "onLanguage:cobol";
-      "onDebug";
+      "onLanguage:cobol"; (* Note: optional since VS Code 1.74, as in
+                             `contributes`) *)
+      (* XXX: should we really expect mixed-case file extensions like
+         `prog.coB`? *)
+      "workspaceContains:**/*." ^ cob_extensions_pattern;
+      "workspaceContains:{_superbol,superbol.toml}";
+      (* "onDebug"; *) (* <- not relevant yet *)
     ]
     ~contributes

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -425,4 +425,7 @@ let manifest =
       "workspaceContains:{_superbol,superbol.toml}";
       (* "onDebug"; *) (* <- not relevant yet *)
     ]
+    ~extensionKind: [
+      "workspace";                                 (* <- run on the workspace *)
+    ]
     ~contributes

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -286,6 +286,7 @@ let contributes =
            Manifest.PROPERTY.string "superbol.lsp-path"
              ~title:"SuperBOL executable"
              ~default:""
+             ~scope:"machine"
              ~description:
                "Name of the `superbol-free` executable if available in PATH; may \
                 be an absolute path otherwise. Leave empty to use the bundled \
@@ -294,6 +295,7 @@ let contributes =
            Manifest.PROPERTY.string "superbol.cobc-path"
              ~title:"GnuCOBOL compiler executable"
              ~default:"cobc"
+             ~scope:"machine-overridable"
              ~description:"Path to the GnuCOBOL compiler executable.";
 
            (* Debugger-specific: *)
@@ -309,11 +311,13 @@ let contributes =
            Manifest.PROPERTY.string "superbol.debugger.gdb-path"
              ~title:"GNU debugger executable"
              ~default:"gdb"
+             ~scope:"machine-overridable"
              ~description:"Path to the GNU debugger executable.";
 
            Manifest.PROPERTY.string "superbol.debugger.libcob-path"
              ~title:"GnuCOBOL runtime library"
              ~default:"cobc"
+             ~scope:"machine-overridable"
              ~description:"Path to the GnuCOBOL runtime library file.";
          ])
     ~taskDefinitions: [

--- a/src/vscode/vscode-json/manifest.ml
+++ b/src/vscode/vscode-json/manifest.ml
@@ -476,6 +476,20 @@ type jsonValidation = {
 }
 [@@deriving json_encoding,show]
 
+let jsonValidation ~fileMatch ~url =
+  { jsonValidation_fileMatch = fileMatch;
+    jsonValidation_url = url }
+
+type tomlValidation = {
+  tomlValidation_fileMatch : string ; (* ".toml" *)
+  tomlValidation_url : string ; (* schema URL *)
+}
+[@@deriving json_encoding,show]
+
+let tomlValidation ~fileMatch ~url =
+  { tomlValidation_fileMatch = fileMatch;
+    tomlValidation_url = url }
+
 type keybinding = {
   key_command : string ;
   key_key : string ; (* "ctrl+f1" *)
@@ -756,6 +770,7 @@ type contributes = {
     icons : icon list [@assoc] ; [@dft []]
     iconThemes : iconTheme list ; [@dft []]
     jsonValidation : jsonValidation list ; [@dft []]
+    tomlValidation : tomlValidation list ; [@dft []]
     keybindings : keybinding list ; [@dft []]
     languages : language list ; [@dft []]
     menus : ( string * menu list ) list [@assoc] ; [@dft []]
@@ -794,6 +809,7 @@ let contributes
   ?( icons = [] )
   ?( iconThemes = [] )
   ?( jsonValidation = [] )
+  ?( tomlValidation = [] )
   ?( keybindings = [] )
   ?( languages = [] )
   ?( menus = [] )
@@ -819,6 +835,7 @@ let contributes
     icons ;
     iconThemes ;
     jsonValidation ;
+    tomlValidation ;
     keybindings ;
     languages ;
     menus ;


### PR DESCRIPTION
Gathers some changes from #154, for easier review:
- Customization of activation events for the extension;
- A JSON schema that can be used by TOML-dedicated LSPs to validate and edit the `superbol.toml` configuration file.

Regarding the latter point, this PR adds a dependency to the `tamasfe.even-better-toml` VS Code extension. The idea may be, if and when we find out how that can be done, to have this as a "suggestion" only, not as a mandatory dependency.