### PR TITLE
Bugfix: size of `RENAMES` range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Basic syntax highlighting for SQL statements embedded in `EXEC`/`END-EXEC` blocks [#290](https://github.com/OCamlPro/superbol-studio-oss/pull/290)
 
 ### Fixed
+- Bug when computing the size of `RENAMES` ranges [#295](https://github.com/OCamlPro/superbol-studio-oss/pull/295)
 - Internal handling of diagnostics that may be issued when dealing with `EXEC`/`END-EXEC` blocks [#292](https://github.com/OCamlPro/superbol-studio-oss/pull/292)
 
 

--- a/src/lsp/cobol_data/data_memory.ml
+++ b/src/lsp/cobol_data/data_memory.ml
@@ -75,7 +75,7 @@ let const_size: int -> size = function
 let valof_size s = AE.factor @@ valof s
 let elementary_size: elementary_size -> size = AE.const
 
-let as_int = AE.as_int
+let as_bits = AE.as_int
 
 let add: size -> size -> size = AE.add
 let diff: size -> size -> size = fun a b -> AE.sub a b

--- a/src/lsp/cobol_data/data_memory.mli
+++ b/src/lsp/cobol_data/data_memory.mli
@@ -58,7 +58,7 @@ val size_of_index: size
 val size_of_pointer: size
 
 (** Raises {!NOT_SCALAR} in case of failure. *)
-val as_int: size -> int
+val as_bits: size -> int
 
 val add: size -> size -> size
 val diff: size -> size -> size

--- a/src/lsp/cobol_typeck/typeck_data_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_data_diagnostics.ml
@@ -95,6 +95,13 @@ type error =
         from_field: Cobol_data.Types.field_definition with_loc;
         thru_field: Cobol_data.Types.field_definition with_loc;
       }
+  | Invalid_renaming_size of
+      {
+        loc: srcloc;
+        bits: int;
+        from_field: Cobol_data.Types.field_definition with_loc;
+        thru_field: Cobol_data.Types.field_definition with_loc;
+      }
   | Invalid_renaming_of_variable_length_range of
       {
         loc: srcloc;
@@ -169,6 +176,7 @@ let error_loc = function
   | Invalid_level_number { level = { loc; _ }; _ }
   | Invalid_renaming_of_variable_length_range { loc; _ }
   | Invalid_renaming_range { loc; _ }
+  | Invalid_renaming_size { loc; _ }
   | Item_not_allowed_in_section { level = { loc; _ }; _ }
   | Item_not_found { qualname = { loc; _ } }
   | Misplaced { loc; _ }
@@ -256,6 +264,9 @@ let pp_error ppf = function
                         should@ precede@ second@ field@ %a"
         (Fmt.option Cobol_ptree.pp_qualname') ~&from_field.field_qualname
         (Fmt.option Cobol_ptree.pp_qualname') ~&thru_field.field_qualname
+  | Invalid_renaming_size { bits; _ } ->
+      Pretty.print ppf "Invalid@ range@ of@ %u@ bits@ between@ RENAMES@ \
+                        operands" bits
   | Invalid_renaming_of_variable_length_range { depending_vars = vars; _ } ->
       Pretty.print ppf "Renaming@ of@ variable-length@ range@ (length@ depends@ \
                         on:@ %a)"

--- a/src/lsp/cobol_typeck/typeck_data_items.ml
+++ b/src/lsp/cobol_typeck/typeck_data_items.ml
@@ -696,9 +696,14 @@ let renaming acc
       let size_ = Cobol_data.Memory.size ~from:from_offset ~to_:end_ in
       let acc, renaming_layout =
         try
-          let size = Cobol_data.Memory.as_int size_ in
-          if size > 0 then
+          let bits = Cobol_data.Memory.as_bits size_ in
+          let size = bits / 8 in
+          if size > 0 && bits mod 8 = 0 then
             acc, Renamed_elementary { usage = Display (PIC.alphanumeric ~size) }
+          else if size > 0 then
+            error acc @@ Invalid_renaming_size { loc; from_field; thru_field;
+                                                 bits },
+            Renamed_elementary { usage = Display (PIC.alphanumeric ~size) }
           else
             error acc @@ Invalid_renaming_range { loc; from_field; thru_field },
             dummy_renamed_elementary

--- a/test/cobol_typeck/ko_renames.ml
+++ b/test/cobol_typeck/ko_renames.ml
@@ -107,3 +107,22 @@ let%expect_test "renames-missing-target" =
       11
     >> Error: Item 'B3 IN B' not found
   |}];;
+
+let%expect_test "renames-errors-invalid-sizes" =
+  dotest @@ prog "renames-errors-invalid-sizes"
+    ~working_storage:{|
+       01 FILLER.
+         02 A PIC X.
+         02 B PIC 1 USAGE BIT.
+         66 C RENAMES A THRU B. *> should error
+    |};
+  [%expect {|
+    prog.cob:7.9-7.31:
+       4          01 FILLER.
+       5            02 A PIC X.
+       6            02 B PIC 1 USAGE BIT.
+       7 >          66 C RENAMES A THRU B. *> should error
+    ----            ^^^^^^^^^^^^^^^^^^^^^^
+       8          PROCEDURE DIVISION.
+       9
+    >> Error: Invalid range of 9 bits between RENAMES operands |}];;

--- a/test/cobol_typeck/ok_renames.ml
+++ b/test/cobol_typeck/ok_renames.ml
@@ -147,7 +147,7 @@ let%expect_test "renames-with-redefines" =
         elementary
         usage: {
           display
-          category: ALPHANUMERIC(24)
+          category: ALPHANUMERIC(3)
         }
       }
     }
@@ -336,7 +336,7 @@ let%expect_test "renames-qualif" =
         elementary
         usage: {
           display
-          category: ALPHANUMERIC(56)
+          category: ALPHANUMERIC(7)
         }
       }
     }
@@ -483,7 +483,7 @@ let%expect_test "renames-qualif" =
         elementary
         usage: {
           display
-          category: ALPHANUMERIC(16)
+          category: ALPHANUMERIC(2)
         }
       }
     }


### PR DESCRIPTION
Symbolic sizes are in bits, sizes given to display data categories are in bytes.

Closes #294 