### PR TITLE
Handle ENTRY statement

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -98,6 +98,7 @@ let dual_handler_none =
 %nonassoc DIVIDE
 %nonassoc ENABLE
 %nonassoc ENTER
+%nonassoc ENTRY
 %nonassoc EVALUATE
 %nonassoc EXIT
 %nonassoc FREE
@@ -550,7 +551,6 @@ let method_id_paragraph :=                                         (* +COB2002 *
   | METHOD_ID; "."; pk = property_kind; PROPERTY; i = name;
     o = bo(OVERRIDE); f = bo(IS?; FINAL; {});
     { i, PropertyMethod { kind = pk }, o, f }
-
 
 let options_paragraph [@context options_paragraph] :=              (* +COB2002 *)
   | OPTIONS; "."; ~ = lo(sf(rnel(loc(options_clause)),".")); < >
@@ -4138,6 +4138,21 @@ write_statement:
 let write_target :=
  | n = qualname;   {WriteTargetName n}
  | FILE; n = name; {WriteTargetFile n}
+
+(* ENTRY STATEMENT *)
+let entry_by_clauses :=
+ | io(BY?; REFERENCE); ~ = nell(name); %prec lowest <EntryByReference>
+ | BY?; VALUE; ~ = nell(name); %prec lowest         <EntryByValue>
+
+%public let unconditional_action := ~ = entry_statement; < >
+let entry_statement :=
+ | ENTRY; ~ = entry_body; <Entry>
+let entry_body :=
+ | ~ = loc(alphanum); <EntrySimple>
+ | n = loc(alphanum); USING; clauses = rnel(entry_by_clauses);
+   { EntryUsing { entry_name = n;
+                  entry_by_clauses = clauses } }
+ | FOR; GO; TO; ~ = loc(alphanum); <EntryForGoTo>
 
 (* --- Standalone (for testing) --------------------------------------------- *)
 

--- a/src/lsp/cobol_ptree/branching_statements.ml
+++ b/src/lsp/cobol_ptree/branching_statements.ml
@@ -449,6 +449,7 @@ and statement =
   | Divide of divide_stmt
   | Enable of mcs_command_operands
   | Enter of enter_stmt
+  | Entry of entry_stmt
   | Evaluate of evaluate_stmt
   | Exit of exit_stmt
   | Free of name with_loc list
@@ -987,6 +988,7 @@ and pp_statement ppf = function
   | Divide s -> pp_divide_stmt ppf s
   | Enable ops -> Fmt.pf ppf "ENABLE %a" pp_mcs_command_operands ops
   | Enter s -> pp_enter_stmt ppf s
+  | Entry s -> pp_entry_stmt ppf s
   | Evaluate s -> pp_evaluate_stmt ppf s
   | Exit s -> pp_exit_stmt ppf s
   | Free names ->

--- a/src/lsp/cobol_ptree/simple_statements.ml
+++ b/src/lsp/cobol_ptree/simple_statements.ml
@@ -116,6 +116,39 @@ let pp_enter_stmt ppf { enter_language = lang; enter_routine = rout } =
     (pp_with_loc pp_name) lang
     Fmt.(option (sp ++ pp_with_loc pp_name)) rout
 
+(* ENTRY *)
+type entry_by_clause =
+  | EntryByReference of name with_loc list
+  | EntryByValue of name with_loc list
+[@@deriving ord]
+
+type entry_stmt =
+  | EntrySimple of alphanum_string with_loc
+  | EntryUsing of
+    {
+      entry_name: alphanum_string with_loc;
+      entry_by_clauses: entry_by_clause list;
+    }
+  | EntryForGoTo of alphanum_string with_loc
+[@@deriving ord]
+
+let pp_entry_by_clause ppf = function
+  | EntryByReference ns ->
+      Fmt.pf ppf "BY REFERENCE %a" Fmt.(list ~sep:sp pp_name') ns
+  | EntryByValue ns ->
+      Fmt.pf ppf "BY VALUE %a" Fmt.(list ~sep:sp pp_name') ns
+
+let pp_entry_stmt ppf = function
+  | EntrySimple name ->
+    Fmt.pf ppf "ENTRY@ %a" (pp_with_loc pp_alphanum_string) name
+  | EntryUsing { entry_name; entry_by_clauses } ->
+    Fmt.pf ppf "ENTRY@ %a%a"
+      (pp_with_loc pp_alphanum_string) entry_name
+      Fmt.(list ~sep:nop (sp ++ pp_entry_by_clause)) entry_by_clauses
+  | EntryForGoTo entry_name ->
+    Fmt.pf ppf "ENTRY@ FOR GO TO %a"
+      (pp_with_loc pp_alphanum_string) entry_name
+
 (* EXIT *)
 type exit_stmt =
   | ExitSimple

--- a/test/output-tests/run_extensions.expected
+++ b/test/output-tests/run_extensions.expected
@@ -1733,26 +1733,6 @@ run_extensions.at-2595-prog1.cob:5.24-5.33:
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:2595:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:2638:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:2639:0
-run_extensions.at-2639-hello.cob:14.7-14.12:
-  11          PROCEDURE        DIVISION USING X.
-  12              DISPLAY MSG-HELLO X "!".
-  13         * verifies that this does not generate an exception
-  14 >        ENTRY "unused" USING Y.
-----          ^^^^^
-  15              EXIT PROGRAM.
-  16   
->> Error: Invalid syntax
-
-run_extensions.at-2639-hello.cob:17.7-17.12:
-  14          ENTRY "unused" USING Y.
-  15              EXIT PROGRAM.
-  16   
-  17 >        ENTRY "bye" USING Y.
-----          ^^^^^
-  18              DISPLAY MSG-BYE Y "!".
-  19              EXIT PROGRAM.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:2700:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:2699:0
 run_extensions.at-2699-prog.cob:9.30:
@@ -2354,48 +2334,8 @@ run_extensions.at-4380-test_stdio.c:12.6-12.7:
 
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4454:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4597:0
-run_extensions.at-4597-prog.cob:50.7-50.12:
-  47              DISPLAY 'Program is stopping'
-  48              STOP RUN
-  49              .
-  50 >        ENTRY 'ExtProc-internal2'.
-----          ^^^^^
-  51              DISPLAY 'Exit procedure from ' FUNCTION MODULE-ID ()
-  52              SET Ext-Proc-Address TO ENTRY 'ExtProc'
->> Error: Invalid syntax
-
-run_extensions.at-4597-prog.cob:80.7-80.12:
-  77              MOVE 0 TO RETURN-CODE
-  78              GOBACK
-  79              .
-  80 >        ENTRY 'ExtProc-internal'.
-----          ^^^^^
-  81              DISPLAY 'should have been removed'
-  82              GOBACK
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4672:0
-run_extensions.at-4672-prog.cob:29.7-29.12:
-  26              DISPLAY 'Program is stopping'
-  27              STOP RUN
-  28              .
-  29 >        ENTRY 'ErrProc-internal' USING Err-Message-From-Runtime.
-----          ^^^^^
-  30              DISPLAY 'Error (internal): ' FUNCTION EXCEPTION-LOCATION  '-'
-  31              DISPLAY '                  ' FUNCTION EXCEPTION-STATEMENT '-'
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4767:0
-run_extensions.at-4767-prog.cob:24.7-24.12:
-  21              DISPLAY 'Program is stopping'
-  22              STOP RUN
-  23              .
-  24 >        ENTRY 'ErrProc-internal' USING Err-Message-From-Runtime.
-----          ^^^^^
-  25              DISPLAY 'Error (interal): ' FUNCTION EXCEPTION-LOCATION  '-'
-  26              DISPLAY '                 ' FUNCTION EXCEPTION-STATEMENT '-'
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4796:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4834:0
 Considering: import/gnucobol/tests/testsuite.src/run_extensions.at:4853:0

--- a/test/output-tests/run_fundamental.expected
+++ b/test/output-tests/run_fundamental.expected
@@ -378,16 +378,6 @@ run_fundamental.at-1494-prog.cob:55.16-55.28:
 >> Error: Invalid syntax
 
 Considering: import/gnucobol/tests/testsuite.src/run_fundamental.at:1526:0
-run_fundamental.at-1526-module.cob:8.7-8.12:
-   5          PROCEDURE        DIVISION.
-   6              DISPLAY 'A' WITH NO ADVANCING
-   7              GOBACK.
-   8 >        ENTRY 'modulepart'.
-----          ^^^^^
-   9              DISPLAY 'B' WITH NO ADVANCING
-  10              GOBACK.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_fundamental.at:1525:0
 Considering: import/gnucobol/tests/testsuite.src/run_fundamental.at:1558:0
 run_fundamental.at-1558-module.c:5.6-5.7:

--- a/test/output-tests/run_misc.expected
+++ b/test/output-tests/run_misc.expected
@@ -895,58 +895,8 @@ Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4104:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4105:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4172:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4170:0
-run_misc.at-4170-prog.cob:13.8-13.13:
-  10   
-  11           PROCEDURE DIVISION.
-  12   
-  13 >         ENTRY 'ent1'.
-----           ^^^^^
-  14           DISPLAY VAR1 END-DISPLAY
-  15           GOBACK.
->> Error: Invalid syntax
-
-run_misc.at-4170-prog.cob:17.8-17.13:
-  14           DISPLAY VAR1 END-DISPLAY
-  15           GOBACK.
-  16   
-  17 >         ENTRY 'ent2'.
-----           ^^^^^
-  18           DISPLAY VAR2 END-DISPLAY
-  19           GOBACK.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4171:0
-run_misc.at-4171-prog1.cob:13.8-13.13:
-  10   
-  11           PROCEDURE DIVISION.
-  12   
-  13 >         ENTRY 'ent2'.
-----           ^^^^^
-  14           DISPLAY VAR2 END-DISPLAY
-  15           GOBACK.
->> Error: Invalid syntax
-
-run_misc.at-4171-prog1.cob:17.8-17.13:
-  14           DISPLAY VAR2 END-DISPLAY
-  15           GOBACK.
-  16   
-  17 >         ENTRY 'ent3'.
-----           ^^^^^
-  18           DISPLAY VAR3 END-DISPLAY
-  19           GOBACK.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4217:0
-run_misc.at-4217-prog.cob:26.7-26.12:
-  23          END-IF
-  24          GOBACK.
-  25   
-  26 >        ENTRY "subprogram".
-----          ^^^^^
-  27              DISPLAY "subprogram" WITH NO ADVANCING
-  28              END-DISPLAY
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4242:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4243:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:4269:0
@@ -3366,16 +3316,6 @@ run_misc.at-7800-caller.cob:20.11-20.15:
 >> Warning: Invalid syntax
 
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:7794:0
-run_misc.at-7794-preload.cob:13.7-13.12:
-  10          SOME-PAR.
-  11              PERFORM OTHER-SEC
-  12              MOVE 0 TO RETURN-CODE.
-  13 >        ENTRY "LEAVE-ME".
-----          ^^^^^
-  14          END-PAR.
-  15              EXIT PROGRAM.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:7796:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:8103:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:8708:0
@@ -6824,125 +6764,45 @@ Considering: import/gnucobol/tests/testsuite.src/run_misc.at:13768:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:13799:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:13880:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:13943:0
-run_misc.at-13943-prog.cob:10.17-10.22:
-   7             88 EXT-MODUS  VALUES 3, 4.
-   8          LINKAGE SECTION.
-   9          PROCEDURE DIVISION.
-  10 >            GO TO ENTRY 'STMT05'.
-----                    ^^^^^
-  11          MAIN.
-  12              GO TO ENTRY 'STMT01'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:12.17-12.22:
+run_misc.at-13943-prog.cob:12.31:
    9          PROCEDURE DIVISION.
   10              GO TO ENTRY 'STMT05'.
   11          MAIN.
   12 >            GO TO ENTRY 'STMT01'
-----                    ^^^^^
+----                                  ^
   13                          'STMT02'
   14                          'STMT03'
->> Error: Invalid syntax
+>> Hint: Missing .
 
-run_misc.at-13943-prog.cob:20.7-20.12:
-  17              DEPENDING ON JUMP-ENTRY
+run_misc.at-13943-prog.cob:13.23-13.31:
+  10              GO TO ENTRY 'STMT05'.
+  11          MAIN.
+  12              GO TO ENTRY 'STMT01'
+  13 >                        'STMT02'
+----                          ^^^^^^^^
+  14                          'STMT03'
+  15                          'STMT04'
+>> Warning: Invalid syntax
+
+run_misc.at-13943-prog.cob:17.34:
+  14                          'STMT03'
+  15                          'STMT04'
+  16                          'STMT05'
+  17 >            DEPENDING ON JUMP-ENTRY
+----                                     ^
   18              DISPLAY 'NOT JUMPED'
   19              GOBACK.
-  20 >        ENTRY FOR GO TO 'STMT01'
-----          ^^^^^
-  21              DISPLAY 'STMT01'
-  22          ENTRY FOR GO TO 'STMT02'
->> Error: Invalid syntax
+>> Hint: Missing .
 
-run_misc.at-13943-prog.cob:20.23-20.31:
+run_misc.at-13943-prog.cob:18.11-18.18:
+  15                          'STMT04'
+  16                          'STMT05'
   17              DEPENDING ON JUMP-ENTRY
-  18              DISPLAY 'NOT JUMPED'
-  19              GOBACK.
-  20 >        ENTRY FOR GO TO 'STMT01'
-----                          ^^^^^^^^
-  21              DISPLAY 'STMT01'
-  22          ENTRY FOR GO TO 'STMT02'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:22.7-22.12:
+  18 >            DISPLAY 'NOT JUMPED'
+----              ^^^^^^^
   19              GOBACK.
   20          ENTRY FOR GO TO 'STMT01'
-  21              DISPLAY 'STMT01'
-  22 >        ENTRY FOR GO TO 'STMT02'
-----          ^^^^^
-  23              PERFORM 3 TIMES
-  24          ENTRY FOR GO TO 'STMT03'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:22.23-22.31:
-  19              GOBACK.
-  20          ENTRY FOR GO TO 'STMT01'
-  21              DISPLAY 'STMT01'
-  22 >        ENTRY FOR GO TO 'STMT02'
-----                          ^^^^^^^^
-  23              PERFORM 3 TIMES
-  24          ENTRY FOR GO TO 'STMT03'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:24.7-24.12:
-  21              DISPLAY 'STMT01'
-  22          ENTRY FOR GO TO 'STMT02'
-  23              PERFORM 3 TIMES
-  24 >        ENTRY FOR GO TO 'STMT03'
-----          ^^^^^
-  25                 DISPLAY 'STMT03'
-  26          ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:24.23-24.31:
-  21              DISPLAY 'STMT01'
-  22          ENTRY FOR GO TO 'STMT02'
-  23              PERFORM 3 TIMES
-  24 >        ENTRY FOR GO TO 'STMT03'
-----                          ^^^^^^^^
-  25                 DISPLAY 'STMT03'
-  26          ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:26.7-26.12:
-  23              PERFORM 3 TIMES
-  24          ENTRY FOR GO TO 'STMT03'
-  25                 DISPLAY 'STMT03'
-  26 >        ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
-----          ^^^^^
-  27                 IF EXT-MODUS EXIT PERFORM END-IF
-  28              END-PERFORM
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:26.23-26.31:
-  23              PERFORM 3 TIMES
-  24          ENTRY FOR GO TO 'STMT03'
-  25                 DISPLAY 'STMT03'
-  26 >        ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
-----                          ^^^^^^^^
-  27                 IF EXT-MODUS EXIT PERFORM END-IF
-  28              END-PERFORM
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:29.7-29.12:
-  26          ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
-  27                 IF EXT-MODUS EXIT PERFORM END-IF
-  28              END-PERFORM
-  29 >        ENTRY FOR GO TO 'STMT05'
-----          ^^^^^
-  30              DISPLAY 'STMT05'
-  31              SUBTRACT 1 FROM JUMP-ENTRY
->> Error: Invalid syntax
-
-run_misc.at-13943-prog.cob:29.23-29.31:
-  26          ENTRY FOR GO TO 'STMT04'  DISPLAY 'STMT04'
-  27                 IF EXT-MODUS EXIT PERFORM END-IF
-  28              END-PERFORM
-  29 >        ENTRY FOR GO TO 'STMT05'
-----                          ^^^^^^^^
-  30              DISPLAY 'STMT05'
-  31              SUBTRACT 1 FROM JUMP-ENTRY
->> Error: Invalid syntax
+>> Warning: Invalid syntax
 
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:14022:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:14053:0


### PR DESCRIPTION
The ENTRY statement was not recognised by the grammar in lines such as:
```cobol
     entry    "delfolioMT" using   File-Access ACAS-DAL-Common-data DUMMY-REC.
```
coming from [ACAS](https://sourceforge.net/projects/acas/) in `dummy-rdbmsMT.cbl:127`.

Something I am not very sure of is that I ignored string literals in the visitors.

References:
- [GnuCOBOL parser.y](https://github.com/OCamlPro/gnucobol/blob/gcos4gnucobol-3.x/cobc/parser.y)
- [Microfocus documentation](https://www.microfocus.com/documentation/visual-cobol/vc50all/VS2019/HRLHLHPDF902.html)