### PR TITLE
Add language configuration file to fix word wrapping and improve UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [0.1.4] Next release
 
 ### Added
-- Vscode `language-configuration.json` for cobol to include hyphen in word wrapping [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
+- COBOL language configuration for highlighting matching brackets and auto-insertion of line numbers in fixed- format code [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
+
+### Fixed
+- Word wrapping in presence of hyphens [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
 
 
 ## [0.1.3] Fourth α release (2024-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [0.1.4] Next release
 
+### Added
+- Vscode `language-configuration.json` for cobol to include hyphen in word wrapping [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
+
 
 ## [0.1.3] Fourth α release (2024-07-24)
 

--- a/package.json
+++ b/package.json
@@ -394,7 +394,8 @@
         ],
         "filenamePatterns": [
           "*.[cC]{ob,OB,bl,BL,py,PY,bx,BX}"
-        ]
+        ],
+        "configuration": "./syntaxes/language-configuration.json"
       }
     ],
     "problemMatchers": [

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -97,6 +97,7 @@ let contributes =
       Manifest.language "cobol"
         ~aliases: [ "COBOL" ]
         ~filenamePatterns: [ "*." ^ cob_extensions_pattern ]
+        ~configuration: "./syntaxes/language-configuration.json"
     ]
     ~debuggers: [
       Manifest.debugger "gdb"

--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -1,0 +1,14 @@
+{
+  "wordPattern": "[a-zA-Z0-9_-]+",
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "onEnterRules": [
+    {
+      "beforeText": "^[0-9]{6}.*",
+      "action": { "indent": "none", "appendText": "000000 " }
+    }
+  ]
+}


### PR DESCRIPTION
+ Fix for https://github.com/OCamlPro/superbol-studio-oss/issues/326
+ Brackets highlighting
+ Enter pattern for editions of fixed-format source code