### PR TITLE
Fix optional IS in RECORDING MODE

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -1285,7 +1285,7 @@ record_clause:
      VariableLength { min_length; max_length; depending } }
 
 let recording_mode_clause [@context recording_mode_clause] :=
- | RECORDING; MODE; IS; ~ = recording_mode; < >
+ | RECORDING; MODE; IS?; ~ = recording_mode; < >
 
 let recording_mode :=
  | F;        { ModeFixed }

--- a/test/output-tests/reparse.expected
+++ b/test/output-tests/reparse.expected
@@ -79,7 +79,7 @@ Re-parsing `test/testsuite/ibm/ibmmainframes.com/cob12.cbl':
 Re-parsing `test/testsuite/ibm/ibmmainframes.com/cob13.cbl':
  Parse: OK. Reparse: OK.
 Re-parsing `test/testsuite/ibm/ibmmainframes.com/cob14.cbl':
- Parse: Failure.
+ Parse: OK. Reparse: OK.
 Re-parsing `test/testsuite/ibm/ibmmainframes.com/cob15.cbl':
  Parse: OK. Reparse: OK.
 Re-parsing `test/testsuite/ibm/ibmmainframes.com/cob16.cbl':


### PR DESCRIPTION
The keyword `IS` can be optional in `RECORDING MODE`.

This syntax occurs in `ACAS/common/acas-get-params.cbl:105`. For instance:

```cobol
 FD  ACAS-Params
     recording mode variable.
```