### PR TITLE
Fix ALTERNATE clause of SELECT statement

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -896,7 +896,7 @@ let access_mode :=
  | SEQUENTIAL; {AccessModeSequential}
 
 let alternate_record_key_clause :=
- | ALTERNATE; RECORD; KEY?; IS?; i = qualname;
+ | ALTERNATE; RECORD?; KEY?; IS?; i = qualname;
    il = lo(pf(SOURCE; IS?; {}, names));
    wd = with_duplicates;
    { SelectAlternateRecordKey { key = i; source = il;

--- a/test/output-tests/syn_file.expected
+++ b/test/output-tests/syn_file.expected
@@ -119,46 +119,6 @@ syn_file.at-575-prog.cob:20.38-20.42:
 >> Error: Invalid syntax
 
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:628:0
-syn_file.at-628-prog.cob:11.33:
-   8                           ORGANIZATION  IS INDEXED
-   9                           ACCESS MODE   IS DYNAMIC
-  10                           RECORD    KEY IS TEST-P2 IN TEST-SOME
-  11 >                         ALTERNATE KEY IS TEST-P3 IN TEST-SOME.
-----                                    ^
-  12          SELECT TEST-FILE ASSIGN TO 'FILE-TEST2'
-  13                           ORGANIZATION  IS INDEXED
->> Hint: Missing RECORD
-
-syn_file.at-628-prog.cob:11.34-11.37:
-   8                           ORGANIZATION  IS INDEXED
-   9                           ACCESS MODE   IS DYNAMIC
-  10                           RECORD    KEY IS TEST-P2 IN TEST-SOME
-  11 >                         ALTERNATE KEY IS TEST-P3 IN TEST-SOME.
-----                                     ^^^
-  12          SELECT TEST-FILE ASSIGN TO 'FILE-TEST2'
-  13                           ORGANIZATION  IS INDEXED
->> Error: Invalid syntax
-
-syn_file.at-628-prog.cob:16.33:
-  13                           ORGANIZATION  IS INDEXED
-  14                           ACCESS MODE   IS DYNAMIC
-  15                           RECORD    KEY IS TEST-P1
-  16 >                         ALTERNATE KEY IS TEST-P4.
-----                                    ^
-  17          DATA             DIVISION.
-  18          FILE             SECTION.
->> Hint: Missing RECORD
-
-syn_file.at-628-prog.cob:16.34-16.37:
-  13                           ORGANIZATION  IS INDEXED
-  14                           ACCESS MODE   IS DYNAMIC
-  15                           RECORD    KEY IS TEST-P1
-  16 >                         ALTERNATE KEY IS TEST-P4.
-----                                     ^^^
-  17          DATA             DIVISION.
-  18          FILE             SECTION.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:783:0
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:798:0
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:962:0
@@ -282,26 +242,6 @@ syn_file.at-2062-prog.cob:24.48-24.50:
 
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:2092:0
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:2121:0
-syn_file.at-2121-prog.cob:12.23:
-   9                 ACCESS        DYNAMIC
-  10                 ORGANIZATION  INDEXED
-  11                 RECORD     KEY  TESTKEY1
-  12 >               ALTERNATE  KEY  TESTKEY2
-----                          ^
-  13                 .
-  14          PROCEDURE DIVISION.
->> Hint: Missing RECORD
-
-syn_file.at-2121-prog.cob:12.25-12.28:
-   9                 ACCESS        DYNAMIC
-  10                 ORGANIZATION  INDEXED
-  11                 RECORD     KEY  TESTKEY1
-  12 >               ALTERNATE  KEY  TESTKEY2
-----                            ^^^
-  13                 .
-  14          PROCEDURE DIVISION.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/syn_file.at:2203:0
 syn_file.at-2203-prog.cob:16.18:
   13                    WITH DUPLICATES


### PR DESCRIPTION
I followed [GnuCOBOL's](https://github.com/OCamlPro/gnucobol/blob/89c45a3bc80c2ca6302382bd40fdc585436d65f9/cobc/parser.y#L5635) syntax where not only `KEY` but also `RECORD` is optional.

Such syntax is used in [BankDemo](https://github.com/MicroFocus/BankDemo/blob/c1d49ed2fc9285d6da3b25f01e8265aa86747847/sources/cobol/core/ZBNKLOAD.cbl#L77).