### PR TITLE
Handle arguments of intrinsic TRIM function

### DIFF
--- a/src/lsp/cobol_config/reserved_words.ml
+++ b/src/lsp/cobol_config/reserved_words.ml
@@ -906,6 +906,7 @@ let reserved_words =
     "TRANSFORM";
     "TRANSPARENT";
     "TREE-VIEW";
+    "TRIM";
     "TRUE";
     "TRUNCATION";
     "TYPE";

--- a/src/lsp/cobol_lsp/lsp_semtoks.ml
+++ b/src/lsp/cobol_lsp/lsp_semtoks.ml
@@ -276,9 +276,14 @@ let semtoks_from_ptree ~filename ?range ptree =
         |> Visitor.skip_children
 
     (* inline call of function *)
-    method! fold_inline_call { call_fun; call_args } acc = acc
-      |> add_name' call_fun ProcName
-      |> fold_list ~fold:fold_effective_arg self call_args
+    method! fold_inline_call ic acc = match ic with
+    | FunCall { fun_name; args } -> acc
+      |> add_name' fun_name ProcName
+      |> fold_list ~fold:fold_effective_arg self args
+      |> Visitor.skip_children
+    | TrimCall (arg1, arg2) -> acc
+      |> fold_effective_arg self arg1
+      |> fold_leading_trailing_arg self arg2
       |> Visitor.skip_children
 
     (* Statement *)

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -2184,6 +2184,10 @@ let arguments ==
  | "("; ")";                      { [] }
  | "("; al = rnel(argument); ")"; { al }
 
+let leading_trailing_arg ==
+ | LEADING; {ArgLeading}
+ | TRAILING; {ArgTrailing}
+
 let optional_arguments_list :=
  | (* Empty *) %prec lowest       { [] }
  | ~ = arguments;                 < >
@@ -2254,8 +2258,10 @@ let qualident ==
  | qdn = loc(qualname); sl = subscripts; { { ident_name = qdn; ident_subscripts = sl } }
 
 let function_ident ==
- | FUNCTION; n = function_name; al = arguments; { { call_fun = n; call_args = al } }
- | FUNCTION; n = function_name;                 { { call_fun = n; call_args = [] } }
+ | FUNCTION; n = function_name; al = arguments; { FunCall { fun_name = n; args = al } }
+ | FUNCTION; n = function_name;                 { FunCall { fun_name = n; args = [] } }
+ | FUNCTION; loc(TRIM_FUNC); arg1 = argument; arg2 = leading_trailing_arg;  
+  { TrimCall (arg1, arg2) }
 
 let base_ident ==                 (* identifier without reference modification *)
  | q = qualident;                {QualIdent q} (* Works for object property too *)

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -2258,10 +2258,10 @@ let qualident ==
  | qdn = loc(qualname); sl = subscripts; { { ident_name = qdn; ident_subscripts = sl } }
 
 let function_ident ==
+ | FUNCTION; loc(TRIM_FUNC); "("; arg1 = argument; arg2 = leading_trailing_arg; ")";
+  { TrimCall (arg1, arg2) }
  | FUNCTION; n = function_name; al = arguments; { FunCall { fun_name = n; args = al } }
  | FUNCTION; n = function_name;                 { FunCall { fun_name = n; args = [] } }
- | FUNCTION; loc(TRIM_FUNC); arg1 = argument; arg2 = leading_trailing_arg;  
-  { TrimCall (arg1, arg2) }
 
 let base_ident ==                 (* identifier without reference modification *)
  | q = qualident;                {QualIdent q} (* Works for object property too *)

--- a/src/lsp/cobol_parser/grammar_tokens.mly
+++ b/src/lsp/cobol_parser/grammar_tokens.mly
@@ -942,6 +942,7 @@
 %token TRANSFORM                    [@keyword]
 %token TRANSPARENT                  [@keyword]                [@contexts ]
 %token TREE_VIEW                    [@keyword]                [@contexts ]
+%token TRIM_FUNC                    [@keyword   "TRIM"]
 %token TRUE                         [@keyword]
 %token TRUNCATION                   [@keyword]                [@contexts intermediate_rounding_clause, rounded_phrase]
 %token TYPE                         [@keyword]

--- a/test/syntax-todo/syntax-done.at
+++ b/test/syntax-todo/syntax-done.at
@@ -87,6 +87,20 @@ program-id.             acas-get-params.
 ])
 
 AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [0],
+
+
+
+
+AT_SETUP([MF ENTRY LITERAL USING])
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. customer.
+       PROCEDURE DIVISION.
+       Initialise Section.
+       Entry "Initialise" Using Dsc-Control-Block Data-Block.
+])
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 [Checking `prog.cob'
 ])
 
@@ -147,3 +161,25 @@ AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 ])
 
 
+
+AT_SETUP([RECORDING MODE VARIABLE])
+AT_DATA([prog.cob], [
+identification division.
+program-id.             acas-get-params.
+environment division.
+input-output            section.
+file-control.
+     select OPTIONAL ACAS-Params  assign "acas.param"
+                                  organisation line sequential.
+ data division.
+ file section.
+ FD  ACAS-Params
+     recording mode variable.
+ 01  ACAS-Params-Record  pic x(80).
+])
+
+AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [0],
+[Checking `prog.cob'
+])
+
+AT_CLEANUP

--- a/test/syntax-todo/syntax-done.at
+++ b/test/syntax-todo/syntax-done.at
@@ -87,20 +87,6 @@ program-id.             acas-get-params.
 ])
 
 AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [0],
-
-
-
-
-AT_SETUP([MF ENTRY LITERAL USING])
-AT_DATA([prog.cob], [
-       IDENTIFICATION DIVISION.
-       PROGRAM-ID. customer.
-       PROCEDURE DIVISION.
-       Initialise Section.
-       Entry "Initialise" Using Dsc-Control-Block Data-Block.
-])
-
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 [Checking `prog.cob'
 ])
 
@@ -160,10 +146,28 @@ AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 [Checking `prog.cob'
 ])
 
+AT_CLEANUP
+
+
+AT_SETUP([TRIM TRAILING])
+AT_DATA([prog.cob],[
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+           IF FUNCTION LENGTH (FUNCTION TRIM (WS-ARG TRAILING)) <> 4
+               DISPLAY "OK"
+           END-IF.
+])
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [0], [Checking `prog.cob'
+])
+
+AT_CLEANUP
+
+
 
 
 AT_SETUP([RECORDING MODE VARIABLE])
-AT_DATA([prog.cob], [
+AT_DATA([prog.cob],[
 identification division.
 program-id.             acas-get-params.
 environment division.
@@ -178,8 +182,7 @@ file-control.
  01  ACAS-Params-Record  pic x(80).
 ])
 
-AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [0],
-[Checking `prog.cob'
+AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [0], [Checking `prog.cob'
 ])
 
 AT_CLEANUP

--- a/test/syntax-todo/syntax-todo.at
+++ b/test/syntax-todo/syntax-todo.at
@@ -3,33 +3,6 @@
 # superbol-free, in the future
 
 
-AT_SETUP([TRIM TRAILING])
-AT_DATA([prog.cob], [
-       IDENTIFICATION   DIVISION.
-       PROGRAM-ID.      prog.
-       PROCEDURE        DIVISION.
-           IF FUNCTION LENGTH (FUNCTION TRIM (WS-ARG TRAILING)) <> 4
-               DISPLAY "OK"
-           END-IF.
-])
-
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [1],
-[Checking `prog.cob'
-prog.cob:5.53-5.61:
-   2          IDENTIFICATION   DIVISION.
-   3          PROGRAM-ID.      prog.
-   4          PROCEDURE        DIVISION.
-   5 >            IF FUNCTION LENGTH (FUNCTION TRIM (WS-ARG TRAILING)) <> 4
-----                                                        ^^^^^^^^
-   6                  DISPLAY "OK"
-   7              END-IF.
->> Error: Invalid syntax
-
-])
-
-AT_CLEANUP
-
-
 AT_SETUP([MF TYPEDEF])
 AT_DATA([prog.cob], [
        PROGRAM-ID      prog.
@@ -868,6 +841,7 @@ prog.cob:5.19-5.25:
 ])
 
 AT_CLEANUP
+
 
 
 

--- a/test/syntax-todo/syntax-todo.at
+++ b/test/syntax-todo/syntax-todo.at
@@ -847,39 +847,6 @@ AT_CLEANUP
 
 
 
-AT_SETUP([RECORDING MODE VARIABLE])
-AT_DATA([prog.cob], [
-identification division.
-program-id.             acas-get-params.
-environment division.
-input-output            section.
-file-control.
-     select OPTIONAL ACAS-Params  assign "acas.param"
-                                  organisation line sequential.
- data division.
- file section.
- FD  ACAS-Params
-     recording mode variable.
- 01  ACAS-Params-Record  pic x(80).
-])
-
-AT_CHECK([$SUPERBOL check --recovery=false --free --std=mf prog.cob], [1],
-[Checking `prog.cob'
-prog.cob:12.20-12.28:
-   9    data division.
-  10    file section.
-  11    FD  ACAS-Params
-  12 >      recording mode variable.
-----                       ^^^^^^^^
-  13    01  ACAS-Params-Record  pic x(80).
->> Error: Invalid syntax
-
-])
-
-AT_CLEANUP
-
-
-
 AT_SETUP([LENGTH])
 AT_DATA([prog.cob], [
 identification division.
@@ -901,7 +868,6 @@ prog.cob:5.19-5.25:
 ])
 
 AT_CLEANUP
-
 
 
 


### PR DESCRIPTION
# Problem

The `TRIM` intrinsic function takes either `LEADING` or `TRAILING` (which are also reserved keywords using for string functions for instance) as arguments. However, the grammar of the LSP does not recognise those arguments.

:warning: This pull request is not completed. It looks like `FUNCTION TRIM(..., LEADING)` even after my changes is not recognised so I am probably missing something.