### PR TITLE
Match pseudo-text for exact replacement case insensitively

### DIFF
--- a/src/lsp/cobol_preproc/text.ml
+++ b/src/lsp/cobol_preproc/text.ml
@@ -148,3 +148,16 @@ let alphanum_as_pseudotext a = pseudotext_ alphanum_as_pseudo a
 let rec strip_eof = function
   | { payload = Eof; _ } :: text -> strip_eof text
   | text -> text
+
+let map_pseudowords ~f : pseudotext -> pseudotext =
+  let map_pseudoword_items: (pseudoword_item with_loc list as 'a) -> 'a =
+    EzList.tail_map begin function
+      | { payload = PwText w; loc } -> PwText (f w) &@ loc
+      | x -> x
+    end
+  in
+  EzList.tail_map begin function
+    | { payload = PseudoWord w; loc } ->
+        PseudoWord (map_pseudoword_items w) &@ loc
+    | x -> x
+  end

--- a/src/lsp/cobol_preproc/text.mli
+++ b/src/lsp/cobol_preproc/text.mli
@@ -65,3 +65,4 @@ val pp_alphanum: alphanum Pretty.printer
 val prefix_of_literal_kind: literal_kind -> string
 val char_of_quotation: quotation -> char
 val strip_eof: text -> text
+val map_pseudowords: f:(string -> string) -> pseudotext -> pseudotext

--- a/src/lsp/cobol_preproc/text_processor.ml
+++ b/src/lsp/cobol_preproc/text_processor.ml
@@ -32,7 +32,7 @@ let nonempty_words words : _ result = match ~&words with
   | [] ->
       Error (Missing { loc = ~@words; stuff = At_least_one_text_word })
   | _ ->
-      Ok words
+      Ok (Text.map_pseudowords ~f:String.uppercase_ascii ~&words &@<- words)
 
 type _ partial_word_request =
   | ExactlyOne: string with_loc partial_word_request
@@ -158,6 +158,7 @@ let pseudotext_exact_match
   : pseudotext -> text ->
     ('s option * 's option * srcloc * text, [> `Mismatch | `MissingText]) result =
   let starts_with ~prefix s =
+    let s = String.uppercase_ascii s in
     s = prefix ||
     let pl = String.length prefix in
     String.length s >= pl && Str.first_chars s pl = prefix
@@ -194,7 +195,7 @@ let pseudotext_exact_match
         match ~&t, ~&p with
         | TextWord w,
           PseudoWord [{ payload = PwText pw; _ }]
-          when w <> pw ->
+          when String.uppercase_ascii w <> pw ->
             (* Pseudotext ends with a text-word [pw] that does not match [w]. *)
             Error `Mismatch
 


### PR DESCRIPTION
Before this change, `REPLACE ==x==` did not replace occurrences of `X`.