### PR TITLE
Smoother config management

### DIFF
--- a/src/lsp/cobol_lsp/lsp_project.mli
+++ b/src/lsp/cobol_lsp/lsp_project.mli
@@ -11,6 +11,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** {1 Type definitions} *)
+
 module TYPES: sig
   include module type of Superbol_project.Config.TYPES
   include module type of Superbol_project.TYPES
@@ -22,6 +24,8 @@ include module type of TYPES
    and type layout = TYPES.layout
 
 type t = project
+
+(** {1 Constructors & accessors} *)
 
 (** [for_ ~rootdir ~layout] retrieves a project based on its root directory.
     This may trigger reading project configuration files if the project was not
@@ -57,7 +61,7 @@ val libpath_for: uri:Lsp.Uri.t -> t -> string list
     for [project] should be treated as a copybook. *)
 val detect_copybook: uri:Lsp.Uri.t -> t -> bool
 
-(** Cached representation *)
+(** {1 Cached representation} *)
 
 type cached
 
@@ -69,7 +73,7 @@ val to_cache: t -> cached
     (outdated or missing configuration file). *)
 val of_cache: rootdir:rootdir -> layout:layout -> cached -> t
 
-(** Collections *)
+(** {1 Collections} *)
 
 module SET: sig
   include Set.S with type elt = t
@@ -79,13 +83,17 @@ module SET: sig
 end
 module MAP: Map.S with type key = t
 
-(** Config *)
+(** {1 Configuration management}
+
+    {e Warning}: functions below that return a Boolean actually perform some
+    mutations on project's configurations. They return [true] if the
+    configuration of the given project has changed. *)
 
 val reload_project_config: t -> bool
 val update_project_config: (string * Yojson.Safe.t) list -> t -> bool
 val get_project_config: ?flat:bool -> t -> Yojson.Safe.t
 
-(** Miscellaneous *)
+(** {1 Miscellaneous} *)
 
 val rootdir: t -> rootdir
 val rooturi: t -> Lsp.Uri.t

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -478,34 +478,54 @@ let retrieve_project_for ~uri registry =
     else load_project_cache ~rootdir registry
 
 
-let create_or_retrieve_project_promise ~uri registry =
+let create_or_retrieve_project_promise ~rootdir registry =    (* from rootdir *)
+  try
+    now (Lsp_project.SET.for_rootdir ~rootdir registry.projects) registry
+  with Not_found ->                                (* load or init new project *)
+    let layout = registry.params.config.project_layout in
+    let project = Lsp_project.for_ ~rootdir ~layout in
+    add_project project registry |>
+    if registry.params.config.enable_client_configs
+    then
+      request_n_use_client_config_for ~project
+        ~silence_ignored_settings_warning:true
+    else
+      now project
+
+
+let create_or_retrieve_doc_project_promise ~uri registry =    (* from doc uri *)
   try
     now (Lsp_project.SET.for_ ~uri registry.projects) registry
   with Not_found ->
     let layout = registry.params.config.project_layout in
     let rootdir = Lsp_project.rootdir_for ~uri ~layout in
-    try
-      now (Lsp_project.SET.for_rootdir ~rootdir registry.projects) registry
-    with Not_found ->                              (* load or init new project *)
-      let project = Lsp_project.for_ ~rootdir ~layout in
-      add_project project registry |>
-      if registry.params.config.enable_client_configs
-      then
-        request_n_use_client_config_for ~project
-          ~silence_ignored_settings_warning:true
-      else
-        now project
+    create_or_retrieve_project_promise ~rootdir registry
 
 
-let on_write_project_config_command uri registry =
+let on_write_project_config_command ?uri registry =
   let write_project_config project registry =
-    Lsp_io.log_info "Saving@ configuration@ for@ project@ of@ %s"
-      (Lsp.Uri.to_string uri);
+    Lsp_io.log_info "Saving@ configuration@ for@ project@ at@ %s"
+      Lsp_project.(string_of_rootdir @@ rootdir project);
     Superbol_project.save_config ~verbose:true project;
     registry
   in
-  perform write_project_config
-    ~after:(create_or_retrieve_project_promise ~uri registry)
+  match uri with
+  | None ->
+      Lsp_project.SET.fold write_project_config registry.projects registry
+  | Some uri
+    when not (Sys.is_directory (Lsp.Uri.to_path uri)) ->
+      perform write_project_config
+        ~after:(create_or_retrieve_doc_project_promise ~uri registry)
+  | Some uri ->
+      try
+        let dirname = Lsp.Uri.to_path uri in
+        let rootdir = Superbol_project.rootdir_at ~dirname in   (* may invalid. *)
+        let project = Lsp_project.SET.for_rootdir ~rootdir registry.projects in
+        write_project_config project registry
+      with Not_found | Invalid_argument _ ->
+        Lsp_error.request_failed "%s@ is@ not@ the@ root@ directory@ of@ any@ \
+                                  project@ from@ the@ workspace"
+          (Lsp.Uri.to_string uri)
 
 
 let get_project_config_command uri registry =
@@ -517,7 +537,7 @@ let get_project_config_command uri registry =
     Lsp_project.SET.for_ ~uri registry.projects
   with Not_found ->
     (* NOTE: for this we need to be able to delay replies to server requests. *)
-    Lsp_error.request_failed "%s is not part of any project from the\
+    Lsp_error.request_failed "%s@ is@ not@ part@ of@ any@ project@ from@ the@ \
                               workspace"
       (Lsp.Uri.to_string uri)
 
@@ -568,7 +588,7 @@ let add ~doc:(DidOpenTextDocumentParams.{ textDocument = { uri; _ }; _ } as doc)
       document_error_while_"opening" doc e backtrace registry
   in
   perform add_in_project
-    ~after:(create_or_retrieve_project_promise ~uri registry)
+    ~after:(create_or_retrieve_doc_project_promise ~uri registry)
 
 
 let did_open (DidOpenTextDocumentParams.{ textDocument = { uri; text; _ };

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -369,6 +369,8 @@ let use_client_config_for ~project (configs: Yojson.Safe.t list) registry =
   if Sys.file_exists project.Lsp_project.config_filename
   then now project registry
   else begin
+    Lsp_io.log_info "Received@ client@ configuration:@ @[%a@]"
+      (Yojson.Safe.pretty_print ~std:false) (`List configs);
     let registry, out_of_date_docs = match configs with
       | [`Assoc assoc] ->
           if Lsp_project.update_project_config assoc project

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -358,7 +358,8 @@ let reload_docs_of ~project out_of_date_docs registry =
     let registry = dispatch_diagnostics doc registry in
     let registry = add_or_replace_doc doc registry in
     if registry.params.with_semantic_tokens
-    then delay_unit ~request:SemanticTokensRefresh registry
+    then (delay_unit ~request:SemanticTokensRefresh registry |>
+          delay_unit ~request:WorkspaceDiagnosticRefresh)
     else registry
   end out_of_date_docs registry
 

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -104,7 +104,7 @@ val on_watched_file_changes
   : Lsp.Types.FileEvent.t list -> t -> t
 
 val on_write_project_config_command
-  : Lsp.Uri.t -> t -> t
+  : ?uri:Lsp.Uri.t -> t -> t
 
 val get_project_config_command
   : Lsp.Uri.t -> t -> Yojson.Safe.t

--- a/src/lsp/superbol_project/project.mli
+++ b/src/lsp/superbol_project/project.mli
@@ -121,7 +121,11 @@ val config: t -> Project_config.t
     directory. *)
 val save_config: ?verbose:bool -> t -> unit
 
-val reload_config: ?verbose:bool -> t -> diagnostics
+(** [reload_config ~verbose project] reloads the configuration of [project] from
+    its associated TOML file.  Returns [true] when the reloaded configuration
+    does not match with the one before the call.  Prints some informative
+    message on [stderr] if [verbose] is set. *)
+val reload_config: ?verbose:bool -> t -> bool with_diags
 
 (** {1 Collections} *)
 

--- a/src/lsp/superbol_project/project_config.mli
+++ b/src/lsp/superbol_project/project_config.mli
@@ -11,6 +11,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** {1 Type definitions} *)
+
 module TYPES: sig
 
   type path =
@@ -36,11 +38,9 @@ include module type of TYPES
 
 type t = config
 
-val new_default: unit -> t
+(** {1 TOML file management} *)
 
-val cobol_config_from_dialect_name
-  : string
-  -> Cobol_config.t Cobol_common.Diagnostics.with_diags
+val new_default: unit -> t
 
 (** [load_file ~verbose config_filename] loads the given project configuration
     file.  Raises {!ERROR} or [Sys_error] in case of failure. *)
@@ -55,11 +55,15 @@ val save
   -> t
   -> unit
 
+(** [reload ~verbose ~config_filename config] returns [true], possibly along
+    diagnostics, if the reloaded configuration has changed. *)
 val reload
   : ?verbose:bool
   -> config_filename:string
   -> t
-  -> Cobol_common.Diagnostics.diagnostics
+  -> bool Cobol_common.Diagnostics.with_diags
+
+(** {1 Accessors} *)
 
 (** [libpath_for ~filename project] constructs a list of directory names where
     copybooks are looked up, for a given source file name, in a project with the
@@ -71,7 +75,19 @@ val libpath_for: filename:string -> t -> string list
     configuration [config]. *)
 val detect_copybook: filename:string -> t -> bool
 
-(** Cached representation *)
+(** {1 Intermediate conversion utilities}
+
+    Those may also raise {!ERROR}*)
+
+val cobol_config_from_dialect_name
+  : string
+  -> Cobol_config.t Cobol_common.Diagnostics.with_diags
+
+val cobol_source_format
+  : string
+  -> Cobol_config.source_format_spec
+
+(** {1 Cached representation} *)
 
 exception BAD_CHECKSUM
 

--- a/src/vscode/superbol-vscode-platform/superbol_commands.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_commands.ml
@@ -17,9 +17,9 @@ open Vscode
 type handler =
   | Instance of     (* Intended for partial application of [handler instance] *)
       (Superbol_instance.t -> args:Ojs.t list -> unit)
-  | Text of
-      (Superbol_instance.t -> textEditor:TextEditor.t ->
-       edit:TextEditorEdit.t -> args:Ojs.t list -> unit)
+  (* | Text of *)
+  (*     (Superbol_instance.t -> textEditor:TextEditor.t -> *)
+  (*      edit:TextEditorEdit.t -> args:Ojs.t list -> unit) *)
 
 type t =
   {
@@ -44,10 +44,10 @@ let _restart_language_server =
     end
 
 let _write_project_config =
-  command "superbol.write.project.config" @@ Text
-    begin fun instance ~textEditor ~edit:_ ~args:_ ->
+  command "superbol.write.project.config" @@ Instance
+    begin fun instance ~args:_ ->
       let _: unit Promise.t =
-        Superbol_instance.write_project_config ~text_editor:textEditor instance
+        Superbol_instance.write_project_config instance
       in ()
     end
 
@@ -57,10 +57,10 @@ let register extension instance { id; handler } =
       let callback = callback instance in
       ExtensionContext.subscribe extension
         ~disposable:(Commands.registerCommand ~command:id ~callback)
-  | Text callback ->
-      let callback = callback instance in
-      ExtensionContext.subscribe extension
-        ~disposable:(Commands.registerTextEditorCommand ~command:id ~callback)
+  (* | Text callback -> *)
+  (*     let callback = callback instance in *)
+  (*     ExtensionContext.subscribe extension *)
+  (*       ~disposable:(Commands.registerTextEditorCommand ~command:id ~callback) *)
 
 let register_all extension instance =
   List.iter (register extension instance) !commands


### PR DESCRIPTION
Gathers two (hopefully) self-explaining commits:
- Avoid full reparses when transitioning between equivalent configurations;
- Remove requirement to have a file open to create `superbol.toml` files.

Includes a tiny bit of refactoring as well.