### PR TITLE
Fix INSPECT TALLYING FOR ALL CHARACTERS

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -3287,7 +3287,7 @@ let tallying :=
     { { tallying_target = i; tallying_clauses = tfl } }
 
 let tallying_for :=
- | CHARACTERS; l = rl(inspect_where); {TallyingCharacters l}
+ | ALL?; CHARACTERS; l = rl(inspect_where); {TallyingCharacters l}
  | ALL; l = ident_after_before_list;        {TallyingRange (TallyAll, l)}
  | LEADING; l = ident_after_before_list;    {TallyingRange (TallyLeading, l)}
 


### PR DESCRIPTION
# Problem

In the `INSPECT ... TALLYING` statement, it is possible to write `FOR ALL CHARACTERS` FOR `FOR CHARACTERS`.

Such syntax occurs in [ACAS](https://sourceforge.net/projects/acas/) (`makesqltable-original.cbl` ligne 178, 196, 210, 243) and is accepted by the GnuCOBOL compiler. 