### PR TITLE
Better handling of `,` & `;` separators in manipulated text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-dune             linguist-generated
 linking_flags.sh linguist-generated
+/dune            linguist-generated
 /.drom           linguist-generated
 /Makefile        linguist-generated
 /dune-project    linguist-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Improvements to the grammar [#280](https://github.com/OCamlPro/superbol-studio-oss/pull/280)
+- Internal representation of separator comma and semicolon for proper handling in `EXEC`/`END-EXEC` blocks [#279](https://github.com/OCamlPro/superbol-studio-oss/pull/213)
 
 ## [0.1.1] Second α release (2024-04-23)
 

--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,1 @@
+dune             linguist-generated

--- a/src/lsp/cobol_parser/grammar_tokens.mly
+++ b/src/lsp/cobol_parser/grammar_tokens.mly
@@ -27,7 +27,8 @@
 %token <string * char * string> FIXEDLIT [@recovery "0", '.', "0"]
 %token <string * char * string * string> FLOATLIT [@recovery "0", '.', "0", "1"]
 %token <string> DIGITS [@recovery integer_zero]
-%token <string> PICTURE_STRING [@recovery "X"]    (* picture character string *)
+%token <string> PICTURE_STRING [@recovery "X"]
+                  [@symbol "<picture character string>"]
 %token <Cobol_common.Exec_block.t> EXEC_BLOCK
 
 %token EIGHTY_EIGHT

--- a/src/lsp/cobol_parser/parser_diagnostics.ml
+++ b/src/lsp/cobol_parser/parser_diagnostics.ml
@@ -25,7 +25,6 @@ and malformed_stuff =
 
 and missing_stuff =
   | Continuation_of of string
-  | Picture_string of { instead: Cobol_preproc.Text.text_word }
 
 and unexpected_stuff =
   | Pseudotext
@@ -42,9 +41,6 @@ let pp_malformed_stuff ppf = function
 let pp_missing_stuff ppf = function
   | Continuation_of str ->
       Pretty.print ppf "continuation@ of@ `%s'" str
-  | Picture_string { instead } ->
-      Pretty.print ppf "PICTURE@ string@ (got@ `%a'@ instead)"
-        Cobol_preproc.Text.pp_word instead
 
 let pp_unexpected_stuff ppf = function
   | Pseudotext ->

--- a/src/lsp/cobol_parser/text_lexer.mli
+++ b/src/lsp/cobol_parser/text_lexer.mli
@@ -15,6 +15,7 @@ module TYPES: sig
   type keyword_handle
   type intrinsic_handle
   type lexer
+  type lexer_state
 end
 include module type of TYPES
 
@@ -35,10 +36,9 @@ val pp_tokens_via_handles: TokenHandles.t Pretty.printer
 val word_of_token : (Grammar_tokens.token, string) Hashtbl.t
 val punct_of_token : (Grammar_tokens.token, string) Hashtbl.t
 
-
 (* --- *)
 
-val create: ?decimal_point_is_comma:bool -> unit -> lexer
+val create: unit -> lexer
 val handle_of_token: lexer -> Grammar_tokens.token -> keyword_handle
 val reserve_words: lexer -> Cobol_config.words_spec -> unit
 val intrinsic_handles: lexer -> string list -> IntrinsicHandles.t
@@ -47,25 +47,26 @@ val token_of_intrinsic: string -> Grammar_tokens.token
 
 val enable_keywords: TokenHandles.t -> unit
 val disable_keywords: TokenHandles.t -> unit
-val decimal_point_is_comma: lexer -> lexer
 val register_intrinsics: lexer -> IntrinsicHandles.t -> unit
 val unregister_intrinsics: lexer -> IntrinsicHandles.t -> unit
 
 (* --- *)
 
-(** [tokens ~options lexbuf'] tokenizes a lexing buffer with location [lexbuf']
-    into a list of localized tokens. *)
-val tokens
-  : lexer
-  -> Lexing.lexbuf Cobol_common.Srcloc.with_loc
-  -> Grammar_tokens.token Cobol_common.Srcloc.with_loc list
+val initial_state: lexer_state
+val expecting_picture_string: lexer_state -> bool
+val cancel_picture_string_expectation: lexer_state -> lexer_state
+val decimal_point_is_comma: lexer_state -> lexer_state
 
-(** [tokens_of_string'] is similar to {!token}, except that it operates on a
-    localized string. *)
-val tokens_of_string'
+(** [read_tokens lexer lexer_state str] scans a localized string [str] into a
+    list of localized tokens.
+
+    This function returns the list of localized tokens, along with an updated
+    state for the lexer. *)
+val read_tokens
   : lexer
+  -> lexer_state
   -> string Cobol_common.Srcloc.with_loc
-  -> Grammar_tokens.token Cobol_common.Srcloc.with_loc list
+  -> Grammar_tokens.token Cobol_common.Srcloc.with_loc list * lexer_state
 
 (* --- *)
 

--- a/src/lsp/cobol_preproc/src_lexing.mli
+++ b/src/lsp/cobol_preproc/src_lexing.mli
@@ -35,6 +35,17 @@ val comment
   -> Lexing.lexbuf
   -> 'a state * Text.text
 
+val separator
+  : char: char
+  -> (Src_format.fixed state as 's)
+  -> ktkd:('s -> Lexing.lexbuf -> 'a)
+  -> knom:('s -> Lexing.lexbuf -> 'a)
+  -> Lexing.lexbuf -> 'a
+val separator'
+  : char: char
+  -> k:('s -> Lexing.lexbuf -> 'b)
+  -> ('a state as 's) -> Lexing.lexbuf -> 'b
+
 type alphanumeric_continuation =
   | Nominal
   | Closed of Text.quotation
@@ -62,24 +73,24 @@ val cdir_word
   -> knom:('s -> Lexing.lexbuf -> 'a)
   -> Lexing.lexbuf -> 'a
 val cdir_word'
-  : k:('a state -> Lexing.lexbuf -> 'b)
-  -> 'a state -> Lexing.lexbuf -> 'b
+  : k:('s -> Lexing.lexbuf -> 'b)
+  -> ('a state as 's) -> Lexing.lexbuf -> 'b
 val text_word
   : ?cont:bool
   -> ktkd:('s -> Lexing.lexbuf -> 'a)
   -> knom:('s -> Lexing.lexbuf -> 'a)
   -> (Src_format.fixed state as 's) -> Lexing.lexbuf -> 'a
 val text_word'
-  : k:('a state -> Lexing.lexbuf -> 'b)
-  -> 'a state -> Lexing.lexbuf -> 'b
+  : k:('s -> Lexing.lexbuf -> 'b)
+  -> ('a state as 's) -> Lexing.lexbuf -> 'b
 val alphanum_lit
   : ?doubled_opener:bool
   -> ktkd:('s -> Lexing.lexbuf -> 'a)
   -> knom:('s -> Lexing.lexbuf -> 'a)
   -> (Src_format.fixed state as 's) -> Lexing.lexbuf -> 'a
 val alphanum_lit'
-  : k:('a state -> Lexing.lexbuf -> 'b)
-  -> 'a state -> Lexing.lexbuf -> 'b
+  : k:('s -> Lexing.lexbuf -> 'b)
+  -> ('a state as 's) -> Lexing.lexbuf -> 'b
 
 (* --- *)
 

--- a/src/lsp/cobol_preproc/src_reader.ml
+++ b/src/lsp/cobol_preproc/src_reader.ml
@@ -68,6 +68,7 @@ let with_source_format: Src_format.any with_loc -> t -> (t, error) result =
 (* Note: {!next_chunk} never outputs compiler-directive text-words in positions
    other than the first two.  Such a chunk also terminates at the end of the
    source line as it cannot be continued (contrary to normal source lines). *)
+(* CHECKME: weirdly placed separators? *)
 let lookup_compiler_directive: Text.text -> _ =
   let compdir prefix w text =
     try Ok (prefix, Src_lexer.distinguish_directive w, text)

--- a/src/lsp/cobol_preproc/src_tokenizer.ml
+++ b/src/lsp/cobol_preproc/src_tokenizer.ml
@@ -62,6 +62,8 @@ let cdtoks_of_word directive_kind
       boollit ~prefix_length:1 ~base:`Bool str
   | Alphanum { knd = BoolX; str; qte = _ } ->
       boollit ~prefix_length:2 ~base:`Hex str
+  | Separator _ ->
+      [], acc
   | Eof ->
       [EOL, ~@@word], acc
   | Pseudo _
@@ -101,6 +103,8 @@ let pptoks_of_word (word: text_word Cobol_common.Srcloc.with_loc) acc =
       -> [PSEUDO_TEXT p &@<- word]
     | ExecBlock text
       -> [EXEC_BLOCK text &@<- word]
+    | Separator _c
+      -> []
     | Eof
       -> [EOL &@<- word]
   in

--- a/src/lsp/cobol_preproc/text.ml
+++ b/src/lsp/cobol_preproc/text.ml
@@ -60,6 +60,8 @@ module FMT = struct
     | TextWord str
     | CDirWord str ->
         Pretty.string ppf str
+    | Separator c ->
+        Pretty.char ppf c
     | Alphanum a ->
         pp_alphanum ppf a
     | AlphanumPrefix { knd; qte; str } ->

--- a/src/lsp/cobol_preproc/text_printer.ml
+++ b/src/lsp/cobol_preproc/text_printer.ml
@@ -134,6 +134,7 @@ let string_of_text ?(cobc=false) ?(max_line_gap=1) text =
           (Pretty.list ~fopen:"" ~fsep:"" ~fclose:""
              (fun ppf w -> Fmt.string ppf (string_of_word w.payload))) text
     (* Pretty.to_string "EXEC@ %s@ END-EXEC" string_of_text text *)
+    | Separator _
     | Eof -> ""
   in
   let rec iter pos text =

--- a/src/lsp/cobol_preproc/text_processor.ml
+++ b/src/lsp/cobol_preproc/text_processor.ml
@@ -234,6 +234,9 @@ let pseudotext_exact_match
             (* Matched an alphanumeric literal: simply recurse. *)
             aux ?prefix (~@t :: tlocs) pl tl
 
+        | Separator _, _ ->
+            aux ?prefix (~@t :: tlocs) pseudotext tl
+
         | _ ->
             Error `Mismatch
 

--- a/src/lsp/cobol_preproc/text_types.ml
+++ b/src/lsp/cobol_preproc/text_types.ml
@@ -21,6 +21,7 @@ and t = text                                                         (* alias *)
 and text_word =
   | TextWord of string                                         (* upper-cased *)
   | CDirWord of string                                         (* upper-cased *)
+  | Separator of char (* separator ',' or ';', followed by one or more spaces *)
   | Alphanum of alphanum
   | AlphanumPrefix of alphanum
   | Pseudo of pseudotext

--- a/test/cobol_parsing/decimal_point.ml
+++ b/test/cobol_parsing/decimal_point.ml
@@ -71,3 +71,24 @@ let%expect_test "decimal-point-is-comma-with-missing-period" =
     COMMA, PROCEDURE, DIVISION, DISPLAY, DIGITS[1], ., DIGITS[1], DISPLAY,
     FIXED[1,1], DISPLAY, SINT[-1], ., DIGITS[1], DISPLAY, FIXED[-1,1], ., EOF
 |}];;
+
+let%expect_test "decimal-point-is-comma-with-separators" =
+  Parser_testing.show_parsed_tokens {|
+        IDENTIFICATION, DIVISION.
+        PROGRAM-ID. prog.
+        ENVIRONMENT; DIVISION.
+        CONFIGURATION SECTION.
+        SPECIAL-NAMES.
+            DECIMAL-POINT,
+              IS COMMA.
+        PROCEDURE DIVISION.
+            DISPLAY 1.1, 1,1, -1.1; "and", 999,999, 433,1;
+            DISPLAY -1,1, "done".
+  |};
+  [%expect {|
+    IDENTIFICATION, DIVISION, ., PROGRAM-ID, ., INFO_WORD[prog], ., ENVIRONMENT,
+    DIVISION, ., CONFIGURATION, SECTION, ., SPECIAL-NAMES, ., DECIMAL-POINT, IS,
+    COMMA, ., PROCEDURE, DIVISION, ., DISPLAY, DIGITS[1], ., DIGITS[1],
+    FIXED[1,1], SINT[-1], ., DIGITS[1], "and", FIXED[999,999], FIXED[433,1],
+    DISPLAY, FIXED[-1,1], "done", ., EOF
+|}];;

--- a/test/cobol_parsing/dune
+++ b/test/cobol_parsing/dune
@@ -17,7 +17,7 @@
 
 (library
  (name test_cobol_parser)
- (modules cS_tokens decimal_point tokens)
+ (modules cS_tokens decimal_point tokens exec_blocks)
  (preprocess
   (pps ppx_expect))
  (inline_tests

--- a/test/cobol_parsing/exec_blocks.ml
+++ b/test/cobol_parsing/exec_blocks.ml
@@ -1,0 +1,29 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let%expect_test "exec-block-with-cobol-separators" =
+  Parser_testing.show_parsed_tokens {|
+       PROGRAM-ID.        prog.
+       PROCEDURE          DIVISION.
+           EXEC SQL
+              SELECT something_1, something_2 FROM some_table
+                 WHERE condition > 0;
+           END-EXEC.
+           STOP RUN.
+  |};
+  [%expect {|
+    PROGRAM-ID, ., INFO_WORD[prog], ., PROCEDURE, DIVISION, .,
+    EXEC_BLOCK[EXEC SQL SELECT something_1 , something_2 FROM some_table WHERE
+               condition > 0 ; END-EXEC],
+    ., STOP, RUN, ., EOF
+|}];;

--- a/test/output-tests/preproc.expected
+++ b/test/output-tests/preproc.expected
@@ -132,6 +132,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Accept/ACCEPT.CBL':
  .
  DISPLAY
  "Name is "
+ ,
  Initials
  SPACE
  Surname
@@ -230,6 +231,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Accept/MULTIPLIER.CBL':
  .
  DISPLAY
  "Result is = "
+ ,
  Result
  .
  STOP
@@ -286,26 +288,37 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Conditn/CONDITIONS.CBL'
  Vowel
  VALUE
  "a"
+ ,
  "e"
+ ,
  "i"
+ ,
  "o"
+ ,
  "u"
  .
  88
  Consonant
  VALUE
  "b"
+ ,
  "c"
+ ,
  "d"
+ ,
  "f"
+ ,
  "g"
+ ,
  "h"
  "j"
  THRU
  "n"
+ ,
  "p"
  THRU
  "t"
+ ,
  "v"
  THRU
  "z"
@@ -323,6 +336,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Conditn/CONDITIONS.CBL'
  "a"
  THRU
  "z"
+ ,
  "0"
  THRU
  "9"
@@ -455,6 +469,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Conditn/IterIf.cbl':
  THEN
  ADD
  Num1
+ ,
  Num2
  GIVING
  Result
@@ -473,6 +488,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Conditn/IterIf.cbl':
  END-IF
  DISPLAY
  "Result is = "
+ ,
  Result
  END-PERFORM
  .
@@ -639,6 +655,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Indexed/DirectReadIdx.C
  KEY
  DISPLAY
  "VIDEO STATUS :- "
+ ,
  VideoStatus
  END-READ
  END-IF
@@ -660,6 +677,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Indexed/DirectReadIdx.C
  KEY
  DISPLAY
  "VIDEO STATUS :- "
+ ,
  VideoStatus
  END-READ
  END-IF
@@ -843,6 +861,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Indexed/Seq2Index.CBL':
  KEY
  DISPLAY
  "VIDEO STATUS :- "
+ ,
  VideoStatus
  END-WRITE
  READ
@@ -858,6 +877,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Indexed/Seq2Index.CBL':
  .
  CLOSE
  VideoFile
+ ,
  SeqVideoFile
  .
  STOP
@@ -1022,6 +1042,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Indexed/SeqReadIdx.cbl'
  KEY
  DISPLAY
  "VIDEO STATUS :- "
+ ,
  VideoStatus
  END-START
  END-IF
@@ -1191,6 +1212,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Merge/MERGE.CBL':
  WStudentId
  USING
  InsertionsFile
+ ,
  StudentFile
  GIVING
  NewStudentFile
@@ -1932,6 +1954,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Relative/ReadREL.CBL':
  KEY
  DISPLAY
  "SUPP STATUS :-"
+ ,
  SupplierStatus
  END-READ
  PERFORM
@@ -2168,6 +2191,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Relative/Seq2Rel.cbl':
  .
  CLOSE
  SupplierFile
+ ,
  SupplierFileSeq
  .
  STOP
@@ -2575,6 +2599,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteA.
  .
  CLOSE
  SalesFile
+ ,
  PrintFile
  .
  STOP
@@ -3092,6 +3117,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteB.
  .
  CLOSE
  SalesFile
+ ,
  PrintFile
  .
  STOP
@@ -3880,6 +3906,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteFu
  .
  ADD
  Commission
+ ,
  FixedRate(CityCode,SalesPersonNum
  )
  GIVING
@@ -3924,6 +3951,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteFu
  .
  CLOSE
  SalesFile
+ ,
  PrintFile
  .
  STOP
@@ -4722,6 +4750,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteSu
  .
  ADD
  Commission
+ ,
  FixedRate(CityCode,SalesPersonNum
  )
  GIVING
@@ -4766,6 +4795,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/ReportWriter/RepWriteSu
  .
  CLOSE
  SalesFile
+ ,
  PrintFile
  .
  STOP
@@ -5400,6 +5430,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SeqRpt/SeqRpt.CBL':
  Male
  VALUE
  "M"
+ ,
  "m"
  .
  FD
@@ -5542,6 +5573,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SeqRpt/SeqRpt.CBL':
  PrintReportLines
  CLOSE
  StudentFile
+ ,
  ReportFile
  STOP
  RUN
@@ -6306,8 +6338,11 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/Strings/UnstringFileEg.
  ValidTypeCode
  VALUE
  "1,"
+ ,
  "2,"
+ ,
  "3,"
+ ,
  "4,"
  .
  02
@@ -6618,6 +6653,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DateValid/DateD
  "Validate"
  USING
  InputDateIn
+ ,
  ValidationResult
  .
  DISPLAY
@@ -6811,6 +6847,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DateValid/ValiD
  DIVISION
  USING
  InputDateLA
+ ,
  ValidationResultLB
  .
  Begin
@@ -7079,12 +7116,14 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  "EuroDateToSortDate"
  USING
  FirstDate
+ ,
  FirstDate
  .
  CALL
  "EuroDateToSortDate"
  USING
  SecondDate
+ ,
  SecondDate
  .
  CALL
@@ -7093,6 +7132,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  BY
  CONTENT
  FirstDate
+ ,
  SecondDate
  BY
  REFERENCE
@@ -7102,12 +7142,14 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  "SortDateToEuroDate"
  USING
  FirstDate
+ ,
  FirstDate
  .
  CALL
  "SortDateToEuroDate"
  USING
  SecondDate
+ ,
  SecondDate
  .
  MOVE
@@ -7159,6 +7201,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  BY
  CONTENT
  FirstDate
+ ,
  BY
  REFERENCE
  ValidationResult
@@ -7188,6 +7231,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  BY
  CONTENT
  SecondDate
+ ,
  BY
  REFERENCE
  ValidationResult
@@ -7300,6 +7344,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  DIVISION
  USING
  DDMMYYYYDate
+ ,
  YYYYDDMMDate
  .
  Begin
@@ -7400,6 +7445,7 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  DIVISION
  USING
  YYYYDDMMDate
+ ,
  DDMMYYYYDate
  .
  Begin
@@ -7471,7 +7517,9 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/DayDiff/DayDiff
  DIVISION
  USING
  Date1
+ ,
  Date2
+ ,
  Difference
  .
  Begin
@@ -7615,11 +7663,15 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/Multiply/Driver
  BY
  CONTENT
  Number1
+ ,
  Number2
+ ,
  FirstString
+ ,
  BY
  REFERENCE
  SecondString
+ ,
  Result
  .
  DISPLAY
@@ -7873,9 +7925,13 @@ Pre-processing `test/testsuite/microfocus/www.csis.ul.ie/SubProg/Multiply/Multip
  DIVISION
  USING
  Param1
+ ,
  Param2
+ ,
  StrA
+ ,
  StrB
+ ,
  Answer
  .
  Begin
@@ -8793,6 +8849,7 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob14.cbl':
  DISPLAY
  B
  "NOT FOUND"
+ ,
  GO
  000X
  .
@@ -8804,11 +8861,13 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob14.cbl':
  "FOUND "
  MNO
  ":"
+ ,
  DISPLAY
  " AT POS:"
  A
  " FOR NAME: "
  MNAME
+ ,
  GO
  000X
  .
@@ -8967,7 +9026,9 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob14.cbl':
  .
  DISPLAY
  MNO
+ ,
  " "
+ ,
  MNAME
  .
  GO
@@ -9139,6 +9200,7 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob15.cbl':
  DISPLAY
  B
  "NOT FOUND"
+ ,
  GO
  000X
  .
@@ -9150,11 +9212,13 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob15.cbl':
  "FOUND "
  MNO
  ":"
+ ,
  DISPLAY
  " AT POS:"
  A
  " FOR NAME: "
  MNAME
+ ,
  GO
  000X
  .
@@ -9313,7 +9377,9 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob15.cbl':
  .
  DISPLAY
  MNO
+ ,
  " "
+ ,
  MNAME
  .
  GO
@@ -9519,6 +9585,7 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob16.cbl':
  DISPLAY
  B
  "NOT FOUND"
+ ,
  GO
  000X
  .
@@ -9530,11 +9597,13 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob16.cbl':
  "FOUND "
  MNO
  ":"
+ ,
  DISPLAY
  " AT POS:"
  A
  " FOR NAME: "
  MNAME
+ ,
  GO
  000X
  .
@@ -9679,7 +9748,9 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob16.cbl':
  .
  DISPLAY
  INO
+ ,
  " "
+ ,
  INAME
  .
  GO
@@ -9889,6 +9960,7 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob17.cbl':
  DISPLAY
  B
  "NOT FOUND"
+ ,
  GO
  000X
  .
@@ -9900,11 +9972,13 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob17.cbl':
  "FOUND "
  MNO
  ":"
+ ,
  DISPLAY
  " AT POS:"
  A
  " FOR NAME: "
  MNAME
+ ,
  GO
  000X
  .
@@ -10040,7 +10114,9 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob17.cbl':
  .
  DISPLAY
  INO
+ ,
  " "
+ ,
  INAME
  .
  GO
@@ -11798,6 +11874,7 @@ Pre-processing `test/testsuite/ibm/ibmmainframes.com/cob8.cbl':
  A2
  (
  I
+ ,
  J
  )
  =

--- a/test/output-tests/run_misc.expected
+++ b/test/output-tests/run_misc.expected
@@ -4642,16 +4642,6 @@ run_misc.at-11928-cmod.c:29.23-67.17:
   69            str = cob_get_picx_param (k, NULL, 0);
 >> Error: Unexpected pseudotext
 
-run_misc.at-11928-cmod.c:68.23-68.30:
-  65            printf ("BY REFERENCE ");
-  66         }
-  67         if (type == COB_TYPE_ALPHANUMERIC) {
-  68 >          sprintf (pic, "X(%d)", size);
-----                          ^^^^^^^
-  69            str = cob_get_picx_param (k, NULL, 0);
-  70            printf ("%-11s '%s'", pic, str);
->> Error: Missing PICTURE string (got `"X(%d)"' instead)
-
 run_misc.at-11928-cmod.c:73.6-73.7:
   70            printf ("%-11s '%s'", pic, str);
   71            cob_free ((void*)str);
@@ -4687,16 +4677,6 @@ run_misc.at-11928-cmod.c:73.22-76.24:
   77            sprintf (pic, "(%d)", size);
   78            str = cob_get_grp_param (k, NULL, 0);
 >> Error: Unexpected pseudotext
-
-run_misc.at-11928-cmod.c:77.23-77.29:
-  74            sprintf (pic, "N(%d)", size); /* FIXME */
-  75            printf ("exchange of national data is not supported yet");
-  76         } else if (type == COB_TYPE_GROUP) {
-  77 >          sprintf (pic, "(%d)", size);
-----                          ^^^^^^
-  78            str = cob_get_grp_param (k, NULL, 0);
-  79            printf ("%-11s '%.*s'", pic, size, str);
->> Error: Missing PICTURE string (got `"(%d)"' instead)
 
 run_misc.at-11928-cmod.c:84.6-84.7:
   81            memset (wrk,' ',sizeof(wrk));
@@ -5387,16 +5367,6 @@ run_misc.at-12158-cmod.c:29.23-69.17:
   71            printf ("%-11s '%s'", pic, str);
 >> Error: Unexpected pseudotext
 
-run_misc.at-12158-cmod.c:70.23-70.30:
-  67         }
-  68         str = (char *) cob_get_field_str_buffered (fld);
-  69         if (type == COB_TYPE_ALPHANUMERIC) {
-  70 >          sprintf (pic, "X(%d)", size);
-----                          ^^^^^^^
-  71            printf ("%-11s '%s'", pic, str);
-  72            cob_put_field_str (fld, "Bye!");
->> Error: Missing PICTURE string (got `"X(%d)"' instead)
-
 run_misc.at-12158-cmod.c:73.6-73.7:
   70            sprintf (pic, "X(%d)", size);
   71            printf ("%-11s '%s'", pic, str);
@@ -5432,16 +5402,6 @@ run_misc.at-12158-cmod.c:73.22-76.24:
   77            sprintf (pic,"(%d)",size);
   78            printf ("%-11s '%.*s'",pic,size,str);
 >> Error: Unexpected pseudotext
-
-run_misc.at-12158-cmod.c:77.22-77.28:
-  74            sprintf (pic,"N(%d)",size); /* FIXME */
-  75            printf ("exchange of national data is not supported yet");
-  76         } else if (type == COB_TYPE_GROUP) {
-  77 >          sprintf (pic,"(%d)",size);
-----                         ^^^^^^
-  78            printf ("%-11s '%.*s'",pic,size,str);
-  79            cob_put_field_str (fld, "Bye-Bye Birdie!");
->> Error: Missing PICTURE string (got `"(%d)"' instead)
 
 run_misc.at-12158-cmod.c:80.6-80.7:
   77            sprintf (pic,"(%d)",size);

--- a/test/output-tests/syn_misc.expected
+++ b/test/output-tests/syn_misc.expected
@@ -1742,24 +1742,6 @@ Considering: import/gnucobol/tests/testsuite.src/syn_misc.at:4614:0
 Considering: import/gnucobol/tests/testsuite.src/syn_misc.at:4771:0
 Considering: import/gnucobol/tests/testsuite.src/syn_misc.at:4859:0
 Considering: import/gnucobol/tests/testsuite.src/syn_misc.at:4860:0
-syn_misc.at-4860-prog2.cob:3.19:
-   1   
-   2          ID,;DIVISION;,.,;
-   3 >            author,.;tester.
-----                      ^
-   4          PROGRAM-ID,;.;,prog2;,.;,
-   5              REMARKS;. Should work.,,
->> Hint: Missing <comment entry>
-
-syn_misc.at-4860-prog2.cob:3.20-3.26:
-   1   
-   2          ID,;DIVISION;,.,;
-   3 >            author,.;tester.
-----                       ^^^^^^
-   4          PROGRAM-ID,;.;,prog2;,.;,
-   5              REMARKS;. Should work.,,
->> Error: Invalid syntax
-
 syn_misc.at-4860-prog2.cob:12.7-12.9:
    9   
   10         DDATA;DIVISION,.


### PR DESCRIPTION
These changes shall enable `EXEC`/`END-EXEC` blocks with languages in which commas and semicolons are relevant (like SQL).  This is achieved by adding a new `Separator` constructor for elements of manipulated text.

Further handling of weird GC extensions that allow `77,x;PIC,99,99.` (equivalent to `77 x PIC 99,99.`) required some rewriting of the scanning code.