### PR TITLE
Provide means to statically link the LSP server for Linux

### DIFF
--- a/.drom
+++ b/.drom
@@ -30,7 +30,7 @@ d00f73c835ae4a1589d55ebda4ab381b:CHANGES.md
 
 # begin context for Makefile
 # file Makefile
-96bf12f11a68f9bce9adc30db2cd4a7d:Makefile
+f1f3872e69172bdba79903e5931ebb7d:Makefile
 # end context for Makefile
 
 # begin context for README.md
@@ -245,7 +245,7 @@ bb3a9d286f0dc64021db4194427263ee:scripts/copy-bin.sh
 
 # begin context for scripts/static-build.sh
 # file scripts/static-build.sh
-b243cb6f630e2b0483b76eef1572ff95:scripts/static-build.sh
+a49b1a7726042e6f37ce09424b769fd8:scripts/static-build.sh
 # end context for scripts/static-build.sh
 
 # begin context for sphinx/_static/css/fixes.css

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,12 @@ all: build
 
 build:
 	./scripts/before.sh build
+ifeq ($(TARGET_PLAT)_$(BUILD_STATIC_EXECS),linux_true)
+# note: build-profile is ignored here.
+	./scripts/static-build.sh
+else
 	${DUNE} build ${DUNE_ARGS} ${DUNE_CROSS_ARGS} @install
+endif
 	./scripts/copy-bin.sh superbol-studio-oss superbol-vscode-platform polka-js-stubs interop-js-stubs node-js-stubs vscode-js-stubs vscode-languageclient-js-stubs vscode-json vscode-debugadapter vscode-debugprotocol superbol-free superbol_free_lib superbol_project cobol_common cobol_parser cobol_ptree ebcdic_lib cobol_lsp ppx_cobcflags pretty cobol_config cobol_indent cobol_indent_old cobol_preproc cobol_data cobol_typeck cobol_unit ez_toml ezr_toml
 	./scripts/after.sh build
 

--- a/Makefile.drom-tpl
+++ b/Makefile.drom-tpl
@@ -27,7 +27,11 @@ all: build
 
 build:
 	./scripts/before.sh build
+ifeq ($(TARGET_PLAT)_$(BUILD_STATIC_EXECS),linux_true)
+	./scripts/static-build.sh
+else
 	${DUNE} build!{build-profile} ${DUNE_ARGS} ${DUNE_CROSS_ARGS} @install
+endif
 	./scripts/copy-bin.sh !{packages}
 	./scripts/after.sh build
 

--- a/Makefile.header
+++ b/Makefile.header
@@ -25,7 +25,11 @@ TARGET_VSIX = $(TARGET_NAME)-$(VERSION)-$(TARGET_SPEC)-$(TARGET_PROFILE).vsix
 DOT_EXE = $(if $(filter win32,$(TARGET_PLAT)),.exe)
 SUPERBOL_LSP = superbol-free-$(TARGET_SPEC)$(DOT_EXE)
 SUPERBOL_LSPs = $(wildcard superbol-free-*-*)
-SUPERBOL_LSP_BUILT = ${DUNE_BUILD_SRCDIR}/lsp/superbol-free/main.exe
+ifeq ($(TARGET_PLAT)_$(BUILD_STATIC_EXECS),linux_true)
+  SUPERBOL_LSP_BUILT = superbol-free
+else
+  SUPERBOL_LSP_BUILT = ${DUNE_BUILD_SRCDIR}/lsp/superbol-free/main.exe
+endif
 
 YARN = npx --yes yarn 
 
@@ -53,12 +57,12 @@ ifeq ($(TARGET_PLAT),linux)
 	$(CP) $(SUPERBOL_LSP_BUILT) $(SUPERBOL_LSP)
 
   ifeq ($(shell uname),Linux)
-  package.json: $(SUPERBOL_LSP)
+  package.json: $(SUPERBOL_LSP_BUILT)
 	cp -f package.json package.json.prev
 	./$(SUPERBOL_LSP) json vscode --gen package.json
 	diff -u package.json.prev package.json && rm -f package.json.prev 
   endif
-endif
+endif				#linux
 
 .PHONY: build-debug yarn-debug
 
@@ -183,7 +187,7 @@ deploy-all: # Make sure to run target `all-vsix-release-packages` beforehand
 
 .PHONY: clean-execs
 clean-execs:
-	rm -f $(SUPERBOL_LSPs)
+	rm -f superbol-free $(SUPERBOL_LSPs)
 
 distclean: clean-execs vsix-clean
 clean: clean-execs

--- a/scripts/static-build.sh.drom-tpl
+++ b/scripts/static-build.sh.drom-tpl
@@ -13,10 +13,10 @@ set -o pipefail
 # and `docker-alpine-packages` to add more apk packages
 git ls-files -z | xargs -0 tar c | \
 docker run --rm -i \
-    ocamlpro/ocaml:4.14 \
+    !(docker-alpine-image:default:ocamlpro/ocaml:4.14) \
     sh -uexc \
       'tar x >&2 &&
-       sudo apk add g++ openssl-libs-static bash  >&2 &&
+       sudo apk add g++ openssl-libs-static bash !(docker-alpine-packages) >&2 &&
        opam update >&2 &&
        opam switch create . --empty >&2 &&
        opam switch set-invariant ocaml-system >&2 &&


### PR DESCRIPTION
This is achieved using docker, and on demand by setting `BUILD_STATIC_EXECS=true`