### PR TITLE
Set upperbound on lsp version

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-87f249ca419608d7f0ccd748946d4c0a:.
+8c51879620df5ee78e682121fa0f6c23:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -76,7 +76,7 @@ c8281f46ba9a11d0b61bc8ef67eaa357:docs/style.css
 
 # begin context for dune-project
 # file dune-project
-8e9d416c902f3add28c0170d913f26e8:dune-project
+4e989e0a9f2846286056c008047f99ff:dune-project
 # end context for dune-project
 
 # begin context for opam/cobol_common.opam
@@ -106,7 +106,7 @@ d7c870139778d0a6e34395be1ea0c85b:opam/cobol_indent_old.opam
 
 # begin context for opam/cobol_lsp.opam
 # file opam/cobol_lsp.opam
-9063b0ec1b18f632346f56b92c3baf21:opam/cobol_lsp.opam
+f1979dd618dbe096cbf3f6ebd7b764ad:opam/cobol_lsp.opam
 # end context for opam/cobol_lsp.opam
 
 # begin context for opam/cobol_parser.opam

--- a/dune-project
+++ b/dune-project
@@ -294,7 +294,7 @@
    (superbol_project (= version))
    (superbol_preprocs (= version))
    (pretty (= version))
-   (lsp ( >= 1.18 ))
+   (lsp (and ( >= 1.18 )( < 1.19 )))
    (jsonrpc ( >= 1.15 ))
    (cobol_typeck (= version))
    (cobol_parser (= version))

--- a/opam/cobol_lsp.opam
+++ b/opam/cobol_lsp.opam
@@ -51,7 +51,7 @@ depends: [
   "superbol_project" {= version}
   "superbol_preprocs" {= version}
   "pretty" {= version}
-  "lsp" {>= "1.18"}
+  "lsp" {>= "1.18" & < "1.19"}
   "jsonrpc" {>= "1.15"}
   "cobol_typeck" {= version}
   "cobol_parser" {= version}

--- a/opam/osx/cobol_lsp-osx.opam
+++ b/opam/osx/cobol_lsp-osx.opam
@@ -53,7 +53,7 @@ depends: [
   "superbol_project-osx" {= version}
   "superbol_preprocs-osx" {= version}
   "pretty-osx" {= version}
-  "lsp-osx" {>= "1.18"}
+  "lsp-osx" {>= "1.18" & < "1.19"}
   "jsonrpc-osx" {>= "1.15"}
   "cobol_typeck-osx" {= version}
   "cobol_parser-osx" {= version}

--- a/opam/windows/cobol_lsp-windows.opam
+++ b/opam/windows/cobol_lsp-windows.opam
@@ -53,7 +53,7 @@ depends: [
   "superbol_project-windows" {= version}
   "superbol_preprocs-windows" {= version}
   "pretty-windows" {= version}
-  "lsp-windows" {>= "1.18"}
+  "lsp-windows" {>= "1.18" & < "1.19"}
   "jsonrpc-windows" {>= "1.15"}
   "cobol_typeck-windows" {= version}
   "cobol_parser-windows" {= version}

--- a/src/lsp/cobol_lsp/package.toml
+++ b/src/lsp/cobol_lsp/package.toml
@@ -62,7 +62,7 @@ cobol_typeck = "version"
 superbol_preprocs = "version"
 superbol_project = "version"
 jsonrpc = ">=1.15"
-lsp = "1.18"
+lsp = ">=1.18 <1.19"
 pretty = "version"
 toml = "7.1.0"
 


### PR DESCRIPTION
Temporary to let other PR build
A PR to upgrade to 1.19 will be required later