### PR TITLE
Bugfix: handle contexts that terminate upon shift instead of reduce

### DIFF
--- a/test/cobol_parsing/cS_tokens.ml
+++ b/test/cobol_parsing/cS_tokens.ml
@@ -133,3 +133,23 @@ let%expect_test "context-sensitive-tokens-lower-case" =
     DIGITS[01], WORD[X], CONSTANT, BYTE-LENGTH, WORD[BYTE-LENGTH], ., PROCEDURE,
     DIVISION, ., EOF
 |}];;
+
+let%expect_test "context-sensitive-tokens-weird-exit" =
+  Parser_testing.show_parsed_tokens {|
+       PROGRAM-ID.        prog.
+       DATA               DIVISION.
+       WORKING-STORAGE    SECTION.
+       01  X              CONSTANT IS GLOBAL 666.
+       01  Y              CONSTANT 999.
+       77  BYTE-LENGTH    PIC X VALUE "A".
+       PROCEDURE          DIVISION.
+           DISPLAY BYTE-LENGTH.
+           STOP RUN.
+  |};
+  [%expect {|
+    PROGRAM-ID, ., INFO_WORD[prog], ., DATA, DIVISION, ., WORKING-STORAGE,
+    SECTION, ., DIGITS[01], WORD[X], CONSTANT, IS_GLOBAL, DIGITS[666], .,
+    DIGITS[01], WORD[Y], CONSTANT, DIGITS[999], ., DIGITS[77], WORD[BYTE-LENGTH],
+    PICTURE, PICTURE_STRING[X], VALUE, "A", ., PROCEDURE, DIVISION, ., DISPLAY,
+    WORD[BYTE-LENGTH], ., STOP, RUN, ., EOF
+|}];;


### PR DESCRIPTION
Fixing that was an epic fight :sweat_smile:.

Before these changes, some contexts were not exited properly. For instance `01 x CONSTANT 12345.` entered context `constant`, but did not leave it. The reason was simple: this context is here left via a shift instead of a reduction, which was previously though as the only means for a grammar rule to be left. The latter assumption turned out to be wrong, and this PR addresses this issue.

Prior to this PR, the new test failed, with the `BYTE-LENGTH` words wrongly recognized as keywords.