### PR TITLE
Optionally pass a `--storage-directory` argument to the LSP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.4] Next release
 
 ### Added
+- Configuration flag for caching in storage provided by Visual Studio Code [#167](https://github.com/OCamlPro/superbol-studio-oss/pull/167)
 - Configuration setting for copybook filename extensions [#332](https://github.com/OCamlPro/superbol-studio-oss/pull/332), with updated JSON schema [#333](https://github.com/OCamlPro/superbol-studio-oss/pull/333)
 - COBOL language configuration for highlighting matching brackets and auto-insertion of line numbers in fixed-format code [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
             "cbx"
           ],
           "items": "string",
-          "order": 1
+          "order": 4
         },
         "superbol.cobc-path": {
           "title": "GnuCOBOL Compiler Executable",
@@ -151,6 +151,12 @@
           "type": "boolean",
           "default": false,
           "order": 21
+        },
+        "superbol.cacheInGlobalStorage": {
+          "markdownDescription": "Use storage provided by Visual Studio Code for caching.  When this setting is set to *false*, the cache related to the contents of a given workspace folder *f* is stored in a file named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not removed automatically, whatever their location.",
+          "type": "boolean",
+          "default": false,
+          "order": 22
         },
         "superbol.debugger.display-variable-attributes": {
           "title": "Display Variable Attributes",

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -343,7 +343,7 @@ let contributes =
                (with_superbol_toml_note
                   "File extensions for copybook resolution")
              ~default:Cobol_common.Copybook.copybook_extensions
-             ~order:1;
+             ~order:4;
 
            (* Paths *)
 
@@ -372,6 +372,16 @@ let contributes =
                "Force reporting of syntax diagnostics for dialects other than \
                 ``COBOL85``."
              ~order:21;
+
+           Manifest.PROPERTY.bool "superbol.cacheInGlobalStorage"
+             ~default:false
+             ~markdownDescription:
+               "Use storage provided by Visual Studio Code for caching.  When \
+                this setting is set to *false*, the cache related to the \
+                contents of a given workspace folder *f* is stored in a file \
+                named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not \
+                removed automatically, whatever their location."
+             ~order:22;
 
            (* Debugger-specific: *)
 


### PR DESCRIPTION
This change avoids creating a `_superbol` folder in each project's root directory.  A storage space provided by the client is used instead.

For now, the "global" storage space provided by VS Code for the extension is used. It is unclear (/ I did not search for) who is responsible for cleaning that space (or the local storage).