### PR TITLE
Simplify handling of RECORDING MODE clause

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -1283,7 +1283,7 @@ record_clause:
      VariableLength { min_length; max_length; depending } }
 
 let recording_mode_clause [@context recording_mode_clause] :=
- | RECORDING; MODE; IS; ~ = recording_mode; <RecordingMode>
+ | RECORDING; MODE; IS; ~ = recording_mode; < >
 
 let recording_mode :=
  | F;        { ModeFixed }

--- a/src/lsp/cobol_ptree/data_descr.ml
+++ b/src/lsp/cobol_ptree/data_descr.ml
@@ -73,19 +73,11 @@ type recording_mode =
   | ModeVariable
 [@@deriving ord]
 
-type recording_mode_clause =
-  | RecordingMode of recording_mode
-[@@deriving ord]
-
 let pp_recording_mode ppf = function
   | ModeFixedOrVariable -> Fmt.pf ppf "U"
   | ModeSpanned         -> Fmt.pf ppf "S"
   | ModeFixed           -> Fmt.pf ppf "FIXED"
   | ModeVariable        -> Fmt.pf ppf "VARIABLE"
-
-let pp_recording_mode_clause ppf = function
-  | RecordingMode mode ->
-    Fmt.pf ppf "RECORDING MODE IS %a" pp_recording_mode mode
 
 type label_clause =
   | LabelStandard

--- a/src/lsp/cobol_ptree/data_descr_visitor.ml
+++ b/src/lsp/cobol_ptree/data_descr_visitor.ml
@@ -63,7 +63,7 @@ class ['a] folder = object
   method fold_property_clause           : (property_clause             , 'a) fold = default
   method fold_property_kind             : (property_kind               , 'a) fold = default
   method fold_record_clause             : (record_clause               , 'a) fold = default
-  method fold_recording_mode_clause     : (recording_mode_clause       , 'a) fold = default
+  method fold_recording_mode            : (recording_mode              , 'a) fold = default
   method fold_report_clause             : (report_clause               , 'a) fold = default
   method fold_report_clause'            : (report_clause with_loc      , 'a) fold = default
   method fold_report_data_name_or_final : (report_data_name_or_final   , 'a) fold = default
@@ -288,14 +288,8 @@ let fold_record_clause (v: _ #folder) =
           >> fold_integer v max_length
     end
 
-let fold_recording_mode_clause (v: _ #folder) =
-  handle v#fold_recording_mode_clause
-    ~continue:begin fun (RecordingMode mode) x -> match mode with
-      | ModeFixedOrVariable
-      | ModeSpanned
-      | ModeFixed
-      | ModeVariable -> x
-    end
+let fold_recording_mode (v: _ #folder) =
+  leaf v#fold_recording_mode
 
 let fold_report_clause (v: _ #folder) =
   handle v#fold_report_clause

--- a/src/lsp/cobol_ptree/data_sections.ml
+++ b/src/lsp/cobol_ptree/data_sections.ml
@@ -445,7 +445,7 @@ and file_fd_clause =
         contents: file_block_contents;
       }
   | FileRecord of record_clause
-  | FileRecordingMode of recording_mode_clause
+  | FileRecordingMode of recording_mode
   | FileLabel of label_clause
   | FileValueOf of valueof_clause list
   | FileData of file_data_clause
@@ -469,7 +469,9 @@ let pp_file_fd_clause ppf = function
         Fmt.(option (any "@ TO " ++ pp_integer)) to_
         pp_file_block_contents contents
   | FileRecord rc -> pp_record_clause ppf rc
-  | FileRecordingMode md -> pp_recording_mode_clause ppf md
+  | FileRecordingMode md ->
+      Fmt.pf ppf "RECORDING MODE IS %a"
+      pp_recording_mode md
   | FileLabel lc -> pp_label_clause ppf lc
   | FileValueOf vcl ->
       Fmt.pf ppf "VALUE OF %a"

--- a/src/lsp/cobol_ptree/data_sections_visitor.ml
+++ b/src/lsp/cobol_ptree/data_sections_visitor.ml
@@ -217,7 +217,7 @@ let fold_file_fd_clause (v: _ #folder) =
       | FileRecord c -> x
           >> Data_descr_visitor.fold_record_clause v c
       | FileRecordingMode m -> x
-          >> Data_descr_visitor.fold_recording_mode_clause v m
+          >> Data_descr_visitor.fold_recording_mode v m
       | FileLabel c -> x
           >> Data_descr_visitor.fold_label_clause v c
       | FileValueOf c -> x


### PR DESCRIPTION
The `RECORDING MODE` clause used a single-constructor type

```ocaml
  type recording_mode_clause =
    | RecordingMode of recording_mode
```

which was not necessary. A visitor and pretty printer was defined for it but I pushed those one level upper (in data sections). 