### PR TITLE
Handle `COMMON` keyword in `PROGRAM-ID`

### DIFF
--- a/src/lsp/cobol_ptree/compilation_group_visitor.ml
+++ b/src/lsp/cobol_ptree/compilation_group_visitor.ml
@@ -72,7 +72,7 @@ let rec fold_program_unit (v: _ #folder) =
           | ProgramDefinition { (* has_identification_division_header; *)
               preliminary_informational_paragraphs = infos0;
               supplementary_informational_paragraphs = infos1;
-              kind; _ } -> ignore kind; x
+              mode; _ } -> ignore mode; x
               (* >> fold_bool v has_identification_division_header *)
               >> fold_informational_paragraphs v infos0
               >> fold_name' v program_name

--- a/test/output-tests/syn_definition.expected
+++ b/test/output-tests/syn_definition.expected
@@ -18,26 +18,6 @@ syn_definition.at-60-SHORT2.cob:3.24-3.32:
 >> Error: Invalid syntax
 
 Considering: import/gnucobol/tests/testsuite.src/syn_definition.at:145:0
-syn_definition.at-145-containing-prog.cob:8.42-8.48:
-   5          PROCEDURE        DIVISION.
-   6   
-   7          IDENTIFICATION   DIVISION.
-   8 >        PROGRAM-ID.      prog-1 IS INITIAL COMMON.
-----                                             ^^^^^^
-   9          PROCEDURE        DIVISION.
-  10              STOP RUN.
->> Error: Invalid syntax
-
-syn_definition.at-145-containing-prog.cob:14.44-14.50:
-  11          END PROGRAM      prog-1.
-  12   
-  13          IDENTIFICATION   DIVISION.
-  14 >        PROGRAM-ID.      prog-2 IS RECURSIVE COMMON.
-----                                               ^^^^^^
-  15          PROCEDURE        DIVISION.
-  16              STOP RUN.
->> Error: Invalid syntax
-
 syn_definition.at-145-containing-prog.cob:17.31:
   14          PROGRAM-ID.      prog-2 IS RECURSIVE COMMON.
   15          PROCEDURE        DIVISION.


### PR DESCRIPTION
# Problem

The grammar could recognise the `INITIAL`, `RECURSIVE` and `COMMON` keywords after `PROGRAM-ID. id IS?` but not:
- `INITIAL COMMON` and `RECURSIVE COMMON`;
- `COMMON INITIAL` and `COMMON RECURSIVE`

I followed the [grammar of GnuCOBOL](https://github.com/OCamlPro/gnucobol/blob/89c45a3bc80c2ca6302382bd40fdc585436d65f9/cobc/parser.y#L3992).