### PR TITLE
Alphanumeric names for more COBOL units

### DIFF
--- a/src/lsp/cobol_data/data_visitor.ml
+++ b/src/lsp/cobol_data/data_visitor.ml
@@ -71,7 +71,7 @@ let fold_usage (v: _ #folder) =
       | Packed_decimal pic ->
           fold_picture v pic
       | Function_pointer name
-      | Object_reference Some Name { class_or_interface_name = name; _ }
+      | Object_reference Some NamedClass { class_or_interface_name = name; _ }
       | Pointer Some name
       | Program_pointer Some name ->
           Cobol_ptree.Terms_visitor.fold_name' v name

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -241,13 +241,19 @@ let preproc_n_combine_tokens ~source_format =
     | [CONSTANT]                     -> Error `MissingInputs
     | CONSTANT :: RECORD :: _          -> subst_n CONSTANT_RECORD 2
 
-    | [PROGRAM_ID]
-    | [PROGRAM_ID; PERIOD]           -> Error `MissingInputs
-    | PROGRAM_ID :: PERIOD :: _        -> info_word_after 2
-    | PROGRAM_ID :: _                  -> info_word_after 1
+    | PROGRAM_ID :: PERIOD :: _
+    | FUNCTION_ID :: PERIOD :: _
+    | CLASS_ID :: PERIOD :: _
+    | INTERFACE_ID :: PERIOD :: _      -> info_word_after 2
 
-    | [END] | [END; PROGRAM]         -> Error `MissingInputs
-    | END :: PROGRAM :: _              -> info_word_after 2
+    | PROGRAM_ID :: _
+    | FUNCTION_ID :: _                -> info_word_after 1
+
+    | [END]                          -> Error `MissingInputs
+    | END :: PROGRAM :: _
+    | END :: FUNCTION :: _
+    | END :: CLASS :: _
+    | END :: INTERFACE :: _            -> info_word_after 2
 
     | [AUTHOR | INSTALLATION |
        DATE_WRITTEN | DATE_MODIFIED |

--- a/src/lsp/cobol_ptree/compilation_group_visitor.ml
+++ b/src/lsp/cobol_ptree/compilation_group_visitor.ml
@@ -102,14 +102,14 @@ let fold_function_unit (v: _#folder) =
     ~continue:begin fun { function_name; function_as; function_is_proto;
                           function_options; function_env; function_data;
                           function_proc; function_end_name } x -> x
-      >> fold_name' v function_name
+      >> fold_name_or_literal' v function_name
       >> fold_strlit_opt v function_as
       >> fold_bool v function_is_proto                      (* XXX: useful? *)
       >> fold_options_paragraph'_opt v function_options
       >> fold_environment_division'_opt v function_env
       >> fold_data_division'_opt v function_data
       >> fold_procedure_division'_opt v function_proc
-      >> fold_name' v function_end_name                     (* XXX: useful? *)
+      >> fold_name_or_literal' v function_end_name            (* XXX: useful? *)
     end
 
 let fold_function_unit' (v: _#folder) =
@@ -136,7 +136,7 @@ let fold_method_definition (v: _#folder) =
       >> fold_environment_division'_opt v method_env
       >> fold_data_division'_opt v method_data
       >> fold_procedure_division'_opt v method_proc
-      >> fold_name' v method_end_name                       (* XXX: useful? *)
+      >> fold_name' v method_end_name                         (* XXX: useful? *)
     end
 
 let fold_method_definitions (v: _#folder) =
@@ -175,7 +175,7 @@ let fold_class_definition' (v: _#folder) =
     ~fold:begin fun v { class_name; class_as; class_final; class_inherits;
                         class_usings; class_options; class_env;
                         class_factory; class_instance; class_end_name } x -> x
-      >> fold_name' v class_name
+      >> fold_name_or_literal' v class_name
       >> fold_strlit_opt v class_as
       >> fold_bool v class_final
       >> fold_name'_list v class_inherits
@@ -184,7 +184,7 @@ let fold_class_definition' (v: _#folder) =
       >> fold_environment_division'_opt v class_env
       >> fold_option ~fold:fold_factory_definition v class_factory
       >> fold_option ~fold:fold_instance_definition v class_instance
-      >> fold_name' v class_end_name
+      >> fold_name_or_literal' v class_end_name
     end
 
 let fold_interface_definition' (v: _#folder) =
@@ -192,14 +192,14 @@ let fold_interface_definition' (v: _#folder) =
     ~fold:begin fun v { interface_name; interface_as; interface_inherits;
                         interface_usings; interface_options; interface_env;
                         interface_methods; interface_end_name } x -> x
-      >> fold_name' v interface_name
+      >> fold_name_or_literal' v interface_name
       >> fold_strlit_opt v interface_as
       >> fold_name'_list v interface_inherits
       >> fold_name'_list v interface_usings
       >> fold_options_paragraph'_opt v interface_options
       >> fold_environment_division'_opt v interface_env
       >> fold_method_definitions'_opt v interface_methods
-      >> fold_name' v interface_end_name
+      >> fold_name_or_literal' v interface_end_name
     end
 
 let fold_compilation_unit' (v: _#folder) =

--- a/src/lsp/cobol_ptree/data_descr.ml
+++ b/src/lsp/cobol_ptree/data_descr.ml
@@ -387,7 +387,7 @@ and object_reference_kind =
       {
         factory_of: bool;
       }
-  | Name of
+  | NamedClass of
       {
         class_or_interface_name: name with_loc;
         factory_of: bool;
@@ -418,7 +418,7 @@ let pp_object_reference_kind ppf = function
   | ActiveClass { factory_of } ->
     if factory_of then Fmt.pf ppf "FACTORY OF ";
     Fmt.pf ppf "ACTIVE-CLASS"
-  | Name { class_or_interface_name = n; factory_of; only } ->
+  | NamedClass { class_or_interface_name = n; factory_of; only } ->
     if factory_of then Fmt.pf ppf "FACTORY OF ";
     pp_name' ppf n;
     if only then Fmt.pf ppf " ONLY"

--- a/src/lsp/cobol_ptree/data_descr_visitor.ml
+++ b/src/lsp/cobol_ptree/data_descr_visitor.ml
@@ -257,7 +257,7 @@ let fold_object_reference_kind (v: _ #folder) =
     ~continue:begin function
       | ActiveClass _ ->
           Fun.id                                             (* consider leaf *)
-      | Name { class_or_interface_name; _ } ->
+      | NamedClass { class_or_interface_name; _ } ->
           fold_name' v class_or_interface_name
     end
 

--- a/src/lsp/cobol_typeck/old_env_builder.ml
+++ b/src/lsp/cobol_typeck/old_env_builder.ml
@@ -88,6 +88,7 @@ let initialize_prog_env =
 (* TODO: avoid returning `options with_diags` *)
 let for_compilation_unit =
   let build_env ?parent_env name env =
+    let name = Cobol_ptree.program_name' name in
     let prog_env = Cobol_data.PROG_ENV.make ?parent:parent_env ~&name in
     Visitor.skip @@
     DIAGS.map_result ~f:Option.some (initialize_prog_env env prog_env)
@@ -95,12 +96,12 @@ let for_compilation_unit =
   let env_builder = object
     inherit [_] Cobol_ptree.Visitor.folder
     method! fold_program_unit { program_name = name; program_env = env; _ } =
-      let name = Cobol_ptree.program_name' name in
       acc_result @@ fun parent_env -> build_env name env ?parent_env
     method! fold_function_unit f =
       acc_result @@ fun _ -> build_env f.function_name f.function_env
     method! fold_method_definition m =
-      acc_result @@ fun _ -> build_env m.method_name m.method_env
+      acc_result @@ fun _ -> build_env (Name m.method_name &@<-
+                                        m.method_name) m.method_env
     method! fold_class_definition' { payload = c; _ } =
       acc_result @@ fun _ -> build_env c.class_name c.class_env
     method! fold_interface_definition' { payload = i; _ } =

--- a/src/lsp/cobol_typeck/old_prog_builder.ml
+++ b/src/lsp/cobol_typeck/old_prog_builder.ml
@@ -25,10 +25,11 @@ module CU = Cobol_data.Compilation_unit
 module CUs = CU.SET
 
 let name_of_compilation_unit = function
-  | Program { program_name = name; _ } -> Cobol_ptree.program_name ~&name
+  | Program { program_name = name; _ }
   | Function { function_name = name; _ }
   | ClassDefinition { class_name = name; _ }
-  | InterfaceDefinition { interface_name = name; _ } -> ~&name
+  | InterfaceDefinition { interface_name = name; _ } ->
+      Cobol_ptree.program_name ~&name
 
 let register_cu ~cu_name ~cu_loc ~cu_env ~cu_wss (parents, progs) =
   let prog = CU.{ cu_name; cu_loc; cu_env; cu_wss } in

--- a/src/lsp/cobol_typeck/typeck_units.ml
+++ b/src/lsp/cobol_typeck/typeck_units.ml
@@ -21,13 +21,11 @@ module CUs = Cobol_unit.Collections.SET
 module CUMap = Cobol_unit.Collections.MAP
 
 let name_of_compilation_unit: Cobol_ptree.compilation_unit -> _ = function
-  | Program { program_name = name; _ } ->
-    let loc = ~@ name in
-    let name = Pretty.to_string "%a" Cobol_ptree.pp_name_or_literal ~&name in
-    name &@ loc
+  | Program { program_name = name; _ }
   | Function { function_name = name; _ }
   | ClassDefinition { class_name = name; _ }
-  | InterfaceDefinition { interface_name = name; _ } -> name
+  | InterfaceDefinition { interface_name = name; _ } ->
+      Pretty.to_string "%a" Cobol_ptree.pp_name_or_literal ~&name &@<- name
 
 type acc =
   {

--- a/test/output-tests/run_fundamental.expected
+++ b/test/output-tests/run_fundamental.expected
@@ -297,22 +297,22 @@ run_fundamental.at-1494-prog.cob:12.11-12.15:
   14          END FUNCTION reply.
 >> Error: Invalid syntax
 
+run_fundamental.at-1494-prog.cob:12.24:
+   9          01 result.
+  10             05 filler PIC X OCCURS 0 to 999 DEPENDING ON arg-len.
+  11          PROCEDURE DIVISION USING BY REFERENCE argument RETURNING result.
+  12 >            MOVE FUNCTION LENGTH (argument) TO arg-len
+----                           ^
+  13              MOVE argument TO result.
+  14          END FUNCTION reply.
+>> Hint: Missing <word>
+
 run_fundamental.at-1494-prog.cob:12.25-12.31:
    9          01 result.
   10             05 filler PIC X OCCURS 0 to 999 DEPENDING ON arg-len.
   11          PROCEDURE DIVISION USING BY REFERENCE argument RETURNING result.
   12 >            MOVE FUNCTION LENGTH (argument) TO arg-len
 ----                            ^^^^^^
-  13              MOVE argument TO result.
-  14          END FUNCTION reply.
->> Error: Invalid syntax
-
-run_fundamental.at-1494-prog.cob:12.41-12.42:
-   9          01 result.
-  10             05 filler PIC X OCCURS 0 to 999 DEPENDING ON arg-len.
-  11          PROCEDURE DIVISION USING BY REFERENCE argument RETURNING result.
-  12 >            MOVE FUNCTION LENGTH (argument) TO arg-len
-----                                            ^
   13              MOVE argument TO result.
   14          END FUNCTION reply.
 >> Error: Invalid syntax

--- a/test/output-tests/syn_functions.expected
+++ b/test/output-tests/syn_functions.expected
@@ -81,12 +81,22 @@ syn_functions.at-198-prog.cob:16.11-16.15:
   18              .
 >> Error: Invalid syntax
 
-syn_functions.at-198-prog.cob:16.27-16.29:
+syn_functions.at-198-prog.cob:16.24:
   13          01  ret PIC X.
   14              
   15          PROCEDURE DIVISION RETURNING ret.
   16 >            MOVE FUNCTION x TO ret
-----                              ^^
+----                           ^
+  17              MOVE FUNCTION x TO ret
+  18              .
+>> Hint: Missing <word>
+
+syn_functions.at-198-prog.cob:16.25-16.26:
+  13          01  ret PIC X.
+  14              
+  15          PROCEDURE DIVISION RETURNING ret.
+  16 >            MOVE FUNCTION x TO ret
+----                            ^
   17              MOVE FUNCTION x TO ret
   18              .
 >> Error: Invalid syntax


### PR DESCRIPTION
The period after `FUNCTION-ID` is also made optional.

(Partly) extracted from #262 