### PR TITLE
Refactor `Expect` api for completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.1.3] Next release
 
 ### Added
-- Context-sensitive completion for keywords and user-defined words [#304](https://github.com/OCamlPro/superbol-studio-oss/pull/304), [#312](https://github.com/OCamlPro/superbol-studio-oss/pull/312)
+- Context-sensitive completion for keywords and user-defined words [#304](https://github.com/OCamlPro/superbol-studio-oss/pull/304), [#312](https://github.com/OCamlPro/superbol-studio-oss/pull/312), [#314](https://github.com/OCamlPro/superbol-studio-oss/pull/314)
 - Internal support for inspecting the parser's state right before EOF [#302](https://github.com/OCamlPro/superbol-studio-oss/pull/302)
 - Show data item information on hover [#293](https://github.com/OCamlPro/superbol-studio-oss/pull/293) [#305](https://github.com/OCamlPro/superbol-studio-oss/pull/305)
 - Folding of `EXEC`/`END-EXEC` blocks [#291](https://github.com/OCamlPro/superbol-studio-oss/pull/291)

--- a/src/lsp/cobol_parser/grammar_expect.mli
+++ b/src/lsp/cobol_parser/grammar_expect.mli
@@ -23,12 +23,11 @@ module Completion_entry: sig
   val pp: t Fmt.t
 end
 
-type xnonterminal =
-  | X: 'a nonterminal -> xnonterminal
+type action =
+  | Feed: 'a nonterminal -> action
+  | Reduce: production -> action
 
-val reducible_productions_in: env:_ env -> production list
-
-val nullable_nonterminals_in: env:_ env -> xnonterminal list
+val actions_in: env:_ env -> action list
 
 val completion_entries_in: env:_ env -> Completion_entry.t list
 

--- a/test/lsp/lsp_completion.ml
+++ b/test/lsp/lsp_completion.ml
@@ -3621,6 +3621,124 @@ let%expect_test "control-completion" =
         INTERFACE-ID.\n
         PROGRAM-ID |}];;
 
+let%expect_test "double-program-completion" =
+  let end_with_postproc = completion_positions @@ extract_position_markers {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. progA.
+        DATA DIVISION.
+        WORKING-STORAGE SECTION.
+        01 A1 PIC X.
+        01 A2 PIC X.
+        PROCEDURE DIVISION.
+          DISPLAY _|_A1.
+          STOP RUN.
+        END PROGRAM progA.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. progB.
+        DATA DIVISION.
+        WORKING-STORAGE SECTION.
+        01 B1 PIC X.
+        01 B2 PIC X.
+        PROCEDURE DIVISION.
+          DISPLAY _|_B1.
+          STOP RUN.
+        END PROGRAM progB.
+  |cobol}  in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    __rootdir__/prog.cob:9.18:
+       6           01 A1 PIC X.
+       7           01 A2 PIC X.
+       8           PROCEDURE DIVISION.
+       9 >           DISPLAY A1.
+    ----                     ^
+      10             STOP RUN.
+      11           END PROGRAM progA.
+    (line 8, character 18):
+    Basic (17 entries):
+        A1
+        A2
+        ADDRESS
+        ALL
+        EXCEPTION-OBJECT
+        FUNCTION
+        HIGH-VALUES
+        LINAGE-COUNTER
+        LINE-COUNTER
+        LOW-VALUES
+        NULL
+        PAGE-COUNTER
+        QUOTES
+        SELF
+        SPACES
+        SUPER
+        ZEROS
+    Eager (17 entries):
+        A1
+        A2
+        ADDRESS OF
+        ALL
+        EXCEPTION-OBJECT
+        FUNCTION
+        HIGH-VALUES
+        LINAGE-COUNTER
+        LINE-COUNTER
+        LOW-VALUES
+        NULL
+        PAGE-COUNTER
+        QUOTES
+        SELF
+        SPACES
+        SUPER
+        ZEROS
+    __rootdir__/prog.cob:20.18:
+      17           01 B1 PIC X.
+      18           01 B2 PIC X.
+      19           PROCEDURE DIVISION.
+      20 >           DISPLAY B1.
+    ----                     ^
+      21             STOP RUN.
+      22           END PROGRAM progB.
+    (line 19, character 18):
+    Basic (17 entries):
+        B1
+        B2
+        ADDRESS
+        ALL
+        EXCEPTION-OBJECT
+        FUNCTION
+        HIGH-VALUES
+        LINAGE-COUNTER
+        LINE-COUNTER
+        LOW-VALUES
+        NULL
+        PAGE-COUNTER
+        QUOTES
+        SELF
+        SPACES
+        SUPER
+        ZEROS
+    Eager (17 entries):
+        B1
+        B2
+        ADDRESS OF
+        ALL
+        EXCEPTION-OBJECT
+        FUNCTION
+        HIGH-VALUES
+        LINAGE-COUNTER
+        LINE-COUNTER
+        LOW-VALUES
+        NULL
+        PAGE-COUNTER
+        QUOTES
+        SELF
+        SPACES
+        SUPER
+        ZEROS |}]
+
 let%expect_test "intrinsic-completion" =
   let end_with_postproc = completion_positions @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.


### PR DESCRIPTION
Replaced `reducible_productions_in` and `nullable_nonterminals_in` with `actions_in`
Created new type `action` to unify both `feed` and `reduce` action possibility