### PR TITLE
SuperBOL Studio Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ control.  Extensions dedicated to the edition of TOML files, such as
 provide the same level of assistance as when you edit
 `.vscode/settings.json`.
 
+> [!TIP]
+>
+> Install the
+> [`OCamlPro.SuperBOL-studio-pack`](https://marketplace.visualstudio.com/items?itemName=OCamlPro.SuperBOL-studio-pack)
+> extension to get SuperBOL Studio OSS and `tamasfe.even-better-toml`
+> altogether.
+
 ![Editing `superbol.toml`](./assets/superbol-editing-superbol.toml.png)
 
 ### Further documentation

--- a/package.json
+++ b/package.json
@@ -446,9 +446,9 @@
   ],
   "name": "SuperBOL",
   "displayName": "SuperBOL Studio OSS",
-  "description": "Provides a COBOL mode in VSCode, based on the SuperBOL LSP server for COBOL",
+  "description": "Provides a COBOL mode in Visual Studio Code, based on the SuperBOL LSP server for COBOL, and optional source level debugger and commands for GnuCOBOL 3.2+",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/OCamlPro/superbol-studio-oss"

--- a/package.json
+++ b/package.json
@@ -441,9 +441,6 @@
   "extensionKind": [
     "workspace"
   ],
-  "extensionDependencies": [
-    "tamasfe.even-better-toml"
-  ],
   "name": "SuperBOL",
   "displayName": "SuperBOL Studio OSS",
   "description": "Provides a COBOL mode in Visual Studio Code, based on the SuperBOL LSP server for COBOL, and optional source level debugger and commands for GnuCOBOL 3.2+",

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -485,8 +485,4 @@ let manifest =
     ~extensionKind: [
       "workspace";                                 (* <- run on the workspace *)
     ]
-    ~extensionDependencies: [
-      "tamasfe.even-better-toml"; (* <- to edit `superbol.toml`; actually just a
-                                     suggestion *)
-    ]
     ~contributes

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -35,8 +35,9 @@ let package =
   Manifest.package
     "SuperBOL"
     ~displayName: "SuperBOL Studio OSS"
-    ~description: "Provides a COBOL mode in VSCode, based on the SuperBOL LSP \
-                   server for COBOL"
+    ~description: "Provides a COBOL mode in Visual Studio Code, based on the \
+                   SuperBOL LSP server for COBOL, and optional source level \
+                   debugger and commands for GnuCOBOL 3.2+"
     ~license: "MIT"
     ~version: Version.version
     ~repository: {

--- a/studio/CHANGELOG.md
+++ b/studio/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ChangeLog
+
+## 0.1.0
+
+- Initial release

--- a/studio/LICENSE.md
+++ b/studio/LICENSE.md
@@ -1,0 +1,1 @@
+MIT License

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,0 +1,11 @@
+# SuperBOL Studio Pack
+
+Bundles SuperBOL Studio OSS for COBOL, along with other useful
+extensions.
+
+At the moment, the latter set only includes:
+
+- [`tamasfe.even-better-toml`](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml),
+  which is an extensions dedicated to the edition of TOML files.  It
+  proves usefull when editing `superbol.toml` configuration files for
+  SuperBOL.

--- a/studio/icon.png
+++ b/studio/icon.png
@@ -1,0 +1,1 @@
+../assets/superbol-128.png

--- a/studio/package.json
+++ b/studio/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "SuperBOL-studio-pack",
+    "version": "0.1.0",
+    "displayName": "SuperBOL Studio Pack",
+    "publisher": "OCamlPro",
+    "license": "MIT",
+    "icon": "icon.png",
+    "description": "Bundles the SuperBOL Studio for COBOL along with other useful extensions",
+    "categories": ["Extension Packs"],
+    "extensionPack": [
+        "OCamlPro.SuperBOL",
+        "tamasfe.even-better-toml"
+    ],
+    "engines": {
+        "vscode": "^1.76.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/OCamlPro/superbol-studio-oss"
+    }
+}


### PR DESCRIPTION
- Update the main extension's description, and remove its dependency to `tamasfe.even-better-toml`;
- Add an extension pack into the `studio` sub-directory. Calling `vsce package --out superbol-studio-pack-0.1.0.vsix` into `studio` will build a pack that can directly be published on the marketplace.