### PR TITLE
Various UX adjustments

### DIFF
--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -467,7 +467,7 @@ let lookup_data_definition_for_hover cu_name element_at_pos group =
   with Cobol_unit.Qualmap.Ambiguous _ -> raise Not_found
 
 let data_definition_on_hover
-    ?(always_show_hover_text_in_data_div = true)
+    ?(always_show_hover_text_in_data_div = false)
     ~uri position Cobol_typeck.Outputs.{ group; _ } =
   let filename = Lsp.Uri.to_path uri in
   match Lsp_lookup.element_at_position ~uri position group with

--- a/src/lsp/cobol_lsp/lsp_request.mli
+++ b/src/lsp/cobol_lsp/lsp_request.mli
@@ -24,7 +24,8 @@ module INTERNAL: sig
     -> Lsp.Types.ReferenceParams.t
     -> Lsp.Types.Location.t list option
   val hover
-    : Lsp_server.t
+    : ?always_show_hover_text_in_data_div: bool
+    -> Lsp_server.t
     -> Lsp.Types.HoverParams.t
     -> Lsp.Types.Hover.t option
   val completion

--- a/src/lsp/superbol_preprocs/main.ml
+++ b/src/lsp/superbol_preprocs/main.ml
@@ -16,7 +16,10 @@ module EXEC_MAP = Cobol_preproc.Options.EXEC_MAP
 let exec_scanners =
   Cobol_parser.Options.{
     exec_scanner_fallback = Generic.scanner;  (* for now; TODO: Call.scanner? *)
-    exec_scanners = Cobol_preproc.Options.EXEC_MAP.singleton "SQL" Esql.scanner;
+    (* NB: Kept empty for now (the LSP does not yet benefit from this
+       preprocessor) *)
+    exec_scanners = Cobol_preproc.Options.EXEC_MAP.empty;
+    (* exec_scanners = Cobol_preproc.Options.EXEC_MAP.singleton "SQL" Esql.scanner; *)
   }
 
 let more scanners =

--- a/test/cobol_parsing/exec_blocks.ml
+++ b/test/cobol_parsing/exec_blocks.ml
@@ -11,8 +11,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let exec_scanners =
+  Superbol_preprocs.more [
+    "SQL", Superbol_preprocs.Esql.scanner;
+  ]
+
 let%expect_test "exec-block-with-cobol-separators" =
-  Parser_testing.show_parsed_tokens {|
+  Parser_testing.show_parsed_tokens
+    ~parser_options:(Parser_testing.options ~exec_scanners ()) @@
+  {|
        PROGRAM-ID.        prog.
        PROCEDURE          DIVISION.
            EXEC SQL
@@ -35,7 +42,9 @@ let%expect_test "exec-block-with-invalid-percentage-character" =
       "NO-%", Superbol_preprocs.No_percentage_toy.scanner;
     ]
   in
-  Parser_testing.show_diagnostics ~exec_scanners {|
+  Parser_testing.show_diagnostics
+    ~parser_options:(Parser_testing.options ~exec_scanners ()) @@
+  {|
        PROGRAM-ID.        prog.
        PROCEDURE          DIVISION.
            EXEC NO-%

--- a/test/cobol_parsing/tokens.ml
+++ b/test/cobol_parsing/tokens.ml
@@ -40,7 +40,7 @@ let%expect_test "tokens-after-syntax-errors" =
 
 let%expect_test "token-locations" =
   Parser_testing.show_parsed_tokens ~source_format:Auto ~with_locations:true
-    ~verbose:true
+    ~parser_options:(Parser_testing.options ~verbose:true ())
     {|(TMP:1)|};
   [%expect {|
     Tks: (, WORD[TMP], :, DIGITS[1], ), EOF

--- a/test/cobol_typeck/typeck_testing.ml
+++ b/test/cobol_typeck/typeck_testing.ml
@@ -15,15 +15,11 @@ open Parser_testing
 
 module DIAGS = Cobol_common.Diagnostics
 
-let show_diagnostics ?(show_data = false) ?(verbose = false)
+let show_diagnostics ?(show_data = false)
+    ?(parser_options = Parser_testing.options ())
     ?source_format ?filename contents =
   preproc ?source_format ?filename contents |>
-  Cobol_parser.parse_simple
-    ~options: {
-      default_parser_options with
-      verbose;
-      recovery = EnableRecovery { silence_benign_recoveries = true };
-    } |>
+  Cobol_parser.parse_simple ~options:parser_options |>
   Cobol_parser.Outputs.translate_diags |>
   DIAGS.map_result ~f:Cobol_typeck.compilation_group |>
   DIAGS.more_result ~f:Cobol_typeck.Results.translate_diags |>

--- a/test/lsp/lsp_hover.ml
+++ b/test/lsp/lsp_hover.ml
@@ -22,7 +22,9 @@ let print_hovered server ~projdir (prog, prog_positions) =
     Pretty.out "%a(line %d, character %d):@."
       Fmt.(option ~none:nop @@ fmt "%s ") key
       position.line position.character;
-    match LSP.Request.hover server params with
+    match
+      LSP.Request.hover ~always_show_hover_text_in_data_div:true server params
+    with
     | None ->
         Pretty.out "Hovering nothing worthy@."
     | Some { contents = `List strings; range } ->
@@ -74,7 +76,7 @@ let%expect_test "hover-copy" =
     ```
     ALPHANUMERIC(1)
     ---
-    Additional pre-processing information:
+    Additional pre-processing:
     ```cobol
            01 FIELD PIC X.
     ```
@@ -95,7 +97,7 @@ let%expect_test "hover-copy" =
     ```
     ALPHANUMERIC(1)
     ---
-    Additional pre-processing information:
+    Additional pre-processing:
     ```cobol
            01 FIELD PIC X.
     ```
@@ -116,7 +118,7 @@ let%expect_test "hover-copy" =
     ```
     ALPHANUMERIC(1)
     ---
-    Additional pre-processing information:
+    Additional pre-processing:
     ```cobol
            01 FIELD PIC X.
     ```
@@ -137,7 +139,7 @@ let%expect_test "hover-copy" =
     ```
     ALPHANUMERIC(1)
     ---
-    Additional pre-processing information:
+    Additional pre-processing:
     ```cobol
            01 FIELD PIC X.
     ``` |}];;

--- a/test/output-tests/reparse.ml
+++ b/test/output-tests/reparse.ml
@@ -17,8 +17,13 @@ open FileString.OP
 open Testsuite_utils
 
 let default_parser_options =
+  let exec_scanners =
+    Superbol_preprocs.more [
+      "SQL", Superbol_preprocs.Esql.scanner;
+    ]
+  in
   Cobol_parser.Options.{
-    (default ~exec_scanners: Superbol_preprocs.exec_scanners) with
+    (default ~exec_scanners) with
     recovery = DisableRecovery
   }
 


### PR DESCRIPTION
- Disable hover on whole data item defintions for now: it's too invasive;
- Disable scanning of `EXEC SQL` blocks by the LSP server: it is still brittle and does not benefit from the result.