### PR TITLE
Use alphanum instead of alphanum_string in ENTRY statement

### DIFF
--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -4254,11 +4254,11 @@ let entry_by_clauses :=
 let entry_statement :=
  | ENTRY; ~ = entry_body; <Entry>
 let entry_body :=
- | ~ = loc(alphanum); <EntrySimple>
- | n = loc(alphanum); USING; clauses = rnel(entry_by_clauses);
+ | ~ = loc(alphanum_literal); <EntrySimple>
+ | n = loc(alphanum_literal); USING; clauses = rnel(entry_by_clauses);
    { EntryUsing { entry_name = n;
                   entry_by_clauses = clauses } }
- | FOR; GO; TO; ~ = loc(alphanum); <EntryForGoTo>
+ | FOR; GO; TO; ~ = loc(alphanum_literal); <EntryForGoTo>
 
 
 (* EXEC / END-EXEC block (unexpanded) *)

--- a/src/lsp/cobol_ptree/simple_statements.ml
+++ b/src/lsp/cobol_ptree/simple_statements.ml
@@ -123,13 +123,13 @@ type entry_by_clause =
 [@@deriving ord]
 
 type entry_stmt =
-  | EntrySimple of alphanum_string with_loc
+  | EntrySimple of alphanum with_loc
   | EntryUsing of
     {
-      entry_name: alphanum_string with_loc;
+      entry_name: alphanum with_loc;
       entry_by_clauses: entry_by_clause list;
     }
-  | EntryForGoTo of alphanum_string with_loc
+  | EntryForGoTo of alphanum with_loc
 [@@deriving ord]
 
 let pp_entry_by_clause ppf = function
@@ -140,14 +140,14 @@ let pp_entry_by_clause ppf = function
 
 let pp_entry_stmt ppf = function
   | EntrySimple name ->
-    Fmt.pf ppf "ENTRY@ %a" (pp_with_loc pp_alphanum_string) name
+    Fmt.pf ppf "ENTRY@ %a" (pp_with_loc pp_alphanum) name
   | EntryUsing { entry_name; entry_by_clauses } ->
     Fmt.pf ppf "ENTRY@ %a%a"
-      (pp_with_loc pp_alphanum_string) entry_name
+      (pp_with_loc pp_alphanum) entry_name
       Fmt.(list ~sep:nop (sp ++ pp_entry_by_clause)) entry_by_clauses
   | EntryForGoTo entry_name ->
     Fmt.pf ppf "ENTRY@ FOR GO TO %a"
-      (pp_with_loc pp_alphanum_string) entry_name
+      (pp_with_loc pp_alphanum) entry_name
 
 (* EXIT *)
 type exit_stmt =

--- a/src/lsp/cobol_ptree/statements_visitor.ml
+++ b/src/lsp/cobol_ptree/statements_visitor.ml
@@ -999,8 +999,10 @@ and fold_entry_by_clause (v: _ #folder) : entry_by_clause -> 'a -> 'a =
 and fold_entry' (v: _ #folder) : entry_stmt with_loc -> 'a -> 'a =
   handle' v#fold_entry' v
     ~fold:begin fun v stmt x -> match stmt with
-      | EntrySimple _name -> x
-      | EntryUsing { entry_name = _; entry_by_clauses } -> x
+      | EntrySimple name -> x
+        >> fold_alphanum' v name 
+      | EntryUsing { entry_name; entry_by_clauses } -> x
+        >> fold_alphanum' v entry_name
         >> fold_list ~fold:fold_entry_by_clause v entry_by_clauses
       | EntryForGoTo _entry_name -> x
     end


### PR DESCRIPTION
The point was to make the code coherent with [pull request #256](https://github.com/OCamlPro/superbol-studio-oss/pull/256).