### PR TITLE
Add check syntax command

### DIFF
--- a/src/lsp/superbol_free_lib/command_check_syntax.ml
+++ b/src/lsp/superbol_free_lib/command_check_syntax.ml
@@ -32,7 +32,7 @@ let cmd =
     let common, common_args = Common_args.get () in
 
   EZCMD.sub
-    "parse file"            (* add the corresponding line in Main.subcommands *)
+    "check syntax"            (* add the corresponding line in Main.subcommands *)
     begin fun () ->
       action (common ()) !files |>
       Seq.iter Cobol_common.Diagnostics.sink_result
@@ -40,9 +40,9 @@ let cmd =
     ~args:(common_args @ [
         [],
         Arg.Anons (fun list -> files := list),
-        EZCMD.info ~docv:"FILE" "Cobol file to parse";
+        EZCMD.info ~docv:"FILE" "Cobol file to check";
       ])
-    ~doc: "Parse a Cobol file"
+    ~doc: "Check the syntax of a Cobol file"
     ~man:[
       `S "DESCRIPTION";
       `Blocks [

--- a/src/lsp/superbol_free_lib/command_check_syntax.ml
+++ b/src/lsp/superbol_free_lib/command_check_syntax.ml
@@ -1,0 +1,51 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Copyright (c) 2021-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(*  All rights reserved.                                                  *)
+(*  This file is distributed under the terms of the                       *)
+(*  OCAMLPRO-NON-COMMERCIAL license.                                      *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** `parse` command *)
+
+open Ezcmd.V2
+open EZCMD.TYPES
+
+open Common_args
+
+let action { preproc_options; parser_options } files =
+  let parse input =
+    input |>
+    Cobol_preproc.preprocessor ~options:preproc_options |>
+    Cobol_parser.parse_simple ~options:parser_options
+  in
+  List.to_seq files |>
+  Seq.map begin fun filename ->
+    Pretty.out "@[Considering@ `%s'@]@." filename;
+    Cobol_preproc.Input.from ~filename ~f:parse
+  end
+
+let cmd =
+  let files = ref [] in
+    let common, common_args = Common_args.get () in
+
+  EZCMD.sub
+    "parse file"            (* add the corresponding line in Main.subcommands *)
+    begin fun () ->
+      action (common ()) !files |>
+      Seq.iter Cobol_common.Diagnostics.sink_result
+    end
+    ~args:(common_args @ [
+        [],
+        Arg.Anons (fun list -> files := list),
+        EZCMD.info ~docv:"FILE" "Cobol file to parse";
+      ])
+    ~doc: "Parse a Cobol file"
+    ~man:[
+      `S "DESCRIPTION";
+      `Blocks [
+        `P ""
+      ];
+    ]

--- a/src/lsp/superbol_free_lib/main.ml
+++ b/src/lsp/superbol_free_lib/main.ml
@@ -25,6 +25,7 @@ let public_subcommands = [
   Command_texi2rst.cmd ;
   Command_indent_range.cmd;
   Command_indent_file.cmd;
+  Command_check_syntax.cmd;
   Command_json_vscode.cmd;
   Command_snapshot.cmd;
 


### PR DESCRIPTION
See issue https://github.com/OCamlPro/superbol-studio-oss/issues/142

This PR adds a "check syntax" command to check the presence of syntax errors in a COBOL file. It can be used as follows:
```
./superbol-free[...] check syntax <path to COBOL file>
```