### PR TITLE
Use per-language scanners for `EXEC`/`END-EXEC` blocks

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-4f8f98b9b1774084269015155b53c175:.
+ac7d886fc3dfd07fda915e4f91fb8743:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -80,8 +80,7 @@ c8281f46ba9a11d0b61bc8ef67eaa357:docs/style.css
 
 # begin context for dune-project
 # file dune-project
-afda02ca8769d29e6d635902a5980764:dune-project
-ba662e430c51d699aff2a7eab529f3fa:dune-project
+36cd02a1362d6a97e537b292d4f89fb1:dune-project
 # end context for dune-project
 
 # begin context for opam/cobol_common.opam
@@ -201,7 +200,7 @@ eaa52762ea6a03491c05ce8a833dbdf6:opam/superbol-free.opam
 
 # begin context for opam/superbol_preprocs.opam
 # file opam/superbol_preprocs.opam
-f066a097fba430a14086affb7b678c65:opam/superbol_preprocs.opam
+8338f1ad09b3d2aa0c8c2e5ed386e88e:opam/superbol_preprocs.opam
 # end context for opam/superbol_preprocs.opam
 
 # begin context for opam/superbol_project.opam
@@ -451,7 +450,7 @@ bc7d6018a6cdcfb9209efd8d5aeacb95:src/lsp/superbol_free_lib/version.mlt
 
 # begin context for src/lsp/superbol_preprocs/dune
 # file src/lsp/superbol_preprocs/dune
-f695b1b5982172b95675d738fabd8cb0:src/lsp/superbol_preprocs/dune
+f5b7c58bbac13fe6141368414f4cb96f:src/lsp/superbol_preprocs/dune
 # end context for src/lsp/superbol_preprocs/dune
 
 # begin context for src/lsp/superbol_preprocs/version.mlt

--- a/dune-project
+++ b/dune-project
@@ -208,6 +208,7 @@
    (ocaml (>= 4.14.0))
    (pretty (= version))
    (cobol_preproc (= version))
+   (cobol_parser (= version))
    (cobol_common (= version))
    odoc
   )

--- a/opam/superbol_preprocs.opam
+++ b/opam/superbol_preprocs.opam
@@ -47,6 +47,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "pretty" {= version}
   "cobol_preproc" {= version}
+  "cobol_parser" {= version}
   "cobol_common" {= version}
   "odoc" {with-doc}
 ]

--- a/src/lsp/cobol_lsp/lsp_document.ml
+++ b/src/lsp/cobol_lsp/lsp_document.ml
@@ -70,7 +70,7 @@ let uri { textdoc; _ } = Lsp.Text_document.documentUri textdoc
 let rewindable_parse ({ project; textdoc; _ } as doc) =
   Cobol_parser.rewindable_parse_with_artifacts
     ~options:Cobol_parser.Options.{
-        (default ~exec_scanner: Superbol_preprocs.Generic.scanner) with
+        (default ~exec_scanners: Superbol_preprocs.exec_scanners) with
         recovery = EnableRecovery { silence_benign_recoveries = true };
         config = project.config.cobol_config;
       } @@

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -95,7 +95,7 @@ and 'm persist =
 
 (** Initializes a parser state, given a preprocessor. *)
 let make_parser
-    (type m) Parser_options.{ verbose; show; recovery; config; exec_scanner }
+    (type m) Parser_options.{ verbose; show; recovery; config; exec_scanners }
     ?show_if_verbose ~(tokenizer_memory: m memory) pp =
   let tokzr: m Tokzr.state =
     let memory: m Tokzr.memory = match tokenizer_memory with
@@ -103,7 +103,7 @@ let make_parser
       | Parser_options.Eidetic -> Tokzr.eidetic
     in
     let module Config = (val config) in
-    Tokzr.init ~verbose ?show_if_verbose ~exec_scanner ~memory Config.words
+    Tokzr.init ~verbose ?show_if_verbose ~exec_scanners ~memory Config.words
   in
   {
     prev_limit = None;

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -47,7 +47,7 @@ type 'a state
 val init
   : ?verbose:bool
   -> ?show_if_verbose:[> `Tks | `Ctx] list
-  -> exec_scanner: Parser_options.exec_scanner
+  -> exec_scanners: Parser_options.exec_scanners
   -> memory:'a memory
   -> Cobol_config.words_spec
   -> 'a state

--- a/src/lsp/superbol_free_lib/common_args.ml
+++ b/src/lsp/superbol_free_lib/common_args.ml
@@ -164,7 +164,7 @@ let get () =
                           exec_preprocs = EXEC_MAP.empty;
                           libpath = !libpath; env };
       parser_options = { config; recovery; verbose; show = !show;
-                         exec_scanner = Superbol_preprocs.Generic.scanner } }
+                         exec_scanners = Superbol_preprocs.exec_scanners } }
 
   in
   get, args

--- a/src/lsp/superbol_preprocs/dune
+++ b/src/lsp/superbol_preprocs/dune
@@ -5,7 +5,7 @@
   (public_name superbol_preprocs)
   (wrapped true)
   ; use field 'dune-libraries' to add libraries without opam deps
-  (libraries pretty cobol_preproc cobol_common )
+  (libraries pretty cobol_preproc cobol_parser cobol_common )
   ; use field 'dune-flags' to set this value
   (flags (:standard))
   ; use field 'dune-stanzas' to add more stanzas here

--- a/src/lsp/superbol_preprocs/generic.ml
+++ b/src/lsp/superbol_preprocs/generic.ml
@@ -30,4 +30,5 @@ let () =
           None
     end
 
-let scanner text = Generic_exec_block text
+let scanner =
+  Cobol_parser.Options.Stateless_exec_scanner (fun text -> Generic_exec_block text)

--- a/src/lsp/superbol_preprocs/main.ml
+++ b/src/lsp/superbol_preprocs/main.ml
@@ -11,6 +11,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Generic = Generic
-
-include Main
+let exec_scanners =
+  Cobol_parser.Options.{
+    exec_scanner_fallback = Generic.scanner;  (* for now; TODO: Call.scanner? *)
+    exec_scanners = Cobol_preproc.Options.EXEC_MAP.empty;
+  }

--- a/src/lsp/superbol_preprocs/package.toml
+++ b/src/lsp/superbol_preprocs/package.toml
@@ -55,6 +55,7 @@ skip = ["index.mld"]
 [dependencies]
 cobol_common = "version"
 cobol_preproc = "version"
+cobol_parser = "version"
 pretty = "version"
 
 # package tools dependencies

--- a/test/cobol_parsing/parser_testing.ml
+++ b/test/cobol_parsing/parser_testing.ml
@@ -29,7 +29,7 @@ let preproc
 
 let default_parser_options =
   Cobol_parser.Options.default
-    ~exec_scanner:Superbol_preprocs.Generic.scanner
+    ~exec_scanners: Superbol_preprocs.exec_scanners
 
 let show_parsed_tokens ?(verbose = false) ?(with_locations = false)
     ?source_format ?filename contents =

--- a/test/output-tests/gnucobol.ml
+++ b/test/output-tests/gnucobol.ml
@@ -175,7 +175,7 @@ let guess_source_format ~filename ~command =   (* hackish detection of format *)
 
 let default_parser_options =
   Cobol_parser.Options.default
-    ~exec_scanner:Superbol_preprocs.Generic.scanner
+    ~exec_scanners: Superbol_preprocs.exec_scanners
 
 
 let do_check_parse (test_filename, contents, _, { check_loc;

--- a/test/output-tests/reparse.ml
+++ b/test/output-tests/reparse.ml
@@ -18,7 +18,7 @@ open Testsuite_utils
 
 let default_parser_options =
   Cobol_parser.Options.{
-    (default ~exec_scanner:Superbol_preprocs.Generic.scanner) with
+    (default ~exec_scanners: Superbol_preprocs.exec_scanners) with
     recovery = DisableRecovery
   }
 


### PR DESCRIPTION
Also add the ability to pass some state upon each successive scan of blocks for the same language.