### PR TITLE
Fix handling of verbosity flag

### DIFF
--- a/src/lsp/superbol_free_lib/common_args.ml
+++ b/src/lsp/superbol_free_lib/common_args.ml
@@ -115,8 +115,8 @@ let get () =
     EZCMD.info ~docv:"DIRECTORY" "Add DIRECTORY to library search path";
   ] in
 
-  let verbose = !Globals.verbosity > 0 in
   let get () =
+    let verbose = !Globals.verbosity > 0 in
     let config =
       DIAGS.show_n_forget @@
       match !conf, !dialect with


### PR DESCRIPTION
That was mistakenly moved to a place that made the CLI tool ignore any `--verbose` argument.

Obviously that means we're not testing this…