### PR TITLE
Filter out LSP diagnostics for dialects other than COBOL85

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ From here, you can notably configure:
 > Syntax checks performed by SuperBOL Studio currently cover the
 > `COBOL85` dialect, and some constructions of more recent dialects
 > supported by GnuCOBOL.  Reporting of such diagnostics is currently
-> disabled to avoid misleading developers with false diagnostics about
-> syntax errors.
+> disabled for dialects other than `COBOL85` to avoid misleading
+> developers with false diagnostics about syntax errors.
 
 ## Navigation features
 

--- a/src/lsp/cobol_lsp/lsp_server.ml
+++ b/src/lsp/cobol_lsp/lsp_server.ml
@@ -23,6 +23,7 @@ module TYPES = struct
     project_layout: Lsp_project.layout;
     cache_config: Lsp_project_cache.config;
     enable_client_configs: bool;
+    force_syntax_diagnostics: bool;
   }
 
   type params = {
@@ -195,7 +196,9 @@ let dispatch_diagnostics (Lsp_document.{ project; diags; _ } as doc) registry =
     (* Note here we may publish diagnostics for non-opened documents.  LSP
        protocol does not seem to forbid that (but some editors just ignore
        those).  *)
-    Lsp_diagnostics.publish all_diags;
+    if registry.params.config.force_syntax_diagnostics ||
+       Cobol_config.dialect (Lsp_project.config project).cobol_config = COBOL85
+    then Lsp_diagnostics.publish all_diags;
     { registry with
       indirect_diags =
         (* Register published diagnostics for the other documents in case they
@@ -208,7 +211,9 @@ let dispatch_diagnostics (Lsp_document.{ project; diags; _ } as doc) registry =
         URIMap.union (fun _ a b -> Some (List.rev_append a b))
       end indirect4uri URIMap.empty
     in
-    Lsp_diagnostics.publish all_diags;
+    if registry.params.config.force_syntax_diagnostics ||
+       Cobol_config.dialect (Lsp_project.config project).cobol_config = COBOL85
+    then Lsp_diagnostics.publish all_diags;
     registry
   end
 

--- a/src/lsp/cobol_lsp/lsp_server.mli
+++ b/src/lsp/cobol_lsp/lsp_server.mli
@@ -19,6 +19,7 @@ module TYPES: sig
     project_layout: Lsp_project.layout;
     cache_config: Lsp_project_cache.config;
     enable_client_configs: bool;
+    force_syntax_diagnostics: bool;
   }
 
   type params = {

--- a/src/lsp/cobol_lsp/lsp_server_loop.ml
+++ b/src/lsp/cobol_lsp/lsp_server_loop.ml
@@ -29,6 +29,10 @@ open Ez_file.V1.EzFile.OP
     - [enable_client_configs] (defaulting to [false]) enables requests for
       configuration settings to the client;
 
+    - [force_syntax_diagnostics] (defaulting to [false]) forces reporting of
+      syntax and pre-processor-related diagnostics (for dialects other that
+      COBOL85, for which they are always enabled);
+
     - [fallback_storage_directory], when provided (and if [enable_caching]
       holds), is the name of a directory that is used to store a cache whenever
       [project_layout] does not provide a per-project storage directory ({i i.e,}
@@ -37,6 +41,7 @@ let config
     ~(project_layout: Lsp_project.layout)
     ?(enable_caching = true)
     ?(enable_client_configs = false)
+    ?(force_syntax_diagnostics = false)
     ?(fallback_storage_directory: string option)
     () =
   let cache_storage: Lsp_project_cache.storage =
@@ -68,6 +73,7 @@ let config
     };
     project_layout;
     enable_client_configs;
+    force_syntax_diagnostics;
   }
 
 (** Start the lsp server, listening and responding on stdin and stdout.  This is

--- a/src/lsp/cobol_lsp/lsp_server_loop.mli
+++ b/src/lsp/cobol_lsp/lsp_server_loop.mli
@@ -15,6 +15,7 @@ val config
   : project_layout: Superbol_project.layout
   -> ?enable_caching: bool
   -> ?enable_client_configs: bool
+  -> ?force_syntax_diagnostics: bool
   -> ?fallback_storage_directory: string
   -> unit
   -> Lsp_server.config

--- a/src/lsp/superbol_free_lib/arg_utils.ml
+++ b/src/lsp/superbol_free_lib/arg_utils.ml
@@ -15,7 +15,7 @@ open Ezcmd.V2
 open EZCMD.TYPES
 
 type dual_switch = [`enable_disable | `with_without | `boolean]
-type single_switch = [`use]
+type single_switch = [`use | `force]
 
 let dual_switch ?descr (kind: dual_switch) ~name ~default =
   let switch = ref default in
@@ -51,10 +51,14 @@ let single_switch ?descr (kind: single_switch) ~name ~default =
   let set = match kind with
     | `use when not default -> "Use"
     | `use -> "Don't use"
+    | `force when not default -> "Force"
+    | `force -> "Don't force"
   in
   let arg_set = match kind with
     | `use when not default -> name
     | `use -> "no-"^name
+    | `force when not default -> "force-"^name
+    | `force -> "default-"^name
   in
   let descr = Option.value descr ~default:name in
   switch,

--- a/src/lsp/superbol_free_lib/arg_utils.mli
+++ b/src/lsp/superbol_free_lib/arg_utils.mli
@@ -19,7 +19,7 @@
     a single argument selected based on the value of [default]. *)
 val switch
   : ?descr: string
-  -> [ `enable_disable | `with_without | `boolean | `use ]
+  -> [ `enable_disable | `with_without | `boolean | `use | `force ]
   -> name: string
   -> default: bool
   -> bool ref * Ezcmd.V2.EZCMD.TYPES.arg_list

--- a/src/lsp/superbol_free_lib/command_lsp.ml
+++ b/src/lsp/superbol_free_lib/command_lsp.ml
@@ -15,7 +15,7 @@ open Ezcmd.V2
 open EZCMD.TYPES
 
 
-let run_lsp ~enable_caching ~storage =
+let run_lsp ~enable_caching ~force_syntax_diagnostics ~storage =
   Cobol_lsp.INTERNAL.Debug.message "LSP Started with pid %d\n%!"
     (Unix.getpid ());
   Cobol_preproc.Src_overlay.debug_oc := !Cobol_lsp.INTERNAL.Debug.debug_oc;
@@ -31,6 +31,7 @@ let run_lsp ~enable_caching ~storage =
     Cobol_lsp.config ()
       ~enable_caching
       ~enable_client_configs:true
+      ~force_syntax_diagnostics
       ~project_layout
       ?fallback_storage_directory
   in
@@ -42,13 +43,19 @@ let run_lsp ~enable_caching ~storage =
 let cmd =
   let caching, caching_args =
     Arg_utils.switch `enable_disable ~name:"caching" ~default:true
+  and syntax_diagnostics, syntax_diagnostics_args =
+    Arg_utils.switch `force ~name:"syntax-diagnostics" ~default:false
+      ~descr:"reporting of syntax error and hint diagnostics for dialects other \
+              than COBOL85 (for which they are always enabled)"
   in
   let storage = ref None in
   EZCMD.sub "lsp"
     (fun () ->
-       run_lsp ~enable_caching:!caching ~storage:!storage)
+       run_lsp ~enable_caching:!caching
+         ~force_syntax_diagnostics:!syntax_diagnostics
+         ~storage:!storage)
     ~doc:"run LSP server"
-    ~args: (caching_args @ [
+    ~args: (caching_args @ syntax_diagnostics_args @ [
         ["storage-directory"], Arg.String (fun s -> storage := Some s),
         EZCMD.info ~docv:"DIR"
           "Directory under which to store cache data --- prevents the creation \

--- a/test/lsp/lsp_testing.ml
+++ b/test/lsp/lsp_testing.ml
@@ -48,7 +48,8 @@ let init_temp_project ?(toml = "") () =
 let make_server ?(with_semantic_tokens = false) () =
   LSP.Server.init ~params:{ config = { project_layout = layout;
                                        cache_config;
-                                       enable_client_configs = false };
+                                       enable_client_configs = false;
+                                       force_syntax_diagnostics = true };
                             root_uri = None;
                             workspace_folders = [];
                             with_semantic_tokens;


### PR DESCRIPTION
This temporary measure aligns the behavior of the LSP server with the current documentation in the `README.md`: we suppress diagnostics for dialects other than COBOL85 to avoid overwhelming users with wrong diagnostics; we keep them for COBOL85 as the current parser has been tested quite extensively on this dialect.