### PR TITLE
Fix `method_id_paragraph` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Basic syntax highlighting for SQL statements embedded in `EXEC`/`END-EXEC` blocks [#290](https://github.com/OCamlPro/superbol-studio-oss/pull/290)
 
 ### Fixed
-- Improvements to the grammar [#310](https://github.com/OCamlPro/superbol-studio-oss/pull/310)
+- Improvements to the grammar [#310](https://github.com/OCamlPro/superbol-studio-oss/pull/310), [#319](https://github.com/OCamlPro/superbol-studio-oss/pull/319)
 - Internal mishandling of tokens when dealing with some `EXEC`/`END-EXEC` blocks [#301](https://github.com/OCamlPro/superbol-studio-oss/pull/301)
 - Internal pretty-printing routine for `EXEC`/`END-EXEC` blocks [#300](https://github.com/OCamlPro/superbol-studio-oss/pull/300)
 - Support for line continuations that start with a text word [#294](https://github.com/OCamlPro/superbol-studio-oss/pull/294)

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -559,10 +559,10 @@ let interface_id_paragraph :=                                      (* +COB2002 *
 
 let method_id_paragraph :=                                         (* +COB2002 *)
   | METHOD_ID; "."; i = name; slo = as__strlit_;
-    o = bo(OVERRIDE); f = bo(IS?; FINAL; {});
+    o = bo(OVERRIDE); f = bo(IS?; FINAL; {}); ".";
     { i, NamedMethod { as_ = slo }, o, f }
   | METHOD_ID; "."; pk = property_kind; PROPERTY; i = name;
-    o = bo(OVERRIDE); f = bo(IS?; FINAL; {});
+    o = bo(OVERRIDE); f = bo(IS?; FINAL; {}); ".";
     { i, PropertyMethod { kind = pk }, o, f }
 
 let options_paragraph [@context options_paragraph] :=              (* +COB2002 *)

--- a/test/lsp/lsp_document_symbol.ml
+++ b/test/lsp/lsp_document_symbol.ml
@@ -280,7 +280,7 @@ let%expect_test "object-symbol" =
     01 number-of-accounts PIC 9(5) VALUE ZERO.
     PROCEDURE DIVISION.
 
-    METHOD-ID. newAccount
+    METHOD-ID. newAccount.
     DATA DIVISION.
     LOCAL-STORAGE SECTION.
     LINKAGE SECTION.
@@ -292,14 +292,14 @@ let%expect_test "object-symbol" =
       GOBACK.
     END METHOD newAccount.
 
-    METHOD-ID. addAccount
+    METHOD-ID. addAccount.
     PROCEDURE DIVISION.
     method-start.
       ADD 1 TO number-of-accounts.
       GOBACK.
     END METHOD addAccount.
 
-    METHOD-ID. removeAccount
+    METHOD-ID. removeAccount.
     PROCEDURE DIVISION.
     main-entry.
       SUBTRACT 1 FROM number-of-accounts.
@@ -315,7 +315,7 @@ let%expect_test "object-symbol" =
     01 the-date PIC 9(8).
     PROCEDURE DIVISION.
 
-    METHOD-ID. displayUI
+    METHOD-ID. displayUI.
     DATA DIVISION.
     LOCAL-STORAGE SECTION.
     01 in-data.
@@ -346,7 +346,7 @@ let%expect_test "object-symbol" =
       COMPUTE in-amount = FUNCTION NUMVAL (in-wrk).
     END METHOD displayUI.
 
-    METHOD-ID. balance
+    METHOD-ID. balance.
     DATA DIVISION.
     LOCAL-STORAGE SECTION.
     01 display-balance PIC ZZZ,ZZZ,ZZ9.99B.
@@ -357,7 +357,7 @@ let%expect_test "object-symbol" =
       GOBACK.
     END METHOD balance.
 
-    METHOD-ID. deposit
+    METHOD-ID. deposit.
     DATA DIVISION.
     LINKAGE SECTION.
     01 in-deposit PIC S9(9)V99.
@@ -367,7 +367,7 @@ let%expect_test "object-symbol" =
       GOBACK.
     END METHOD deposit.
 
-    METHOD-ID. withdraw
+    METHOD-ID. withdraw.
     DATA DIVISION.
     LINKAGE SECTION.
     01 in-withdraw PIC S9(9)V99.
@@ -381,7 +381,7 @@ let%expect_test "object-symbol" =
       GOBACK.
     END METHOD withdraw.
 
-    METHOD-ID. initializeAccount
+    METHOD-ID. initializeAccount.
     DATA DIVISION.
     LINKAGE SECTION.
     01 new-account-number PIC 9(5).
@@ -465,7 +465,7 @@ let%expect_test "interface-symbol" =
   let end_with_postproc = document_symbol {cobol|
     INTERFACE-ID. BaseFactoryInterface.
     PROCEDURE DIVISION.
-    METHOD-ID. New2
+    METHOD-ID. New2.
     DATA DIVISION.
     LINKAGE SECTION.
     01 outObject USAGE OBJECT REFERENCE ACTIVE-CLASS.
@@ -475,7 +475,7 @@ let%expect_test "interface-symbol" =
 
     INTERFACE-ID. Interface.
     PROCEDURE DIVISION.
-    METHOD-ID. FactoryObject
+    METHOD-ID. FactoryObject.
     DATA DIVISION.
     LINKAGE SECTION.
     01 outFactory USAGE OBJECT REFERENCE FACTORY OF ACTIVE-CLASS.


### PR DESCRIPTION
Added required . after `METHOD-ID. name`