### PR TITLE
Add support for the `textDocument/documentSymbol` LSP request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.1.3] Next release
 
 ### Added
+- Support for LSP request `textDocument/documentSymbol` [#317](https://github.com/OCamlPro/superbol-studio-oss/pull/317)
 - Context-sensitive completion for keywords and user-defined words [#304](https://github.com/OCamlPro/superbol-studio-oss/pull/304), [#312](https://github.com/OCamlPro/superbol-studio-oss/pull/312), [#314](https://github.com/OCamlPro/superbol-studio-oss/pull/314)
 - Internal support for inspecting the parser's state right before EOF [#302](https://github.com/OCamlPro/superbol-studio-oss/pull/302)
 - Show data item information on hover [#293](https://github.com/OCamlPro/superbol-studio-oss/pull/293) [#305](https://github.com/OCamlPro/superbol-studio-oss/pull/305)

--- a/src/lsp/cobol_lsp/lsp_capabilities.ml
+++ b/src/lsp/cobol_lsp/lsp_capabilities.ml
@@ -58,3 +58,4 @@ let reply (_: ClientCapabilities.t) =
     ~foldingRangeProvider:(`Bool true)
     ~completionProvider:completion_option
     ~workspace
+    ~documentSymbolProvider:(`Bool true)

--- a/src/lsp/cobol_lsp/lsp_document_symbol.ml
+++ b/src/lsp/cobol_lsp/lsp_document_symbol.ml
@@ -11,11 +11,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Visitor = Cobol_common.Visitor
+open Lsp.Types
 open Cobol_common.Srcloc.INFIX
 open Lsp.Types.DocumentSymbol
-module Kind = Lsp.Types.SymbolKind
-type range = Lsp.Types.Range.t
+open Cobol_ptree
+module Visitor = Cobol_common.Visitor
+type range = Range.t
 type doc_symbol = t
 
 let enclosing_range (range: range) (buffer: doc_symbol list)  =
@@ -23,126 +24,107 @@ let enclosing_range (range: range) (buffer: doc_symbol list)  =
     | [] -> range.end_
     | last::_ -> last.range.end_
   in
-  Lsp.Types.Range.create ~start:range.start ~end_
+  Range.create ~start:range.start ~end_
 
 let create ~range ?(children=[]) =
   create ~range ~selectionRange:range ~children:(List.rev children)
 
-module type T = sig
-  type t
-  val fold:
-    (loc:Cobol_common.srcloc -> range)
-    -> t
-    -> doc_symbol list
-end
+type proc_acc =
+  {
+    result: doc_symbol list;
+    prev_section: (range * string) option;
+    buffer: doc_symbol list;
+  }
+let proc_init_acc = { result = []; prev_section = None; buffer = [] }
 
-module Proc
-  : T with type t = Cobol_ptree.procedure_division Cobol_common.with_loc
-= struct
-  type t = Cobol_ptree.procedure_division Cobol_common.with_loc
-  type acc =
-    {
-      result: doc_symbol list;
-      prev_section: (range * string) option;
-      buffer: doc_symbol list;
-    }
-
-  let result acc = acc.result
-  let init_acc = { result = []; prev_section = None; buffer = [] }
-
-  let complete_section { result; prev_section; buffer=children } =
-    match prev_section with
-    | None -> children @ result
-    | Some (range, name) ->
-      let range = enclosing_range range children in
-      create ~kind:Function ~name ~range ~children ()
-      :: result
-
-  let folder range_from: acc Cobol_ptree.Visitor.folder =
-    object
-      inherit [acc] Cobol_ptree.Visitor.folder
-
-      method! fold_procedure_division' { loc; _ } { result; _ } =
-        Visitor.do_children_and_then init_acc
-          begin fun acc ->
-            let children = complete_section acc in
-            let range = range_from ~loc in
-            let procedure = create ()
-                ~children
-                ~kind:Module
-                ~range
-                ~name:"PROCEDURE DIVISION"
-            in
-            { init_acc with result = procedure::result; }
-          end
-
-      method! fold_paragraph' { loc; payload = p } acc =
-        let range = range_from ~loc in
-        let name = Option.fold
-            ~none:"Unnamed paragraph"
-            ~some:(fun s' ->
-                ~&s' ^ if p.paragraph_is_section then " SECTION" else "" )
-            p.paragraph_name in
-        begin
-          if p.paragraph_is_section
-          then
-            {
-              buffer = [];
-              prev_section = Some((range, name));
-              result = complete_section acc
-            }
-          else
-            let paragraph = create ~kind:Function ~range ~name () in
-            { acc with buffer = paragraph :: acc.buffer }
-        end
-        |> Visitor.skip_children
-    end
-
-  let fold range_from proc_div =
-    Cobol_ptree.Visitor.fold_procedure_division'
-      (folder range_from)
-      proc_div
-      init_acc
-    |> result
-end
-
-module Data
-  : T with type t = Cobol_ptree.data_division Cobol_common.with_loc
-= struct
-  type t = Cobol_ptree.data_division Cobol_common.with_loc
-  type buffered_data =
-    { range: range; name: string; level: int; buffer: doc_symbol list }
-  type acc =
-    { result: doc_symbol list; previous: buffered_data list; }
-  let result acc = acc.result
-  let init_acc = { result = []; previous = []; }
-
-  let create_variable { name; range; buffer=children; level } =
-    ignore level;
+let complete_section { result; prev_section; buffer=children } =
+  match prev_section with
+  | None -> children @ result
+  | Some (range, name) ->
     let range = enclosing_range range children in
-    create ~children ~kind:Variable ~range ~name ()
+    create ~kind:Function ~name ~range ~children ()
+    :: result
 
-  let rec complete_entries current_level acc  =
-    match acc.previous with
-    | [] -> acc
-    | prev::_ when current_level > prev.level -> acc
-    | [prev] ->
-      let prev_doc_sym = create_variable prev in
-      {
-        result = prev_doc_sym::acc.result;
-        previous = [];
-      }
-    | prev::prev2::tl ->
-      let prev_doc_sym = create_variable prev in
-      let prev2 = { prev2 with buffer = prev_doc_sym::prev2.buffer } in
-      complete_entries current_level { acc with previous = prev2::tl }
+let proc_folder range_from: proc_acc Cobol_ptree.Visitor.folder =
+  object
+    inherit [proc_acc] Cobol_ptree.Visitor.folder
 
-  let folder range_from : acc Cobol_ptree.Visitor.folder =
-    let parent_folder: type a. _ =
-      fun name ({ loc; _ }: a Cobol_ptree.with_loc) acc ->
+    method! fold_procedure_division' { loc; _ } { result; _ } =
+      Visitor.do_children_and_then proc_init_acc
+        begin fun acc ->
+          let children = complete_section acc in
+          let range = range_from ~loc in
+          let procedure = create ()
+              ~children
+              ~kind:Function
+              ~range
+              ~name:"PROCEDURE DIVISION"
+          in
+          { proc_init_acc with result = procedure::result; }
+        end
+
+    method! fold_paragraph' { loc; payload = p } acc =
       let range = range_from ~loc in
-      let parent = create ~kind:Module ~range ~name in
-      Visitor.do_children_and_then init_acc
+      let name = Option.fold
+          ~none:"Unnamed paragraph"
+          ~some:(fun s' ->
+              ~&s' ^ if p.paragraph_is_section then " SECTION" else "" )
+          p.paragraph_name in
+      begin
+        if p.paragraph_is_section
+        then
+          {
+            buffer = [];
+            prev_section = Some((range, name));
+            result = complete_section acc
+          }
+        else
+          let paragraph = create ~kind:Function ~range ~name () in
+          { acc with buffer = paragraph :: acc.buffer }
+      end
+      |> Visitor.skip_children
+  end
+
+let fold_proc_div range_from proc_div =
+  let result acc = acc.result in
+  Cobol_ptree.Visitor.fold_procedure_division'
+    (proc_folder range_from)
+    proc_div
+    proc_init_acc
+  |> result
+
+type buffered_data =
+  { range: range; name: string; level: int; buffer: doc_symbol list }
+type data_acc =
+  { result: doc_symbol list; previous: buffered_data list; }
+let data_init_acc = { result = []; previous = []; }
+
+let create_variable { name; range; buffer=children; level } =
+  ignore level;
+  let range = enclosing_range range children in
+  create ~children ~kind:Variable ~range ~name ()
+
+let rec complete_entries current_level acc  =
+  match acc.previous with
+  | [] -> acc
+  | prev::_ when current_level > prev.level -> acc
+  | [prev] ->
+    let prev_doc_sym = create_variable prev in
+    {
+      result = prev_doc_sym::acc.result;
+      previous = [];
+    }
+  | prev::prev2::tl ->
+    let prev_doc_sym = create_variable prev in
+    let prev2 = { prev2 with buffer = prev_doc_sym::prev2.buffer } in
+    complete_entries current_level { acc with previous = prev2::tl }
+
+let data_folder range_from : data_acc Cobol_ptree.Visitor.folder =
+  let parent_folder: type a. _ =
+    fun name ({ loc; _ }: a with_loc) acc ->
+      let range = range_from ~loc in
+      let parent = create ~kind:Function ~range ~name in
+      Visitor.do_children_and_then data_init_acc
         begin fun inner_acc ->
           let { result = children; _ } = complete_entries 0 inner_acc in
           {
@@ -150,139 +132,152 @@ module Data
             previous = [];
           }
         end
-    in
-    object
-      inherit [acc] Cobol_ptree.Visitor.folder
+  in
+  object
+    inherit [data_acc] Cobol_ptree.Visitor.folder
 
-      method! fold_data_division' =
-        parent_folder "DATA DIVISION"
+    method! fold_data_division' =
+      parent_folder "DATA DIVISION"
 
-      method! fold_file_section' =
-        parent_folder "FILE SECTION"
+    method! fold_file_section' =
+      parent_folder "FILE SECTION"
 
-      method! fold_linkage_section' =
-        parent_folder "LINKAGE SECTION"
+    method! fold_linkage_section' =
+      parent_folder "LINKAGE SECTION"
 
-      method! fold_working_storage_section' =
-        parent_folder "WORKING-STORAGE SECTION"
+    method! fold_working_storage_section' =
+      parent_folder "WORKING-STORAGE SECTION"
 
-      method! fold_local_storage_section' =
-        parent_folder "LOCAL-STORAGE SECTION"
+    method! fold_local_storage_section' =
+      parent_folder "LOCAL-STORAGE SECTION"
 
-      method! fold_communication_section' =
-        parent_folder "COMMUNICATION SECTION"
+    method! fold_communication_section' =
+      parent_folder "COMMUNICATION SECTION"
 
-      method! fold_report_section' =
-        parent_folder "REPORT SECTION"
+    method! fold_report_section' =
+      parent_folder "REPORT SECTION"
 
-      method! fold_screen_section' =
-        parent_folder "SCREEN SECTION"
+    method! fold_screen_section' =
+      parent_folder "SCREEN SECTION"
 
-      method! fold_data_item' { loc; payload = di } acc =
-        let range = range_from ~loc in
-        let data_name =
-          match di.data_name with
-          | Some { payload = Cobol_ptree.DataName s'; _ } -> ~&s'
-          | _ -> "FILLER"
-        in
-        let true_level = ~&(di.data_level) in
-        let name =
-          (if true_level <= 9 then "0" else "")
-          ^ Int.to_string true_level
-          ^ " "
-          ^ data_name
-        in
-        let level = if true_level == 77 then 01 else true_level
-        in
-        let current = { range; name; level; buffer = [] } in
-        let acc = complete_entries current.level acc in
-        { acc with previous = current::acc.previous }
-        |>Visitor.skip
-
-      method! fold_rename_item' { loc; payload = ri } acc =
-        let range = range_from ~loc in
-        let name = "66 " ^ ~&(ri.rename_to) in
-        let current = { range; name; level = 02; buffer = [] } in
-        let acc = complete_entries current.level acc in
-        { acc with previous = current::acc.previous }
-        |>Visitor.skip
-
-      method! fold_constant_item' { loc; payload = ci } acc =
-        let range = range_from ~loc in
-        let name = "01 " ^ ~&(ci.constant_name) in
-        let constant = create ~kind:Constant ~range ~name () in
-        let acc = complete_entries 01 acc in
-        { acc with result = constant::acc.result }
-        |> Visitor.skip
-
-      method! fold_condition_name_item' { loc; payload = c } acc =
-        let range = range_from ~loc in
-        let name = "88 " ^ ~&(c.condition_name) in
-        let condition = create ~kind:Boolean ~range ~name () in
-        begin match acc.previous with
-          | [] -> { acc with result = condition::acc.result }
-          | prev::tl ->
-            let prev = { prev with buffer = condition::prev.buffer }
-            in { acc with previous = prev::tl }
-        end
-        |> Visitor.skip
-    end
-
-  let fold range_from data_div =
-    Cobol_ptree.Visitor.fold_data_division'
-      (folder range_from)
-      data_div
-      init_acc
-    |> result
-end
-
-module Env
-  : T with type t = Cobol_ptree.environment_division Cobol_common.with_loc
-= struct
-  type t = Cobol_ptree.environment_division Cobol_common.with_loc
-  type acc = doc_symbol list
-  let init_acc = []
-
-  let folder range_from: acc Cobol_ptree.Visitor.folder =
-    let parent_folder: type a. _ =
-      fun ?(skip=false) name ({ loc; _ }: a Cobol_common.with_loc ) acc ->
+    method! fold_data_item' { loc; payload = di } acc =
       let range = range_from ~loc in
-      let parent = create ~kind:Module ~range ~name in
+      let data_name =
+        match di.data_name with
+        | Some { payload = DataName s'; _ } -> ~&s'
+        | _ -> "FILLER"
+      in
+      let true_level = ~&(di.data_level) in
+      let name =
+        (if true_level <= 9 then "0" else "")
+        ^ Int.to_string true_level
+        ^ " "
+        ^ data_name
+      in
+      let level = if true_level == 77 then 01 else true_level
+      in
+      let current = { range; name; level; buffer = [] } in
+      let acc = complete_entries current.level acc in
+      { acc with previous = current::acc.previous }
+      |>Visitor.skip
+
+    method! fold_rename_item' { loc; payload = ri } acc =
+      let range = range_from ~loc in
+      let name = "66 " ^ ~&(ri.rename_to) in
+      let current = { range; name; level = 02; buffer = [] } in
+      let acc = complete_entries current.level acc in
+      { acc with previous = current::acc.previous }
+      |>Visitor.skip
+
+    method! fold_constant_item' { loc; payload = ci } acc =
+      let range = range_from ~loc in
+      let name = "01 " ^ ~&(ci.constant_name) in
+      let constant = create ~kind:Constant ~range ~name () in
+      let acc = complete_entries 01 acc in
+      { acc with result = constant::acc.result }
+      |> Visitor.skip
+
+    method! fold_condition_name_item' { loc; payload = c } acc =
+      let range = range_from ~loc in
+      let name = "88 " ^ ~&(c.condition_name) in
+      let condition = create ~kind:Boolean ~range ~name () in
+      begin match acc.previous with
+        | [] -> { acc with result = condition::acc.result }
+        | prev::tl ->
+          let prev = { prev with buffer = condition::prev.buffer }
+          in { acc with previous = prev::tl }
+      end
+      |> Visitor.skip
+  end
+
+let fold_data_div range_from data_div =
+  let result acc = acc.result in
+  Cobol_ptree.Visitor.fold_data_division'
+    (data_folder range_from)
+    data_div
+    data_init_acc
+  |> result
+
+type env_acc = doc_symbol list
+let env_init_acc = []
+
+let env_folder range_from : env_acc Cobol_ptree.Visitor.folder =
+  let parent_folder: type a. _ =
+    fun ?(skip=false) name ({ loc; _ }: a Cobol_common.with_loc ) acc ->
+      let range = range_from ~loc in
+      let parent = create ~kind:Function ~range ~name in
       if skip
       then
         Visitor.skip (parent () :: acc)
       else
-      Visitor.do_children_and_then init_acc
-        begin fun children -> parent ~children () :: acc end
-    in
-    object
-      inherit [acc] Cobol_ptree.Visitor.folder
+        Visitor.do_children_and_then env_init_acc
+          begin fun children -> parent ~children () :: acc end
+  in
+  object
+    inherit [env_acc] Cobol_ptree.Visitor.folder
 
-      method! fold_environment_division' =
-        parent_folder "ENVIRONMENT DIVISION"
+    method! fold_environment_division' =
+      parent_folder "ENVIRONMENT DIVISION"
 
-      method! fold_configuration_section' =
-        parent_folder ~skip:true "CONFIGURATION SECTION"
+    method! fold_configuration_section' =
+      parent_folder ~skip:true "CONFIGURATION SECTION"
 
-      method! fold_input_output_section' =
-        parent_folder ~skip:true "INPUT-OUTPUT SECTION"
-    end
+    method! fold_input_output_section' =
+      parent_folder ~skip:true "INPUT-OUTPUT SECTION"
+  end
 
-  let fold range_from env_div =
-    Cobol_ptree.Visitor.fold_environment_division'
-      (folder range_from)
-      env_div
-      init_acc
-end
+let fold_env_div range_from env_div =
+  Cobol_ptree.Visitor.fold_environment_division'
+    (env_folder range_from)
+    env_div
+    env_init_acc
 
-let retrieve ~uri ptree : Lsp.Types.DocumentSymbol.t list =
+
+let _every_symbol_kind _ =
+  let pos = Position.create ~line:1 ~character:1 in
+  let range = Range.create ~end_:pos ~start:pos in
+  let create kind name = create ~kind ~name ~range () in
+  [ create File "File"; create Module "Module"; create Namespace "Namespace";
+    create Package "Package"; create Class "Class"; create Method "Method";
+    create Property "Property"; create Field "Field";
+    create Constructor "Constructor"; create Enum "Enum";
+    create Interface "Interface"; create Function "Function";
+    create Variable "Variable"; create Constant "Constant";
+    create String "String"; create Number "Number"; create Boolean "Boolean";
+    create Array "Array"; create Object "Object"; create Key "Key";
+    create Null "Null"; create EnumMember "EnumMember"; create Struct "Struct";
+    create Event "Event"; create Operator "Operator";
+    create TypeParameter "TypeParameter";
+  ]
+
+let from_ptree_at ~uri ptree : DocumentSymbol.t list =
   let filename = Lsp.Uri.to_path uri in
   let range_from ~loc = Lsp_position.range_of_srcloc_in ~filename loc in
-  let string_of_name_or_lit (name_or_lit: Cobol_ptree.name_or_literal) =
-    let s = Pretty.to_string "%a" Cobol_ptree.pp_term name_or_lit in s
+  let string_of_name_or_lit (name_or_lit: name_or_literal) =
+    let s = Pretty.to_string "%a" pp_term name_or_lit in s
   in
   let parent_folder: type a. _ =
-    fun ~kind name ({ loc; payload }: a Cobol_ptree.with_loc) acc ->
+    fun ~kind name ({ loc; payload }: a with_loc) acc ->
       let range = range_from ~loc in
       let name =  name payload in
       Visitor.do_children_and_then []
@@ -290,7 +285,6 @@ let retrieve ~uri ptree : Lsp.Types.DocumentSymbol.t list =
           create () ~children ~kind ~range ~name :: acc
         end
   in
-
   Cobol_ptree.Visitor.fold_compilation_group object
     inherit [doc_symbol list] Cobol_ptree.Visitor.folder
 
@@ -298,50 +292,47 @@ let retrieve ~uri ptree : Lsp.Types.DocumentSymbol.t list =
       Visitor.do_children_and_then acc List.rev
 
     method! fold_program_unit' =
-      parent_folder ~kind:Module
-      begin fun (cu: Cobol_ptree.program_unit) ->
-      "PROGRAM-ID. " ^ string_of_name_or_lit ~&(cu.program_name)
-      end
+      parent_folder ~kind:Function
+        begin fun (cu: program_unit) ->
+          "PROGRAM-ID. " ^ string_of_name_or_lit ~&(cu.program_name)
+        end
 
     method! fold_function_unit' =
       parent_folder ~kind:Function
-      begin fun (fu: Cobol_ptree.function_unit) ->
-      "FUNCTION-ID. " ^ string_of_name_or_lit ~&(fu.function_name)
-      end
+        begin fun (fu: function_unit) ->
+          "FUNCTION-ID. " ^ string_of_name_or_lit ~&(fu.function_name)
+        end
 
     method! fold_interface_definition' =
       parent_folder ~kind:Interface
-      begin fun (id: Cobol_ptree.interface_definition) ->
-      "INTERFACE-ID. " ^ string_of_name_or_lit ~&(id.interface_name)
-      end
+        begin fun (id: interface_definition) ->
+          "INTERFACE-ID. " ^ string_of_name_or_lit ~&(id.interface_name)
+        end
 
     method! fold_class_definition' =
       parent_folder ~kind:Class
-      begin fun (c: Cobol_ptree.class_definition) ->
-      "CLASS-ID. " ^ string_of_name_or_lit ~&(c.class_name)
-      end
+        begin fun (c: class_definition) ->
+          "CLASS-ID. " ^ string_of_name_or_lit ~&(c.class_name)
+        end
 
     method! fold_method_definition' =
       parent_folder ~kind:Method
-      begin fun (m: Cobol_ptree.method_definition) ->
-      "METHOD-ID. " ^ ~&(m.method_name)
-      end
+        begin fun (m: method_definition) ->
+          "METHOD-ID. " ^ ~&(m.method_name)
+        end
 
     method! fold_factory_definition' =
-      parent_folder ~kind:Object begin Fun.const "FACTORY." end
+      parent_folder ~kind:Object @@ Fun.const "FACTORY."
 
     method! fold_instance_definition' =
-      parent_folder ~kind:Object begin Fun.const "OBJECT." end
+      parent_folder ~kind:Object @@ Fun.const "OBJECT."
 
     method! fold_environment_division' div acc =
-      let result = Env.fold range_from div in
-      Visitor.skip (result @ acc)
+      Visitor.skip (fold_env_div range_from div @ acc)
 
     method! fold_data_division' div acc =
-      let result = Data.fold range_from div in
-      Visitor.skip (result @ acc)
+      Visitor.skip (fold_data_div range_from div @ acc)
 
     method! fold_procedure_division' div acc =
-      let result = Proc.fold range_from div in
-      Visitor.skip (result @ acc)
+      Visitor.skip (fold_proc_div range_from div @ acc)
   end ptree []

--- a/src/lsp/cobol_lsp/lsp_document_symbol.ml
+++ b/src/lsp/cobol_lsp/lsp_document_symbol.ml
@@ -1,0 +1,296 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Visitor = Cobol_common.Visitor
+open Cobol_common.Srcloc.INFIX
+open Lsp.Types.DocumentSymbol
+type range = Lsp.Types.Range.t
+type doc_symbol = t
+
+let enclosing_range (range: range) (buffer: doc_symbol list)  =
+  let end_ = match buffer with
+    | [] -> range.end_
+    | last::_ -> last.range.end_
+  in
+  Lsp.Types.Range.create ~start:range.start ~end_
+
+module type T = sig
+  type t
+  val fold:
+    (loc:Cobol_common.srcloc -> range)
+    -> t
+    -> doc_symbol list
+end
+
+module Proc
+  : T with type t = Cobol_ptree.procedure_division Cobol_common.with_loc
+= struct
+  type t = Cobol_ptree.procedure_division Cobol_common.with_loc
+  type acc =
+    {
+      result: doc_symbol list;
+      prev_section: (range * string) option;
+      buffer: doc_symbol list;
+    }
+
+  let result acc = acc.result
+  let init_acc = { result = []; prev_section = None; buffer = [] }
+
+  let complete_section { result; prev_section; buffer } =
+    match prev_section with
+    | None -> buffer @ result
+    | Some (range, name) ->
+      let range = enclosing_range range buffer in
+      create ()
+        ~kind:Function
+        ~name
+        ~range ~selectionRange:range
+        ~children:(List.rev buffer)
+      :: result
+
+  let folder range_from: acc Cobol_ptree.Visitor.folder =
+    object
+      inherit [acc] Cobol_ptree.Visitor.folder
+
+      method! fold_procedure_division' { loc; _ } { result; _ } =
+        Visitor.do_children_and_then init_acc
+          begin fun acc ->
+            let children = complete_section acc |> List.rev in
+            let range = range_from ~loc in
+            let procedure = create ()
+                ~children
+                ~kind:Module
+                ~range
+                ~selectionRange:range
+                ~name:"PROCEDURE DIVISION"
+            in
+            { init_acc with result = procedure::result; }
+          end
+
+      method! fold_paragraph' { loc; payload = p } acc =
+        let range = range_from ~loc in
+        let name = Option.fold
+            ~none:"Unnamed paragraph"
+            ~some:(fun s' ->
+                ~&s' ^ if p.paragraph_is_section then " SECTION" else "" )
+            p.paragraph_name in
+        begin
+          if p.paragraph_is_section
+          then
+            {
+              buffer = [];
+              prev_section = Some((range, name));
+              result = complete_section acc
+            }
+          else
+            let paragraph = create ()
+                ~kind:Function
+                ~range
+                ~selectionRange:range
+                ~name
+            in { acc with buffer = paragraph :: acc.buffer }
+        end
+        |> Visitor.skip_children
+    end
+
+  let fold range_from proc_div =
+    Cobol_ptree.Visitor.fold_procedure_division'
+      (folder range_from)
+      proc_div
+      init_acc
+    |> result
+end
+
+module Data
+  : T with type t = Cobol_ptree.data_division Cobol_common.with_loc
+= struct
+  type t = Cobol_ptree.data_division Cobol_common.with_loc
+  type buffered_data =
+    { range: range; name: string; level: int; buffer: doc_symbol list }
+  type acc =
+    { result: doc_symbol list; previous: buffered_data list; }
+  let result acc = acc.result
+  let init_acc = { result = []; previous = []; }
+
+  let create_doc_symbol { name; range; buffer; level } =
+    ignore level;
+    let range = enclosing_range range buffer in
+    create ()
+      ~children:(List.rev buffer)
+      ~kind:Variable
+      ~range:range
+      ~selectionRange:range
+      ~name:name
+
+  let rec complete_entries current_level acc  =
+    match acc.previous with
+    | [] -> acc
+    | prev::_ when current_level > prev.level -> acc
+    | [prev] ->
+      let prev_doc_sym = create_doc_symbol prev in
+      {
+        result = prev_doc_sym::acc.result;
+        previous = [];
+      }
+    | prev::prev2::tl ->
+      let prev_doc_sym = create_doc_symbol prev in
+      let prev2 = { prev2 with buffer = prev_doc_sym::prev2.buffer } in
+      complete_entries current_level { acc with previous = prev2::tl }
+
+  let folder range_from : acc Cobol_ptree.Visitor.folder =
+    let module_folder ~name loc acc =
+      let range = range_from ~loc in
+      let parent = create
+          ~kind:Module
+          ~range
+          ~selectionRange:range
+          ~name
+      in
+      Visitor.do_children_and_then init_acc
+        begin fun inner_acc ->
+          let { result = children; _ } = complete_entries 0 inner_acc in
+          {
+            result = parent ~children:(List.rev children) () :: acc.result;
+            previous = [];
+          }
+        end
+    in
+    object
+      inherit [acc] Cobol_ptree.Visitor.folder
+
+      method! fold_data_division' { loc; _ } =
+        module_folder ~name:"DATA DIVISION" loc
+
+      method! fold_file_section' { loc; _ } =
+        module_folder ~name:"FILE SECTION" loc
+
+      method! fold_linkage_section' { loc; _ } =
+        module_folder ~name:"LINKAGE SECTION" loc
+
+      method! fold_working_storage_section' { loc; _ } =
+        module_folder ~name:"WORKING-STORAGE SECTION" loc
+
+      method! fold_local_storage_section' { loc; _ } =
+        module_folder ~name:"LOCAL-STORAGE SECTION" loc
+
+      method! fold_communication_section' { loc; _ } =
+        module_folder ~name:"COMMUNICATION SECTION" loc
+
+      method! fold_report_section' { loc; _ } =
+        module_folder ~name:"REPORT SECTION" loc
+
+      method! fold_screen_section' { loc; _ } =
+        module_folder ~name:"SCREEN SECTION" loc
+
+      method! fold_data_item' { loc; payload = di } acc =
+        let range = range_from ~loc in
+        let data_name =
+          match di.data_name with
+          | Some { payload = Cobol_ptree.DataName s'; _ } -> ~&s'
+          | _ -> "FILLER"
+        in
+        let true_level = ~&(di.data_level) in
+        let name =
+          (if true_level <= 9 then "0" else "")
+          ^ Int.to_string true_level
+          ^ " "
+          ^ data_name
+        in
+        let level = if true_level == 77 then 01 else true_level
+        in
+        let current = { range; name; level; buffer = [] } in
+        let acc = complete_entries current.level acc in
+        { acc with previous = current::acc.previous }
+        |>Visitor.skip
+
+      method! fold_rename_item' { loc; payload = ri } acc =
+        let range = range_from ~loc in
+        let name = "66 " ^ ~&(ri.rename_to) in
+        let current = { range; name; level = 02; buffer = [] } in
+        let acc = complete_entries current.level acc in
+        { acc with previous = current::acc.previous }
+        |>Visitor.skip
+
+      method! fold_constant_item' { loc; payload = ci } acc =
+        let range = range_from ~loc in
+        let name = "01 " ^ ~&(ci.constant_name) in
+        let constant = create ()
+            ~kind:Constant
+            ~range
+            ~selectionRange:range
+            ~name
+        in
+        let acc = complete_entries 01 acc in
+        { acc with result = constant::acc.result }
+        |> Visitor.skip
+
+      method! fold_condition_name_item' { loc; payload = c } acc =
+        let range = range_from ~loc in
+        let name = "88 " ^ ~&(c.condition_name) in
+        let condition = create ()
+            ~kind:Boolean
+            ~range
+            ~selectionRange:range
+            ~name
+        in
+        begin match acc.previous with
+          | [] -> { acc with result = condition::acc.result }
+          | prev::tl ->
+            let prev = { prev with buffer = condition::prev.buffer }
+            in { acc with previous = prev::tl }
+        end
+        |> Visitor.skip
+    end
+
+  let fold range_from data_div =
+    Cobol_ptree.Visitor.fold_data_division'
+      (folder range_from)
+      data_div
+      init_acc
+    |> result
+end
+
+let retrieve ~uri ptree : Lsp.Types.DocumentSymbol.t list =
+  let filename = Lsp.Uri.to_path uri in
+  let range_from ~loc = Lsp_position.range_of_srcloc_in ~filename loc in
+  let string_of_name_or_lit (name_or_lit: Cobol_ptree.name_or_literal) =
+    let s = Pretty.to_string "%a" Cobol_ptree.pp_term name_or_lit in s
+  in
+  Cobol_ptree.Visitor.fold_compilation_group object
+    inherit [doc_symbol list] Cobol_ptree.Visitor.folder
+
+    method! fold_compilation_group _ acc =
+      Visitor.do_children_and_then acc List.rev
+
+    method! fold_program_unit' { loc; payload = cu } acc =
+      let range = range_from ~loc in
+      let name = "PROGRAM-ID. " ^ string_of_name_or_lit ~&(cu.program_name) in
+      Visitor.do_children_and_then []
+        begin fun children ->
+          create ()
+            ~children:(List.rev children)
+            ~kind:Module
+            ~range
+            ~selectionRange:range
+            ~name
+          :: acc
+        end
+
+    method! fold_data_division' data_div acc =
+      let result = Data.fold range_from data_div in
+      Visitor.skip (result @ acc)
+
+    method! fold_procedure_division' proc_div acc =
+      let result = Proc.fold range_from proc_div in
+      Visitor.skip (result @ acc)
+  end ptree []

--- a/src/lsp/cobol_lsp/lsp_document_symbol.mli
+++ b/src/lsp/cobol_lsp/lsp_document_symbol.mli
@@ -11,7 +11,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val retrieve
+val from_ptree_at
   : uri:Lsp.Uri.t
   -> Cobol_ptree.compilation_group
   -> Lsp.Types.DocumentSymbol.t list

--- a/src/lsp/cobol_lsp/lsp_document_symbol.mli
+++ b/src/lsp/cobol_lsp/lsp_document_symbol.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+val retrieve
+  : uri:Lsp.Uri.t
+  -> Cobol_ptree.compilation_group
+  -> Lsp.Types.DocumentSymbol.t list
+

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -579,52 +579,12 @@ let handle_folding_range registry (params: FoldingRangeParams.t) =
 
 (** { Document Symbol } *)
 
-let _u _f =
-  let pos = Position.create ~line:1 ~character:1 in
-  let range = Range.create ~end_:pos ~start:pos in
-  let l kind name = DocumentSymbol.create ()
-  ~kind
-  ~name
-  ~range
-  ~selectionRange:range
-  in
-  Some(`DocumentSymbol [
-    l File "File";
-    l Module "Module";
-    l Namespace "Namespace";
-    l Package "Package";
-    l Class "Class";
-    l Method "Method";
-    l Property "Property";
-    l Field "Field";
-    l Constructor "Constructor";
-    l Enum "Enum";
-    l Interface "Interface";
-    l Function "Function";
-    l Variable "Variable";
-    l Constant "Constant";
-    l String "String";
-    l Number "Number";
-    l Boolean "Boolean";
-    l Array "Array";
-    l Object "Object";
-    l Key "Key";
-    l Null "Null";
-    l EnumMember "EnumMember";
-    l Struct "Struct";
-    l Event "Event";
-    l Operator "Operator";
-    l TypeParameter "TypeParameter";
-      ])
-
-
 let handle_document_symbol registry (params: DocumentSymbolParams.t) =
   try_with_main_document_data registry params.textDocument
     ~f:begin fun ~doc { ptree; _ }->
       let uri = Lsp.Text_document.documentUri doc.textdoc in
-      match Lsp_document_symbol.retrieve ~uri ptree with
-      | [] -> _u ()
-      | l -> Some (`DocumentSymbol l)
+      let symbols = Lsp_document_symbol.from_ptree_at ~uri ptree in
+      Some (`DocumentSymbol symbols)
     end
 
 (** {3 Generic handling} *)

--- a/src/lsp/cobol_lsp/lsp_request.mli
+++ b/src/lsp/cobol_lsp/lsp_request.mli
@@ -37,4 +37,8 @@ module INTERNAL: sig
     : Lsp_server.t
     -> Lsp.Types.DocumentFormattingParams.t
     -> Lsp.Types.TextEdit.t list option
+  val document_symbol
+    : Lsp_server.t
+    -> Lsp.Types.DocumentSymbolParams.t
+    -> [> `DocumentSymbol of Lsp.Types.DocumentSymbol.t list ] option
 end

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -397,8 +397,8 @@ class_definition [@cost 999]:
  | cid = class_identification
    opo = ro(loc(options_paragraph))
    edo = ro(loc(environment_division))
-   fdo = io(factory_definition) (* Note: inline to avoid conflict *)
-   ido = ro(instance_definition)
+   fdo = io(loc(factory_definition)) (* Note: inline to avoid conflict *)
+   ido = ro(loc(instance_definition))
    END CLASS ec = unit_name "."
    { let _, (class_name, class_as, class_final,
              class_inherits, class_usings) = cid in

--- a/src/lsp/cobol_ptree/compilation_group.ml
+++ b/src/lsp/cobol_ptree/compilation_group.ml
@@ -253,8 +253,8 @@ type class_definition =
     class_usings: name with_loc list;
     class_options: options_paragraph with_loc option;
     class_env: environment_division with_loc option;
-    class_factory: factory_definition option;
-    class_instance: instance_definition option;
+    class_factory: factory_definition with_loc option;
+    class_instance: instance_definition with_loc option;
     class_end_name: name_or_literal with_loc;
   }
 [@@deriving ord]
@@ -279,8 +279,8 @@ let pp_class_definition ppf
     Fmt.(sp ++ pp_class_id_paragraph) (cn, cas, f, inh, us)
     Fmt.[ Option.map (const (pp_with_loc pp_options_paragraph)) opts;
           Option.map (const (pp_with_loc pp_environment_division)) env;
-          Option.map (const pp_factory_definition) fac;
-          Option.map (const pp_instance_definition) inst ]
+          Option.map (const (pp_with_loc pp_factory_definition)) fac;
+          Option.map (const (pp_with_loc pp_instance_definition)) inst ]
 
 
 type interface_definition =

--- a/src/lsp/cobol_ptree/compilation_group_visitor.ml
+++ b/src/lsp/cobol_ptree/compilation_group_visitor.ml
@@ -38,8 +38,11 @@ class virtual ['a] folder = object
   method fold_function_unit        : (function_unit                , 'a) fold = default
   method fold_function_unit'       : (function_unit with_loc       , 'a) fold = default
   method fold_method_definition    : (method_definition            , 'a) fold = default
+  method fold_method_definition'   : (method_definition with_loc   , 'a) fold = default
   method fold_factory_definition   : (factory_definition           , 'a) fold = default
+  method fold_factory_definition'  : (factory_definition with_loc  , 'a) fold = default
   method fold_instance_definition  : (instance_definition          , 'a) fold = default
+  method fold_instance_definition' : (instance_definition with_loc , 'a) fold = default
   method fold_class_definition'    : (class_definition with_loc    , 'a) fold = default
   method fold_interface_definition': (interface_definition with_loc, 'a) fold = default
   method fold_compilation_unit'    : (compilation_unit with_loc    , 'a) fold = default
@@ -139,8 +142,11 @@ let fold_method_definition (v: _#folder) =
       >> fold_name' v method_end_name                         (* XXX: useful? *)
     end
 
+let fold_method_definition' (v: _#folder) =
+  handle' v#fold_method_definition' ~fold:fold_method_definition v
+
 let fold_method_definitions (v: _#folder) =
-  fold_with_loc_list ~fold:fold_method_definition v
+  fold_list ~fold:fold_method_definition' v
 
 let fold_method_definitions' (v: _#folder) =
   fold' ~fold:fold_method_definitions v
@@ -159,6 +165,9 @@ let fold_factory_definition (v: _#folder) =
       >> fold_method_definitions'_opt v factory_methods
     end
 
+let fold_factory_definition' (v: _#folder) =
+  handle' v#fold_factory_definition' ~fold:fold_factory_definition v
+
 let fold_instance_definition (v: _#folder) =
   handle v#fold_instance_definition
     ~continue:begin fun { instance_implements; instance_options; instance_env;
@@ -169,6 +178,9 @@ let fold_instance_definition (v: _#folder) =
       >> fold_data_division'_opt v instance_data
       >> fold_method_definitions'_opt v instance_methods
     end
+
+let fold_instance_definition' (v: _#folder) =
+  handle' v#fold_instance_definition' ~fold:fold_instance_definition v
 
 let fold_class_definition' (v: _#folder) =
   handle' v#fold_class_definition' v
@@ -182,8 +194,8 @@ let fold_class_definition' (v: _#folder) =
       >> fold_name'_list v class_usings
       >> fold_options_paragraph'_opt v class_options
       >> fold_environment_division'_opt v class_env
-      >> fold_option ~fold:fold_factory_definition v class_factory
-      >> fold_option ~fold:fold_instance_definition v class_instance
+      >> fold_option ~fold:fold_factory_definition' v class_factory
+      >> fold_option ~fold:fold_instance_definition' v class_instance
       >> fold_name_or_literal' v class_end_name
     end
 

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -1,0 +1,237 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Lsp.Types
+open Lsp_testing
+
+let rec count (doc_symbols: DocumentSymbol.t list) =
+  List.fold_left (fun acc (doc_sym: DocumentSymbol.t) ->
+      match doc_sym.children with
+      | None -> acc + 1
+      | Some children -> acc + 1 + count children) 0 doc_symbols
+
+let pp_range ppf (range: Range.t) =
+  Fmt.pf ppf "%d:%d -> %d:%d" range.start.line range.start.character
+    range.end_.line range.end_.character
+
+let s_of_kind (kind: SymbolKind.t) =
+  match kind with
+  | File -> "File"
+  | Module -> "Module"
+  | Namespace -> "Namespace"
+  | Package -> "Package"
+  | Class -> "Class"
+  | Method -> "Method"
+  | Property -> "Property"
+  | Field -> "Field"
+  | Constructor -> "Constructor"
+  | Enum -> "Enum"
+  | Interface -> "Interface"
+  | Function -> "Function"
+  | Variable -> "Variable"
+  | Constant -> "Constant"
+  | String -> "String"
+  | Number -> "Number"
+  | Boolean -> "Boolean"
+  | Array -> "Array"
+  | Object -> "Object"
+  | Key -> "Key"
+  | Null -> "Null"
+  | EnumMember -> "EnumMember"
+  | Struct -> "Struct"
+  | Event -> "Event"
+  | Operator -> "Operator"
+  | TypeParameter -> "TypeParameter"
+
+
+let rec print_symbol_with_children ppf (doc_sym: DocumentSymbol.t) =
+  Fmt.pf ppf "@[<v 2>%s(%s)\t%a@;%a@]"
+    doc_sym.name
+    (s_of_kind doc_sym.kind)
+    pp_range doc_sym.range
+    Fmt.(option (list ~sep:sp print_symbol_with_children)) doc_sym.children
+
+let document_symbol doc : string -> unit =
+  let { end_with_postproc; projdir }, server = make_lsp_project () in
+  let server, prog = add_cobol_doc server ~projdir "prog.cob" doc in
+  let params = DocumentSymbolParams.create () ~textDocument:prog in
+  begin match LSP.Request.document_symbol server params with
+    | None ->
+      Pretty.out "No document symbol@."
+    | Some `DocumentSymbol document_symbols ->
+      Pretty.out "@.@[<v 2>Doc symbols (%d total):@;%a@]@\n"
+      (count document_symbols)
+      Fmt.(list ~sep:sp print_symbol_with_children)
+      document_symbols
+  end;
+  end_with_postproc
+;;
+
+let%expect_test "emtpy-document-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. prog.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (1 total):
+      PROGRAM-ID. prog(Module)	1:8 -> 2:25 |}]
+
+let%expect_test "procedure-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. full.
+        PROCEDURE DIVISION.
+          sec1 SECTION.
+            para11.
+            para12.
+          sec2 SECTION.
+            para21.
+          sec3 SECTION.
+        END PROGRAM full.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. onesection.
+        PROCEDURE DIVISION.
+          sec1 SECTION.
+        END PROGRAM onesection.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. oneparagraph.
+        PROCEDURE DIVISION.
+          para1.
+        END PROGRAM oneparagraph.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. anon.
+        PROCEDURE DIVISION.
+          display "anon".
+        END PROGRAM anon.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. anon_n_sec.
+        PROCEDURE DIVISION.
+          display "anon".
+          sec1 SECTION.
+        END PROGRAM anon_n_sec.
+
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. emtpy.
+        PROCEDURE DIVISION.
+        END PROGRAM empty.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (23 total):
+      PROGRAM-ID. full(Module)	1:8 -> 10:25
+        PROCEDURE DIVISION(Module)	3:8 -> 9:23
+          sec1 SECTION(Function)	4:10 -> 6:19
+            para11(Function)	5:12 -> 5:19
+            para12(Function)	6:12 -> 6:19
+          sec2 SECTION(Function)	7:10 -> 8:19
+            para21(Function)	8:12 -> 8:19
+          sec3 SECTION(Function)	9:10 -> 9:23
+      PROGRAM-ID. onesection(Module)	12:8 -> 16:31
+        PROCEDURE DIVISION(Module)	14:8 -> 15:23
+          sec1 SECTION(Function)	15:10 -> 15:23
+      PROGRAM-ID. oneparagraph(Module)	18:8 -> 22:33
+        PROCEDURE DIVISION(Module)	20:8 -> 21:16
+          para1(Function)	21:10 -> 21:16
+      PROGRAM-ID. anon(Module)	24:8 -> 28:25
+        PROCEDURE DIVISION(Module)	26:8 -> 27:25
+          Unnamed paragraph(Function)	27:10 -> 27:25
+      PROGRAM-ID. anon_n_sec(Module)	30:8 -> 35:31
+        PROCEDURE DIVISION(Module)	32:8 -> 34:23
+          Unnamed paragraph(Function)	33:10 -> 33:25
+          sec1 SECTION(Function)	34:10 -> 34:23
+      PROGRAM-ID. emtpy(Module)	37:8 -> 40:26
+        PROCEDURE DIVISION(Module)	39:8 -> 39:27 |}]
+
+let%expect_test "datadiv-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. prog.
+        DATA DIVISION.
+        WORKING-STORAGE SECTION.
+        01.
+          88 fillercond VALUE "aaaa".
+          02 aa PIC X.
+          88 aacond VALUE "a".
+          02 bb.
+            03 cc.
+              04 dd PIC X.
+            03 ee PIC X.
+            03.
+              04 ff PIC X.
+              88 ffcond VALUE "a".
+        66 renanme-aa RENAMES aa THRU bb.
+        01 cons constant "constant".
+        01 zz occurs 10 times indexed by ind.
+          02 yy PIC X.
+        END PROGRAM prog.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (18 total):
+      PROGRAM-ID. prog(Module)	1:8 -> 20:25
+        DATA DIVISION(Module)	3:8 -> 19:22
+          WORKING-STORAGE SECTION(Module)	4:8 -> 19:22
+            01 FILLER(Variable)	5:8 -> 16:41
+              88 fillercond(Boolean)	6:10 -> 6:37
+              02 aa(Variable)	7:10 -> 8:30
+                88 aacond(Boolean)	8:10 -> 8:30
+              02 bb(Variable)	9:10 -> 15:34
+                03 cc(Variable)	10:12 -> 11:26
+                  04 dd(Variable)	11:14 -> 11:26
+                03 ee(Variable)	12:12 -> 12:24
+                03 FILLER(Variable)	13:12 -> 15:34
+                  04 ff(Variable)	14:14 -> 15:34
+                    88 ffcond(Boolean)	15:14 -> 15:34
+              66 renanme-aa(Variable)	16:8 -> 16:41
+            01 cons(Constant)	17:8 -> 17:36
+            01 zz(Variable)	18:8 -> 19:22
+              02 yy(Variable)	19:10 -> 19:22 |}]
+
+let%expect_test "many-division-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. prog.
+        DATA DIVISION.
+        LOCAL-STORAGE SECTION.
+        01 aa PIC X USAGE DISPLAY.
+        WORKING-STORAGE SECTION.
+        01 bb PIC X USAGE DISPLAY.
+        PROCEDURE DIVISION.
+          para.
+        END PROGRAM prog.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (8 total):
+      PROGRAM-ID. prog(Module)	1:8 -> 10:25
+        DATA DIVISION(Module)	3:8 -> 7:34
+          WORKING-STORAGE SECTION(Module)	6:8 -> 7:34
+            01 bb(Variable)	7:8 -> 7:34
+          LOCAL-STORAGE SECTION(Module)	4:8 -> 5:34
+            01 aa(Variable)	5:8 -> 5:34
+        PROCEDURE DIVISION(Module)	8:8 -> 9:15
+          para(Function)	9:10 -> 9:15 |}]
+

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -24,7 +24,7 @@ let pp_range ppf (range: Range.t) =
   Fmt.pf ppf "%d:%d -> %d:%d" range.start.line range.start.character
     range.end_.line range.end_.character
 
-let s_of_kind (kind: SymbolKind.t) =
+let string_of_kind (kind: SymbolKind.t) =
   match kind with
   | File -> "File"
   | Module -> "Module"
@@ -53,11 +53,10 @@ let s_of_kind (kind: SymbolKind.t) =
   | Operator -> "Operator"
   | TypeParameter -> "TypeParameter"
 
-
 let rec print_symbol_with_children ppf (doc_sym: DocumentSymbol.t) =
   Fmt.pf ppf "@[<v 2>%s(%s)\t%a@;%a@]"
     doc_sym.name
-    (s_of_kind doc_sym.kind)
+    (string_of_kind doc_sym.kind)
     pp_range doc_sym.range
     Fmt.(option (list ~sep:sp print_symbol_with_children)) doc_sym.children
 
@@ -87,7 +86,7 @@ let%expect_test "emtpy-document-symbol" =
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (1 total):
-      PROGRAM-ID. prog(Module)	1:8 -> 2:25 |}]
+      PROGRAM-ID. prog(Function)	1:8 -> 2:25 |}]
 
 let%expect_test "procedure-symbol" =
   let end_with_postproc = document_symbol {cobol|
@@ -137,29 +136,29 @@ let%expect_test "procedure-symbol" =
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (23 total):
-      PROGRAM-ID. full(Module)	1:8 -> 10:25
-        PROCEDURE DIVISION(Module)	3:8 -> 9:23
+      PROGRAM-ID. full(Function)	1:8 -> 10:25
+        PROCEDURE DIVISION(Function)	3:8 -> 9:23
           sec1 SECTION(Function)	4:10 -> 6:19
             para11(Function)	5:12 -> 5:19
             para12(Function)	6:12 -> 6:19
           sec2 SECTION(Function)	7:10 -> 8:19
             para21(Function)	8:12 -> 8:19
           sec3 SECTION(Function)	9:10 -> 9:23
-      PROGRAM-ID. onesection(Module)	12:8 -> 16:31
-        PROCEDURE DIVISION(Module)	14:8 -> 15:23
+      PROGRAM-ID. onesection(Function)	12:8 -> 16:31
+        PROCEDURE DIVISION(Function)	14:8 -> 15:23
           sec1 SECTION(Function)	15:10 -> 15:23
-      PROGRAM-ID. oneparagraph(Module)	18:8 -> 22:33
-        PROCEDURE DIVISION(Module)	20:8 -> 21:16
+      PROGRAM-ID. oneparagraph(Function)	18:8 -> 22:33
+        PROCEDURE DIVISION(Function)	20:8 -> 21:16
           para1(Function)	21:10 -> 21:16
-      PROGRAM-ID. anon(Module)	24:8 -> 28:25
-        PROCEDURE DIVISION(Module)	26:8 -> 27:25
+      PROGRAM-ID. anon(Function)	24:8 -> 28:25
+        PROCEDURE DIVISION(Function)	26:8 -> 27:25
           Unnamed paragraph(Function)	27:10 -> 27:25
-      PROGRAM-ID. anon_n_sec(Module)	30:8 -> 35:31
-        PROCEDURE DIVISION(Module)	32:8 -> 34:23
+      PROGRAM-ID. anon_n_sec(Function)	30:8 -> 35:31
+        PROCEDURE DIVISION(Function)	32:8 -> 34:23
           Unnamed paragraph(Function)	33:10 -> 33:25
           sec1 SECTION(Function)	34:10 -> 34:23
-      PROGRAM-ID. emtpy(Module)	37:8 -> 40:26
-        PROCEDURE DIVISION(Module)	39:8 -> 39:27 |}]
+      PROGRAM-ID. emtpy(Function)	37:8 -> 40:26
+        PROCEDURE DIVISION(Function)	39:8 -> 39:27 |}]
 
 let%expect_test "datadiv-symbol" =
   let end_with_postproc = document_symbol {cobol|
@@ -189,9 +188,9 @@ let%expect_test "datadiv-symbol" =
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (18 total):
-      PROGRAM-ID. prog(Module)	1:8 -> 20:25
-        DATA DIVISION(Module)	3:8 -> 19:22
-          WORKING-STORAGE SECTION(Module)	4:8 -> 19:22
+      PROGRAM-ID. prog(Function)	1:8 -> 20:25
+        DATA DIVISION(Function)	3:8 -> 19:22
+          WORKING-STORAGE SECTION(Function)	4:8 -> 19:22
             01 FILLER(Variable)	5:8 -> 16:41
               88 fillercond(Boolean)	6:10 -> 6:37
               02 aa(Variable)	7:10 -> 8:30
@@ -228,10 +227,10 @@ let%expect_test "envdiv-symbol" =
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (4 total):
-      PROGRAM-ID. prog(Module)	1:8 -> 12:25
-        ENVIRONMENT DIVISION(Module)	3:8 -> 11:20
-          CONFIGURATION SECTION(Module)	4:8 -> 8:33
-          INPUT-OUTPUT SECTION(Module)	9:8 -> 11:20 |}]
+      PROGRAM-ID. prog(Function)	1:8 -> 12:25
+        ENVIRONMENT DIVISION(Function)	3:8 -> 11:20
+          CONFIGURATION SECTION(Function)	4:8 -> 8:33
+          INPUT-OUTPUT SECTION(Function)	9:8 -> 11:20 |}]
 
 
 let%expect_test "many-division-symbol" =
@@ -256,15 +255,15 @@ let%expect_test "many-division-symbol" =
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (10 total):
-      PROGRAM-ID. prog(Module)	1:8 -> 14:25
-        ENVIRONMENT DIVISION(Module)	3:8 -> 6:16
-          CONFIGURATION SECTION(Module)	4:8 -> 6:16
-        DATA DIVISION(Module)	7:8 -> 11:34
-          WORKING-STORAGE SECTION(Module)	10:8 -> 11:34
+      PROGRAM-ID. prog(Function)	1:8 -> 14:25
+        ENVIRONMENT DIVISION(Function)	3:8 -> 6:16
+          CONFIGURATION SECTION(Function)	4:8 -> 6:16
+        DATA DIVISION(Function)	7:8 -> 11:34
+          WORKING-STORAGE SECTION(Function)	10:8 -> 11:34
             01 bb(Variable)	11:8 -> 11:34
-          LOCAL-STORAGE SECTION(Module)	8:8 -> 9:34
+          LOCAL-STORAGE SECTION(Function)	8:8 -> 9:34
             01 aa(Variable)	9:8 -> 9:34
-        PROCEDURE DIVISION(Module)	12:8 -> 13:15
+        PROCEDURE DIVISION(Function)	12:8 -> 13:15
           para(Function)	13:10 -> 13:15 |}]
 
 let%expect_test "object-symbol" =
@@ -402,64 +401,64 @@ let%expect_test "object-symbol" =
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     Doc symbols (60 total):
       CLASS-ID. Account(Class)	1:4 -> 126:22
-        ENVIRONMENT DIVISION(Module)	2:4 -> 5:15
-          CONFIGURATION SECTION(Module)	3:4 -> 5:15
+        ENVIRONMENT DIVISION(Function)	2:4 -> 5:15
+          CONFIGURATION SECTION(Function)	3:4 -> 5:15
         FACTORY.(Object)	7:4 -> 38:16
-          DATA DIVISION(Module)	8:4 -> 10:46
-            WORKING-STORAGE SECTION(Module)	9:4 -> 10:46
+          DATA DIVISION(Function)	8:4 -> 10:46
+            WORKING-STORAGE SECTION(Function)	9:4 -> 10:46
               01 number-of-accounts(Variable)	10:4 -> 10:46
           METHOD-ID. newAccount(Method)	13:4 -> 23:26
-            DATA DIVISION(Module)	14:4 -> 17:56
-              LINKAGE SECTION(Module)	16:4 -> 17:56
+            DATA DIVISION(Function)	14:4 -> 17:56
+              LINKAGE SECTION(Function)	16:4 -> 17:56
                 01 an-object(Variable)	17:4 -> 17:56
-              LOCAL-STORAGE SECTION(Module)	15:4 -> 15:26
-            PROCEDURE DIVISION(Module)	18:4 -> 22:13
+              LOCAL-STORAGE SECTION(Function)	15:4 -> 15:26
+            PROCEDURE DIVISION(Function)	18:4 -> 22:13
               begin-here(Function)	19:4 -> 22:13
           METHOD-ID. addAccount(Method)	25:4 -> 30:26
-            PROCEDURE DIVISION(Module)	26:4 -> 29:13
+            PROCEDURE DIVISION(Function)	26:4 -> 29:13
               method-start(Function)	27:4 -> 29:13
           METHOD-ID. removeAccount(Method)	32:4 -> 37:29
-            PROCEDURE DIVISION(Module)	33:4 -> 36:13
+            PROCEDURE DIVISION(Function)	33:4 -> 36:13
               main-entry(Function)	34:4 -> 36:13
         OBJECT.(Object)	40:4 -> 125:15
-          DATA DIVISION(Module)	41:4 -> 45:25
-            WORKING-STORAGE SECTION(Module)	42:4 -> 45:25
+          DATA DIVISION(Function)	41:4 -> 45:25
+            WORKING-STORAGE SECTION(Function)	42:4 -> 45:25
               01 account-balance(Variable)	43:4 -> 43:36
               01 account-number(Variable)	44:4 -> 44:31
               01 the-date(Variable)	45:4 -> 45:25
           METHOD-ID. displayUI(Method)	48:4 -> 77:25
-            DATA DIVISION(Module)	49:4 -> 54:26
-              LOCAL-STORAGE SECTION(Module)	50:4 -> 54:26
+            DATA DIVISION(Function)	49:4 -> 54:26
+              LOCAL-STORAGE SECTION(Function)	50:4 -> 54:26
                 01 in-data(Variable)	51:4 -> 54:26
                   03 action-type(Variable)	52:6 -> 52:27
                   03 in-amount(Variable)	53:6 -> 53:32
                   03 in-wrk(Variable)	54:6 -> 54:26
-            PROCEDURE DIVISION(Module)	55:4 -> 76:51
+            PROCEDURE DIVISION(Function)	55:4 -> 76:51
               method-start(Function)	56:4 -> 72:13
               get-amount(Function)	73:4 -> 76:51
           METHOD-ID. balance(Method)	79:4 -> 88:23
-            DATA DIVISION(Module)	80:4 -> 82:43
-              LOCAL-STORAGE SECTION(Module)	81:4 -> 82:43
+            DATA DIVISION(Function)	80:4 -> 82:43
+              LOCAL-STORAGE SECTION(Function)	81:4 -> 82:43
                 01 display-balance(Variable)	82:4 -> 82:43
-            PROCEDURE DIVISION(Module)	83:4 -> 87:13
+            PROCEDURE DIVISION(Function)	83:4 -> 87:13
               disp-balance(Function)	84:4 -> 87:13
           METHOD-ID. deposit(Method)	90:4 -> 98:23
-            DATA DIVISION(Module)	91:4 -> 93:31
-              LINKAGE SECTION(Module)	92:4 -> 93:31
+            DATA DIVISION(Function)	91:4 -> 93:31
+              LINKAGE SECTION(Function)	92:4 -> 93:31
                 01 in-deposit(Variable)	93:4 -> 93:31
-            PROCEDURE DIVISION(Module)	94:4 -> 97:13
+            PROCEDURE DIVISION(Function)	94:4 -> 97:13
               make-deposit(Function)	95:4 -> 97:13
           METHOD-ID. withdraw(Method)	100:4 -> 112:24
-            DATA DIVISION(Module)	101:4 -> 103:32
-              LINKAGE SECTION(Module)	102:4 -> 103:32
+            DATA DIVISION(Function)	101:4 -> 103:32
+              LINKAGE SECTION(Function)	102:4 -> 103:32
                 01 in-withdraw(Variable)	103:4 -> 103:32
-            PROCEDURE DIVISION(Module)	104:4 -> 111:13
+            PROCEDURE DIVISION(Function)	104:4 -> 111:13
               withdraw-start(Function)	105:4 -> 111:13
           METHOD-ID. initializeAccount(Method)	114:4 -> 124:33
-            DATA DIVISION(Module)	115:4 -> 117:35
-              LINKAGE SECTION(Module)	116:4 -> 117:35
+            DATA DIVISION(Function)	115:4 -> 117:35
+              LINKAGE SECTION(Function)	116:4 -> 117:35
                 01 new-account-number(Variable)	117:4 -> 117:35
-            PROCEDURE DIVISION(Module)	118:4 -> 123:13
+            PROCEDURE DIVISION(Function)	118:4 -> 123:13
               Begin-initialization(Function)	119:4 -> 123:13 |}]
 
 let%expect_test "interface-symbol" =
@@ -491,13 +490,13 @@ let%expect_test "interface-symbol" =
     Doc symbols (12 total):
       INTERFACE-ID. BaseFactoryInterface(Interface)	1:4 -> 9:39
         METHOD-ID. New2(Method)	3:4 -> 8:20
-          DATA DIVISION(Module)	4:4 -> 6:53
-            LINKAGE SECTION(Module)	5:4 -> 6:53
+          DATA DIVISION(Function)	4:4 -> 6:53
+            LINKAGE SECTION(Function)	5:4 -> 6:53
               01 outObject(Variable)	6:4 -> 6:53
-          PROCEDURE DIVISION(Module)	7:4 -> 7:43
+          PROCEDURE DIVISION(Function)	7:4 -> 7:43
       INTERFACE-ID. INTERFACE(Interface)	11:4 -> 19:32
         METHOD-ID. FactoryObject(Method)	13:4 -> 18:29
-          DATA DIVISION(Module)	14:4 -> 16:65
-            LINKAGE SECTION(Module)	15:4 -> 16:65
+          DATA DIVISION(Function)	14:4 -> 16:65
+            LINKAGE SECTION(Function)	15:4 -> 16:65
               01 outFactory(Variable)	16:4 -> 16:65
-          PROCEDURE DIVISION(Module)	17:4 -> 17:44 |}]
+          PROCEDURE DIVISION(Function)	17:4 -> 17:44 |}]

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -208,10 +208,40 @@ let%expect_test "datadiv-symbol" =
             01 zz(Variable)	18:8 -> 19:22
               02 yy(Variable)	19:10 -> 19:22 |}]
 
+let%expect_test "envdiv-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID. prog.
+        ENVIRONMENT DIVISION.
+        CONFIGURATION SECTION.
+        SOURCE-COMPUTER.
+          LINUX.
+        REPOSITORY.
+          FUNCTION ALL INTRINSIC.
+        INPUT-OUTPUT SECTION.
+        FILE-CONTROL.
+        I-O-CONTROL.
+        END PROGRAM prog.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (4 total):
+      PROGRAM-ID. prog(Module)	1:8 -> 12:25
+        ENVIRONMENT DIVISION(Module)	3:8 -> 11:20
+          CONFIGURATION SECTION(Module)	4:8 -> 8:33
+          INPUT-OUTPUT SECTION(Module)	9:8 -> 11:20 |}]
+
+
 let%expect_test "many-division-symbol" =
   let end_with_postproc = document_symbol {cobol|
         IDENTIFICATION DIVISION.
         PROGRAM-ID. prog.
+        ENVIRONMENT DIVISION.
+        CONFIGURATION SECTION.
+        SOURCE-COMPUTER.
+          LINUX.
         DATA DIVISION.
         LOCAL-STORAGE SECTION.
         01 aa PIC X USAGE DISPLAY.
@@ -225,13 +255,15 @@ let%expect_test "many-division-symbol" =
   end_with_postproc [%expect.output];
   [%expect {|
     {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
-    Doc symbols (8 total):
-      PROGRAM-ID. prog(Module)	1:8 -> 10:25
-        DATA DIVISION(Module)	3:8 -> 7:34
-          WORKING-STORAGE SECTION(Module)	6:8 -> 7:34
-            01 bb(Variable)	7:8 -> 7:34
-          LOCAL-STORAGE SECTION(Module)	4:8 -> 5:34
-            01 aa(Variable)	5:8 -> 5:34
-        PROCEDURE DIVISION(Module)	8:8 -> 9:15
-          para(Function)	9:10 -> 9:15 |}]
+    Doc symbols (10 total):
+      PROGRAM-ID. prog(Module)	1:8 -> 14:25
+        ENVIRONMENT DIVISION(Module)	3:8 -> 6:16
+          CONFIGURATION SECTION(Module)	4:8 -> 6:16
+        DATA DIVISION(Module)	7:8 -> 11:34
+          WORKING-STORAGE SECTION(Module)	10:8 -> 11:34
+            01 bb(Variable)	11:8 -> 11:34
+          LOCAL-STORAGE SECTION(Module)	8:8 -> 9:34
+            01 aa(Variable)	9:8 -> 9:34
+        PROCEDURE DIVISION(Module)	12:8 -> 13:15
+          para(Function)	13:10 -> 13:15 |}]
 

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -152,10 +152,10 @@ let%expect_test "procedure-symbol" =
           para1(Function)	21:10 -> 21:16
       PROGRAM-ID. anon(Function)	24:8 -> 28:25
         PROCEDURE DIVISION(Function)	26:8 -> 27:25
-          Unnamed paragraph(Function)	27:10 -> 27:25
+          Anonymous paragraph(Function)	27:10 -> 27:25
       PROGRAM-ID. anon_n_sec(Function)	30:8 -> 35:31
         PROCEDURE DIVISION(Function)	32:8 -> 34:23
-          Unnamed paragraph(Function)	33:10 -> 33:25
+          Anonymous paragraph(Function)	33:10 -> 33:25
           sec1 SECTION(Function)	34:10 -> 34:23
       PROGRAM-ID. emtpy(Function)	37:8 -> 40:26
         PROCEDURE DIVISION(Function)	39:8 -> 39:27 |}]

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -267,3 +267,237 @@ let%expect_test "many-division-symbol" =
         PROCEDURE DIVISION(Module)	12:8 -> 13:15
           para(Function)	13:10 -> 13:15 |}]
 
+let%expect_test "object-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+    CLASS-ID. Account INHERITS Base.
+    ENVIRONMENT DIVISION.
+    CONFIGURATION SECTION.
+    REPOSITORY.
+    CLASS Base.
+
+    FACTORY.
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+    01 number-of-accounts PIC 9(5) VALUE ZERO.
+    PROCEDURE DIVISION.
+
+    METHOD-ID. newAccount
+    DATA DIVISION.
+    LOCAL-STORAGE SECTION.
+    LINKAGE SECTION.
+    01 an-object USAGE IS OBJECT REFERENCE ACTIVE-CLASS.
+    PROCEDURE DIVISION RETURNING an-object.
+    begin-here.
+      INVOKE SELF "new" RETURNING an-object.
+      INVOKE an-object "initializeAccount" USING BY CONTENT number-of-accounts.
+      GOBACK.
+    END METHOD newAccount.
+
+    METHOD-ID. addAccount
+    PROCEDURE DIVISION.
+    method-start.
+      ADD 1 TO number-of-accounts.
+      GOBACK.
+    END METHOD addAccount.
+
+    METHOD-ID. removeAccount
+    PROCEDURE DIVISION.
+    main-entry.
+      SUBTRACT 1 FROM number-of-accounts.
+      GOBACK.
+    END METHOD removeAccount.
+    END FACTORY.
+
+    OBJECT.
+    DATA DIVISION.
+    WORKING-STORAGE SECTION.
+    01 account-balance PIC S9(9)V99.
+    01 account-number PIC X(9).
+    01 the-date PIC 9(8).
+    PROCEDURE DIVISION.
+
+    METHOD-ID. displayUI
+    DATA DIVISION.
+    LOCAL-STORAGE SECTION.
+    01 in-data.
+      03 action-type PIC X.
+      03 in-amount PIC S9(9)V99.
+      03 in-wrk PIC X(12).
+    PROCEDURE DIVISION.
+    method-start.
+      DISPLAY "Enter D for Deposit, B for Balance or W for Withdrawal"
+      ACCEPT in-data
+      EVALUATE action-type
+        WHEN "D"
+          PERFORM get-amount
+          INVOKE SELF "deposit" USING in-amount
+        WHEN "W"
+          PERFORM get-amount
+          INVOKE SELF "withdraw" USING in-amount
+        WHEN "B"
+          INVOKE SELF "balance"
+        WHEN OTHER
+          DISPLAY "Enter valid transaction type."
+          GOBACK
+      END-EVALUATE
+      GOBACK.
+    get-amount.
+      DISPLAY "Enter amount 9(9).99"
+      ACCEPT in-wrk
+      COMPUTE in-amount = FUNCTION NUMVAL (in-wrk).
+    END METHOD displayUI.
+
+    METHOD-ID. balance
+    DATA DIVISION.
+    LOCAL-STORAGE SECTION.
+    01 display-balance PIC ZZZ,ZZZ,ZZ9.99B.
+    PROCEDURE DIVISION.
+    disp-balance.
+      MOVE account-balance to display-balance
+      DISPLAY "Your Account Balance is:" display-balance
+      GOBACK.
+    END METHOD balance.
+
+    METHOD-ID. deposit
+    DATA DIVISION.
+    LINKAGE SECTION.
+    01 in-deposit PIC S9(9)V99.
+    PROCEDURE DIVISION USING in-deposit.
+    make-deposit.
+      ADD in-deposit TO account-balance
+      GOBACK.
+    END METHOD deposit.
+
+    METHOD-ID. withdraw
+    DATA DIVISION.
+    LINKAGE SECTION.
+    01 in-withdraw PIC S9(9)V99.
+    PROCEDURE DIVISION USING in-withdraw.
+    withdraw-start.
+      IF account-balance >= in-withdraw
+        SUBTRACT in-withdraw FROM account-balance
+      ELSE
+        DISPLAY "Your Balance is Inadequate"
+      END-IF
+      GOBACK.
+    END METHOD withdraw.
+
+    METHOD-ID. initializeAccount
+    DATA DIVISION.
+    LINKAGE SECTION.
+    01 new-account-number PIC 9(5).
+    PROCEDURE DIVISION USING new-account-number.
+    Begin-initialization.
+      MOVE ZERO TO account-balance
+      MOVE new-account-number TO account-number
+      MOVE FUNCTION CURRENT-DATE (1: 8) TO the-date
+      GOBACK.
+    END METHOD initializeAccount.
+    END OBJECT.
+    END CLASS Account.
+  |cobol}
+ in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (60 total):
+      CLASS-ID. Account(Class)	1:4 -> 126:22
+        ENVIRONMENT DIVISION(Module)	2:4 -> 5:15
+          CONFIGURATION SECTION(Module)	3:4 -> 5:15
+        FACTORY.(Object)	7:4 -> 38:16
+          DATA DIVISION(Module)	8:4 -> 10:46
+            WORKING-STORAGE SECTION(Module)	9:4 -> 10:46
+              01 number-of-accounts(Variable)	10:4 -> 10:46
+          METHOD-ID. newAccount(Method)	13:4 -> 23:26
+            DATA DIVISION(Module)	14:4 -> 17:56
+              LINKAGE SECTION(Module)	16:4 -> 17:56
+                01 an-object(Variable)	17:4 -> 17:56
+              LOCAL-STORAGE SECTION(Module)	15:4 -> 15:26
+            PROCEDURE DIVISION(Module)	18:4 -> 22:13
+              begin-here(Function)	19:4 -> 22:13
+          METHOD-ID. addAccount(Method)	25:4 -> 30:26
+            PROCEDURE DIVISION(Module)	26:4 -> 29:13
+              method-start(Function)	27:4 -> 29:13
+          METHOD-ID. removeAccount(Method)	32:4 -> 37:29
+            PROCEDURE DIVISION(Module)	33:4 -> 36:13
+              main-entry(Function)	34:4 -> 36:13
+        OBJECT.(Object)	40:4 -> 125:15
+          DATA DIVISION(Module)	41:4 -> 45:25
+            WORKING-STORAGE SECTION(Module)	42:4 -> 45:25
+              01 account-balance(Variable)	43:4 -> 43:36
+              01 account-number(Variable)	44:4 -> 44:31
+              01 the-date(Variable)	45:4 -> 45:25
+          METHOD-ID. displayUI(Method)	48:4 -> 77:25
+            DATA DIVISION(Module)	49:4 -> 54:26
+              LOCAL-STORAGE SECTION(Module)	50:4 -> 54:26
+                01 in-data(Variable)	51:4 -> 54:26
+                  03 action-type(Variable)	52:6 -> 52:27
+                  03 in-amount(Variable)	53:6 -> 53:32
+                  03 in-wrk(Variable)	54:6 -> 54:26
+            PROCEDURE DIVISION(Module)	55:4 -> 76:51
+              method-start(Function)	56:4 -> 72:13
+              get-amount(Function)	73:4 -> 76:51
+          METHOD-ID. balance(Method)	79:4 -> 88:23
+            DATA DIVISION(Module)	80:4 -> 82:43
+              LOCAL-STORAGE SECTION(Module)	81:4 -> 82:43
+                01 display-balance(Variable)	82:4 -> 82:43
+            PROCEDURE DIVISION(Module)	83:4 -> 87:13
+              disp-balance(Function)	84:4 -> 87:13
+          METHOD-ID. deposit(Method)	90:4 -> 98:23
+            DATA DIVISION(Module)	91:4 -> 93:31
+              LINKAGE SECTION(Module)	92:4 -> 93:31
+                01 in-deposit(Variable)	93:4 -> 93:31
+            PROCEDURE DIVISION(Module)	94:4 -> 97:13
+              make-deposit(Function)	95:4 -> 97:13
+          METHOD-ID. withdraw(Method)	100:4 -> 112:24
+            DATA DIVISION(Module)	101:4 -> 103:32
+              LINKAGE SECTION(Module)	102:4 -> 103:32
+                01 in-withdraw(Variable)	103:4 -> 103:32
+            PROCEDURE DIVISION(Module)	104:4 -> 111:13
+              withdraw-start(Function)	105:4 -> 111:13
+          METHOD-ID. initializeAccount(Method)	114:4 -> 124:33
+            DATA DIVISION(Module)	115:4 -> 117:35
+              LINKAGE SECTION(Module)	116:4 -> 117:35
+                01 new-account-number(Variable)	117:4 -> 117:35
+            PROCEDURE DIVISION(Module)	118:4 -> 123:13
+              Begin-initialization(Function)	119:4 -> 123:13 |}]
+
+let%expect_test "interface-symbol" =
+  let end_with_postproc = document_symbol {cobol|
+    INTERFACE-ID. BaseFactoryInterface.
+    PROCEDURE DIVISION.
+    METHOD-ID. New2
+    DATA DIVISION.
+    LINKAGE SECTION.
+    01 outObject USAGE OBJECT REFERENCE ACTIVE-CLASS.
+    PROCEDURE DIVISION RETURNING outObject.
+    END METHOD New2.
+    END INTERFACE BaseFactoryInterface.
+
+    INTERFACE-ID. Interface.
+    PROCEDURE DIVISION.
+    METHOD-ID. FactoryObject
+    DATA DIVISION.
+    LINKAGE SECTION.
+    01 outFactory USAGE OBJECT REFERENCE FACTORY OF ACTIVE-CLASS.
+    PROCEDURE DIVISION RETURNING outFactory.
+    END METHOD FactoryObject.
+    END INTERFACE BaseInterface.
+|cobol}
+  in
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    Doc symbols (12 total):
+      INTERFACE-ID. BaseFactoryInterface(Interface)	1:4 -> 9:39
+        METHOD-ID. New2(Method)	3:4 -> 8:20
+          DATA DIVISION(Module)	4:4 -> 6:53
+            LINKAGE SECTION(Module)	5:4 -> 6:53
+              01 outObject(Variable)	6:4 -> 6:53
+          PROCEDURE DIVISION(Module)	7:4 -> 7:43
+      INTERFACE-ID. INTERFACE(Interface)	11:4 -> 19:32
+        METHOD-ID. FactoryObject(Method)	13:4 -> 18:29
+          DATA DIVISION(Module)	14:4 -> 16:65
+            LINKAGE SECTION(Module)	15:4 -> 16:65
+              01 outFactory(Variable)	16:4 -> 16:65
+          PROCEDURE DIVISION(Module)	17:4 -> 17:44 |}]


### PR DESCRIPTION
Documentation: [documentSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol).
Mainly used to show [outline](https://code.visualstudio.com/docs/getstarted/userinterface#_outline-view) and [breadcrumbs](https://code.visualstudio.com/docs/getstarted/userinterface#_breadcrumbs) in VSC.