### PR TITLE
Remove `-ffold-copy=LOWER` from default extra options in build tasks

### DIFF
--- a/src/vscode/superbol-vscode-platform/superbol_tasks.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_tasks.ml
@@ -29,7 +29,7 @@ let attributes_spec ~debug =
     "cobc-path", C ([%js.to: string or_undefined],
                     [%js.of: string], "cobc");
     "extra-args", C ([%js.to: string list or_undefined],
-                     [%js.of: string list], ["-ffold-copy=LOWER"]);
+                     [%js.of: string list], []);
   ]
 
 (* --- *)


### PR DESCRIPTION
By default in build tasks, let GnuCOBOL use its default policy for dealing with case in lookup of copybooks.