### PR TITLE
Ship GnuCOBOL config files in the VSIX, and use them as fallback

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-267cba6b927392db03cbda254d098b28:.
+21d54811d97e56bf8f1651f3d23a69f4:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -15,7 +15,7 @@ version:0.9.0
 
 # begin context for .gitignore
 # file .gitignore
-6e05d43f03fa3a1b1940e4433928e548:.gitignore
+51f9ea0869bc6b9d00819abfe13bfe0a:.gitignore
 # end context for .gitignore
 
 # begin context for CHANGES.md

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ _build
 /yarn-error.log
 /yarn.lock
 /package-json
+/gnucobol-config
 ATTIC
 /out
 !.vscode/tasks.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,3 +10,4 @@ _out/
 !CHANGELOG.md
 !LICENSE.md
 !package.json
+!gnucobol-config/

--- a/Makefile.header
+++ b/Makefile.header
@@ -5,6 +5,7 @@ TARGET_NAME = superbol-vscode-platform
 
 SRCDIR ?= src
 STUDIO_SRCDIR = $(SRCDIR)/vscode/superbol-vscode-platform
+GNUCOBOL_SRCDIR = import/gnucobol
 
 CP ?= cp -f # ln -srf
 
@@ -131,10 +132,17 @@ _out/superbol-vscode-gdb.js:					\
 	all-vsix-debug-packages					\
 	all-vsix-packages
 
+gnucobol-config: $(GNUCOBOL_SRCDIR)/config
+	@mkdir -p $@
+	rm -r -f $@/*.*
+	find $(GNUCOBOL_SRCDIR)/config -type f		\
+		-a -regex '.*.\(conf\|words\|ttbl\)' -print0 |	\
+		xargs -0 cp -f -t $@
+
 vsix-dist-setup:
 	@mkdir -p _dist
 
-vsix-package:
+vsix-package: gnucobol-config
 #	needs 'make build-debug' or 'make build-release' before
 	rm -f _dist/superbol-free-*-*
 	$(CP) $(SUPERBOL_LSP_BUILT) _dist/$(SUPERBOL_LSP)
@@ -162,7 +170,7 @@ all-vsix-debug-packages: build-debug
 all-vsix-packages: all-vsix-debug-packages all-vsix-release-packages
 
 vsix-clean: clean
-	rm -rf _out _dist *.vsix
+	rm -rf _out gnucobol-config _dist *.vsix
 
 # publishing (requires vsce/ovsx login)
 

--- a/drom.toml
+++ b/drom.toml
@@ -77,6 +77,7 @@ dot-gitignore-trailer = """
 /yarn-error.log
 /yarn.lock
 /package-json
+/gnucobol-config
 ATTIC
 /out
 !.vscode/tasks.json

--- a/src/lsp/cobol_config/cobol_config.ml
+++ b/src/lsp/cobol_config/cobol_config.ml
@@ -24,6 +24,8 @@ module Diagnostics = Config_diagnostics
 
 module DIAGS = Cobol_common.Diagnostics
 
+let fallback_config_dir_var = "COB_CONFIG_DIR_FALLBACK"
+
 exception ERROR of Config_diagnostics.error
 
 let __init_default_exn_printers =
@@ -47,7 +49,11 @@ let default_search_path =
   in
   lazy begin
     let cwd = EzFile.getcwd () in
-    let cob_config_dir = Option.to_list (Sys.getenv_opt "COB_CONFIG_DIR") in
+    let cob_config_dir =
+      Option.to_list (Sys.getenv_opt "COB_CONFIG_DIR")
+    and fallback_dir =
+      Option.to_list (Sys.getenv_opt fallback_config_dir_var)
+    in
     let xdg_superbol_dir =      (* is this available on win32/cygwin as well? *)
       append ~sub:"superbol" @@
       match Sys.getenv_opt "XDG_CONFIG_HOME" with
@@ -65,7 +71,8 @@ let default_search_path =
             "/etc/gnucobol"]
       else []
     in
-    cwd ::  cob_config_dir @ xdg_superbol_dir @ windose_specific @ unix_specific
+    cwd :: cob_config_dir @ xdg_superbol_dir @ windose_specific @ unix_specific @
+    fallback_dir
   end
 
 let retrieve_search_path ?search_path () =

--- a/src/vscode/superbol-vscode-platform/superbol_instance.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_instance.mli
@@ -15,10 +15,10 @@
 type t
 type client = Vscode_languageclient.LanguageClient.t
 
-val make : bundled_superbol:string -> unit -> t
+val make: context:Vscode.ExtensionContext.t -> t
 
-val stop_language_server : t -> unit Promise.t
-val start_language_server : t -> unit Promise.t
+val stop_language_server: t -> unit Promise.t
+val start_language_server: t -> unit Promise.t
 
 val write_project_config
   : ?text_editor: Vscode.TextEditor.t

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.ml
@@ -12,16 +12,63 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let serverOptions ~bundled_superbol =
-  Vscode_languageclient.ServerOptions.create ()
+module LSP = Vscode_languageclient
+
+
+(* Helpers to find the bundled superbol executable *)
+let rec find_existing = function
+  | [] -> raise Not_found
+  | uri :: uris ->
+    if Node.Fs.existsSync (Vscode.Uri.fsPath uri) then uri
+    else find_existing uris
+
+
+(* Look for the most specific `superbol-free` executable amongst (in order):
+
+  - `superbol-free-${platform}-${arch}${suffix}`
+  - `superbol-free-${platform}${suffix}`
+  - `superbol-free${suffix}`
+
+  The `platform` and `arch` used are from the corresponding `process`
+  attributes in node.js. The `suffix` is `".exe"` on Windows, and empty
+  otherwise.
+
+  https://nodejs.org/api/process.html#processplatform
+  https://nodejs.org/api/process.html#processarch
+*)
+let find_superbol root =
+  let open Node.Process in
+  let prefix = "superbol-free" in
+  let suffix = if platform == "win32" then ".exe" else "" in
+  Vscode.Uri.fsPath @@ find_existing @@ List.map (fun name ->
+    Vscode.Uri.joinPath root ~pathSegments:[name]) @@ [
+    Format.asprintf "%s-%s-%s%s" prefix platform arch suffix;
+    Format.asprintf "%s-%s%s" prefix platform suffix;
+    Format.asprintf "%s%s" prefix suffix
+  ]
+
+
+let serverOptions ~context =
+  let bundled_superbol =
+    try
+      find_superbol
+        (Vscode.Uri.joinPath ~pathSegments:["_dist"]
+           (Vscode.ExtensionContext.extensionUri context));
+    with Not_found ->
+      (* If there is no bundled executable for the current platform, fall back
+         to looking for superbol-free in the PATH *)
+      "superbol-free"
+  in
+  LSP.ServerOptions.create ()
     ~command:(match Superbol_workspace.superbol_exe () with
         | None -> bundled_superbol
         | Some cmd -> cmd)
     ~args:["lsp"]
 
+
 let clientOptions () =
-  Vscode_languageclient.ClientOptions.create ()
+  LSP.ClientOptions.create ()
     ~documentSelector:[|
-      `Filter (Vscode_languageclient.DocumentFilter.createLanguage ()
+      `Filter (LSP.DocumentFilter.createLanguage ()
                  ~language:"cobol");
     |]

--- a/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
+++ b/src/vscode/superbol-vscode-platform/superbol_languageclient.mli
@@ -12,7 +12,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val serverOptions:
-  bundled_superbol:string ->
-  Vscode_languageclient.ServerOptions.t
-val clientOptions: unit -> Vscode_languageclient.ClientOptions.t
+val serverOptions
+  : context: Vscode.ExtensionContext.t
+  -> Vscode_languageclient.ServerOptions.t
+
+val clientOptions
+  : unit
+  -> Vscode_languageclient.ClientOptions.t


### PR DESCRIPTION
With these changes, having an installed version of GnuCOBOL is no longer required for the LSP part of the extension to work.