### PR TITLE
Probe and apply post-actions on parser recovery path

### DIFF
--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -614,10 +614,10 @@ let parse_with_history ?stop_before_eof ?(save_stage = 10) rwps =
   in
   let ps = rewindable_parser_state rwps in
   Tokzr.enable_context_sensitive_tokens  ps.preproc.tokzr;
-  Tokzr.reregister_intrinsics            ps.preproc.tokzr;
+  Tokzr.restore_intrinsics               ps.preproc.tokzr;
   let res, rwps = loop 0 rwps in
   let ps = rewindable_parser_state rwps in
-  Tokzr.unregister_intrinsics            ps.preproc.tokzr;
+  Tokzr.save_intrinsics                  ps.preproc.tokzr;
   Tokzr.disable_context_sensitive_tokens ps.preproc.tokzr;
   res, rwps
 

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -288,15 +288,6 @@ let on_reduction ps tokens prod =
   then pop_context ps tokens
   else ps, tokens
 
-(** Traverses a path (sequence of parser states or productions) that starts with
-    the state that matches the current context stack, and applies the induced
-    changes to the context stack. *)
-let seesaw_context_stack ps tokens recovery_operations =
-  List.fold_left begin fun (ps, tokens) -> function
-    | Grammar_recovery.Shift (e1, e2) -> on_shift ps tokens e1 e2
-    | Grammar_recovery.Reduce p -> on_reduction ps tokens p
-  end (ps, tokens) recovery_operations
-
 (* --- *)
 
 let env_loc env =
@@ -378,8 +369,25 @@ let after_reduction ps token tokens prod = function
   | AboutToReduce (env, _)
   | Shifting (env, _, _) ->
       post_production ps token tokens prod env
-  | _ ->
+  | InputNeeded _                                   (* <- normally unexpected *)
+  | Accepted _
+  | Rejected ->
       ps, token, tokens
+
+(** Traverses a path (sequence of parser states or productions) that starts with
+    the state that matches the current context stack, and applies the induced
+    changes to the context stack; also applies {!post_production} on the way. *)
+let traverse_recovery_path ps token tokens recovery_path =
+  List.fold_left begin fun (ps, tokens) -> function
+    | Grammar_recovery.Shift (e1, e2) ->
+        on_shift ps tokens e1 e2
+    | Reduce (prod, None) ->
+        on_reduction ps tokens prod
+    | Reduce (prod, Some env) ->
+        let ps, tokens = on_reduction ps tokens prod in
+        let ps, _, tokens = post_production ps token tokens prod env in
+        ps, tokens
+  end (ps, tokens) recovery_path
 
 (* Main code for driving the parser with recovery and lexical contexts: *)
 
@@ -482,7 +490,7 @@ and recover ps tokens candidates ~report_syntax_hints_n_error =
   | `Accept (v, assumed) ->
       accept (report_syntax_hints_n_error ps assumed) v
   | `Ok (c, _, visited, assumed) ->
-      let ps, tokens = seesaw_context_stack ps tokens visited in
+      let ps, tokens = traverse_recovery_path ps token tokens visited in
       normal (report_syntax_hints_n_error ps assumed) tokens c
 
 and accept ps v =

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -710,18 +710,27 @@ let disable_tokens state tokens outgoing_tokens =
   state, retokenize_after (Disabled_keywords outgoing_tokens) state tokens
 
 
+let register_intrinsics { persist = { lexer; _ }; registered_intrinsics; _ } =
+  Text_lexer.register_intrinsics lexer registered_intrinsics
+
+
 let unregister_intrinsics { persist = { lexer; _ }; registered_intrinsics; _ } =
   Text_lexer.unregister_intrinsics lexer registered_intrinsics
 
 
-let reregister_intrinsics { persist = { lexer; _ }; registered_intrinsics; _ } =
-  Text_lexer.register_intrinsics lexer registered_intrinsics
+let save_intrinsics state =
+  unregister_intrinsics state
+
+
+let restore_intrinsics ({ intrinsics_enabled; _ } as state) =
+  if intrinsics_enabled
+  then register_intrinsics state
 
 
 let enable_intrinsics state token tokens =
   if state.intrinsics_enabled then state, token, tokens else        (* error? *)
     let state = put_token_back { state with intrinsics_enabled = true } in
-    reregister_intrinsics state;
+    register_intrinsics state;
     let tokens = token :: tokens in
     let tokens = retokenize_after Enabled_intrinsics state tokens in
     let token, tokens = List.hd tokens, List.tl tokens in

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -131,5 +131,5 @@ val pop_context
 
 val enable_context_sensitive_tokens: _ state -> unit
 val disable_context_sensitive_tokens: _ state -> unit
-val unregister_intrinsics: _ state -> unit
-val reregister_intrinsics: _ state -> unit
+val save_intrinsics: _ state -> unit
+val restore_intrinsics: _ state -> unit

--- a/test/cobol_parsing/dune
+++ b/test/cobol_parsing/dune
@@ -18,7 +18,7 @@
 (library
  (name test_cobol_parser)
  (modules cS_tokens decimal_point tokens exec_blocks
- 	  test_intrinsics_registration)
+	  test_intrinsics_registration)
  (preprocess
   (pps ppx_expect))
  (inline_tests
@@ -28,7 +28,11 @@
 
 (library
  (name test_cobol_parser_rewind)
- (modules test_appending test_appending_large test_stuttering test_cutnpaste_large)
+ (modules test_appending
+	  test_appending_large
+	  test_stuttering
+	  test_cutnpaste_large
+	  test_targeted_insertions)
  (preprocess
   (pps ppx_expect))
  (inline_tests

--- a/test/cobol_parsing/dune
+++ b/test/cobol_parsing/dune
@@ -17,7 +17,8 @@
 
 (library
  (name test_cobol_parser)
- (modules cS_tokens decimal_point tokens exec_blocks)
+ (modules cS_tokens decimal_point tokens exec_blocks
+ 	  test_intrinsics_registration)
  (preprocess
   (pps ppx_expect))
  (inline_tests

--- a/test/cobol_parsing/parser_testing.ml
+++ b/test/cobol_parsing/parser_testing.ml
@@ -58,6 +58,18 @@ let show_diagnostics ?(verbose = false) ?source_format ?filename
     } |>
   Cobol_parser.Outputs.sink_result ~set_status:false ~ppf:Fmt.stdout
 
+let just_parse ?(verbose = false) ?source_format ?filename
+    ?(exec_scanners = Superbol_preprocs.exec_scanners) contents =
+  preproc ?source_format ?filename contents |>
+  Cobol_parser.parse_simple
+    ~options: {
+      default_parser_options with
+      verbose;
+      exec_scanners;
+      recovery = EnableRecovery { silence_benign_recoveries = true };
+    } |>
+  ignore
+
 (* --- *)
 
 (** Structure returned by {!extract_position_markers} below. *)

--- a/test/cobol_parsing/test_intrinsics_registration.ml
+++ b/test/cobol_parsing/test_intrinsics_registration.ml
@@ -38,18 +38,4 @@ let%expect_test "intrinsics-handling-in-multiunit-group" =
           STOP RUN.
        END PROGRAM test.
   |};
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  "Assert_failure src/lsp/cobol_parser/text_tokenizer.ml:755:2"
-  Raised at Cobol_parser__Parser_diagnostics.add_exn in file "src/lsp/cobol_parser/parser_diagnostics.ml", line 146, characters 6-13
-  Called from Cobol_parser__Parser_engine.add_exn in file "src/lsp/cobol_parser/parser_engine.ml", line 156, characters 40-74
-  Called from Cobol_parser__Parser_engine.on_exn in file "src/lsp/cobol_parser/parser_engine.ml", line 492, characters 9-21
-  Called from Cobol_parser__Parser_engine.full_parse in file "src/lsp/cobol_parser/parser_engine.ml", line 507, characters 57-68
-  Called from Cobol_parser__Parser_engine.parse_once in file "src/lsp/cobol_parser/parser_engine.ml", line 529, characters 16-61
-  Called from Parser_testing.just_parse in file "test/cobol_parsing/parser_testing.ml", line 63, characters 2-236
-  Called from Test_cobol_parser__Test_intrinsics_registration.(fun) in file "test/cobol_parsing/test_intrinsics_registration.ml", line 15, characters 2-917
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}];;
+  [%expect{||}];;

--- a/test/cobol_parsing/test_intrinsics_registration.ml
+++ b/test/cobol_parsing/test_intrinsics_registration.ml
@@ -1,0 +1,55 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let%expect_test "intrinsics-handling-in-multiunit-group" =
+  Parser_testing.just_parse {|
+       IDENTIFICATION DIVISION.
+       FUNCTION-ID.   docalc.
+       DATA           DIVISION.
+       LINKAGE        SECTION.
+       01 RES         PIC X(4).
+       PROCEDURE      DIVISION RETURNING RES.
+      *> Syntax error here (missing paragraph name).
+      *> This triggers a parser recovery path that includes a reduction of
+      *> procedure_division nonterminal, that is itself associated with a
+      *> post-action.  Until the next commit in history, that led to an
+      *> internal error due to a missed unregistration of intrinsics.
+           MOVE "func" TO RES
+           GOBACK.
+       END FUNCTION docalc.
+
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.    test.
+       ENVIRONMENT    DIVISION.
+       CONFIGURATION  SECTION.
+       REPOSITORY.
+       FUNCTION       TRIM INTRINSIC.
+       PROCEDURE      DIVISION.
+          STOP RUN.
+       END PROGRAM test.
+  |};
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  "Assert_failure src/lsp/cobol_parser/text_tokenizer.ml:755:2"
+  Raised at Cobol_parser__Parser_diagnostics.add_exn in file "src/lsp/cobol_parser/parser_diagnostics.ml", line 146, characters 6-13
+  Called from Cobol_parser__Parser_engine.add_exn in file "src/lsp/cobol_parser/parser_engine.ml", line 156, characters 40-74
+  Called from Cobol_parser__Parser_engine.on_exn in file "src/lsp/cobol_parser/parser_engine.ml", line 492, characters 9-21
+  Called from Cobol_parser__Parser_engine.full_parse in file "src/lsp/cobol_parser/parser_engine.ml", line 507, characters 57-68
+  Called from Cobol_parser__Parser_engine.parse_once in file "src/lsp/cobol_parser/parser_engine.ml", line 529, characters 16-61
+  Called from Parser_testing.just_parse in file "test/cobol_parsing/parser_testing.ml", line 63, characters 2-236
+  Called from Test_cobol_parser__Test_intrinsics_registration.(fun) in file "test/cobol_parsing/test_intrinsics_registration.ml", line 15, characters 2-917
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}];;

--- a/test/cobol_parsing/test_targeted_insertions.ml
+++ b/test/cobol_parsing/test_targeted_insertions.ml
@@ -113,8 +113,6 @@ let%expect_test "invalid-intrinsics-reregistration-on-reparse" =
         STOP RUN.
 
     Appending chunk 6/6 @ 10:12-10:13 (" ")
-    >> Internal warning in `Cobol_parser__Text_lexer.register_intrinsic`:
-      registration of intrinsic function `TRIM', which was already registered
     Parse-tree:
       IDENTIFICATION DIVISION.
       PROGRAM-ID. testintrinsic.

--- a/test/cobol_parsing/test_targeted_insertions.ml
+++ b/test/cobol_parsing/test_targeted_insertions.ml
@@ -1,0 +1,130 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+let pp_ptree =
+  Fmt.option Cobol_ptree.pp_compilation_group
+    ~none:(Fmt.any "None")
+
+let show_ptree _i _ ptree _diags =
+  Pretty.out "@[<v 2>Parse-tree:@;%a@]@\n@." pp_ptree ptree
+
+let%expect_test "invalid-intrinsics-reregistration-on-reparse" =
+  Parser_testing.iteratively_append_chunks ~f:show_ptree
+    ~ignore_last_chunk:true @@
+  Parser_testing.extract_position_markers
+    ~with_start_pos:false ~with_end_pos:false @@
+  {|
+       >>SOURCE FORMAT IS FREE
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. testintrinsic.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       REPOSITORY.
+       FUNCTION TRIM INTRINSIC.
+       DATA DIVISION.
+       PROCEDURE DIVISION.
+       _|_ _|_ _|_ _|_ _|_ _|_ _|_ _|_
+       STOP RUN.
+  |};
+  [%expect {|
+    Appending chunk 1/6 @ 10:7-10:8 (" ")
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN.
+
+    Appending chunk 2/6 @ 10:8-10:9 (" ")
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN.
+
+    Appending chunk 3/6 @ 10:9-10:10 (" ")
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN.
+
+    Appending chunk 4/6 @ 10:10-10:11 (" ")
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN.
+
+    Appending chunk 5/6 @ 10:11-10:12 (" ")
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN.
+
+    Appending chunk 6/6 @ 10:12-10:13 (" ")
+    >> Internal warning in `Cobol_parser__Text_lexer.register_intrinsic`:
+      registration of intrinsic function `TRIM', which was already registered
+    Parse-tree:
+      IDENTIFICATION DIVISION.
+      PROGRAM-ID. testintrinsic.
+
+      ENVIRONMENT DIVISION.
+      CONFIGURATION SECTION.
+      REPOSITORY.
+      FUNCTION
+      TRIM
+      INTRINSIC.
+      DATA DIVISION.
+      PROCEDURE DIVISION.
+        STOP RUN. |}];;


### PR DESCRIPTION
Includes an automated test that relies on the current requirement for function procedure divisions to start with a paragraph or section title. This test may need to be adapted when this requirement is lifted (or it won't test the issue properly anymore).