### PR TITLE
Unify `pp_token` of Text_tokenizer with other pp

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-8c51879620df5ee78e682121fa0f6c23:.
+718cb8b13f0858c7f365dd1cc0efd9bd:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -346,7 +346,7 @@ de6c46a271140f4f52b2580e0d876351:src/lsp/cobol_lsp/version.mlt
 
 # begin context for src/lsp/cobol_parser/dune
 # file src/lsp/cobol_parser/dune
-44b9b76fe2777a06cbe5a7eb212f7b16:src/lsp/cobol_parser/dune
+0bdd09727ecc330598da0a5c0582a262:src/lsp/cobol_parser/dune
 # end context for src/lsp/cobol_parser/dune
 
 # begin context for src/lsp/cobol_parser/version.mlt

--- a/src/lsp/cobol_lsp/lsp_completion.ml
+++ b/src/lsp/cobol_lsp/lsp_completion.ml
@@ -236,10 +236,9 @@ let string_of_K tokens =
       | [] -> ()
       | Cobol_parser.Tokens.PERIOD::tl ->
         Fmt.string ppf ".\n"; inner tl
-      | hd::tl ->
-        let token' = hd &@ Srcloc.dummy in
+      | token::tl ->
         if space_before then Fmt.sp ppf ();
-        Cobol_parser.INTERNAL.pp_token ppf token'; (* TODO: Cobol_parser.Tokens.pp *)
+        Cobol_parser.Tokens.pp ppf token;
         inner tl
     in
     inner ~space_before:false

--- a/src/lsp/cobol_parser/cobol_parser.ml
+++ b/src/lsp/cobol_parser/cobol_parser.ml
@@ -20,7 +20,13 @@ module Options = Parser_options
 module Outputs = Parser_outputs
 module Diagnostics = Parser_diagnostics
 
-module Tokens = Grammar_tokens
+module Tokens = struct
+  include Grammar_tokens
+  let pp = Text_tokenizer.pp_token
+  let pp' = Text_tokenizer.pp_token'
+  let pp'_list = Text_tokenizer.pp_token'_list
+  let pp'_list_with_loc_info = Text_tokenizer.pp_tokens_with_loc_info
+end
 module Expect = Grammar_expect
 module Printer = Grammar_printer
 module Keywords = Text_keywords
@@ -35,12 +41,6 @@ include Parser_engine
     Signatures of modules below may change unexpectedly. *)
 
 module INTERNAL = struct
-
-  (** {2 COBOL tokens} *)
-
-  let pp_token = Text_tokenizer.pp_token
-  let pp_tokens = Text_tokenizer.pp_tokens
-  let pp_tokens' = Text_tokenizer.pp_tokens'
 
   (** {2 COBOL grammar} *)
 

--- a/src/lsp/cobol_parser/cobol_parser.ml
+++ b/src/lsp/cobol_parser/cobol_parser.ml
@@ -24,7 +24,7 @@ module Tokens = struct
   include Grammar_tokens
   let pp = Text_tokenizer.pp_token
   let pp' = Text_tokenizer.pp_token'
-  let pp'_list = Text_tokenizer.pp_token'_list
+  let pp'_list = Text_tokenizer.pp_tokens
   let pp'_list_with_loc_info = Text_tokenizer.pp_tokens_with_loc_info
 end
 module Expect = Grammar_expect

--- a/src/lsp/cobol_parser/cobol_parser.ml
+++ b/src/lsp/cobol_parser/cobol_parser.ml
@@ -22,10 +22,10 @@ module Diagnostics = Parser_diagnostics
 
 module Tokens = struct
   include Grammar_tokens
-  let pp = Text_tokenizer.pp_token
-  let pp' = Text_tokenizer.pp_token'
-  let pp'_list = Text_tokenizer.pp_tokens
-  let pp'_list_with_loc_info = Text_tokenizer.pp_tokens_with_loc_info
+  let pp = Grammar_tokens_printer.pp_token
+  let pp' = Grammar_tokens_printer.pp_token'
+  let pp'_list = Grammar_tokens_printer.pp_tokens
+  let pp'_list_with_loc_info = Grammar_tokens_printer.pp_tokens_with_loc_info
 end
 module Expect = Grammar_expect
 module Printer = Grammar_printer

--- a/src/lsp/cobol_parser/dune
+++ b/src/lsp/cobol_parser/dune
@@ -43,7 +43,7 @@
   (action
     (with-stdout-to %{targets}
        (run %{exe:./keywords/gen_keywords.exe} %{deps}
-            --external-tokens Grammar_tokens))))
+            --external-tokens Grammar_tokens --with-is-intrinsic))))
 
 (rule
   (targets grammar_expect.ml)

--- a/src/lsp/cobol_parser/grammar_tokens_printer.ml
+++ b/src/lsp/cobol_parser/grammar_tokens_printer.ml
@@ -77,8 +77,10 @@ let pp_token: token Pretty.printer = fun ppf ->
     | FIXEDLIT (i, sep, d) -> print "FIXED[%s%c%s]" i sep d
     | FLOATLIT (i, sep, d, e) -> print "FLOAT[%s%c%sE%s]" i sep d e
     | INTERVENING_ c -> print "<%c>" c
-    | tok when Text_keywords.is_intrinsic_token tok ->
+    | INTRINSIC_FUNC _ as tok ->
         print "INTRINSIC_FUNC[%a]" pp_token_string tok
+    | tok when Text_keywords.is_known_intrinsic_token tok ->
+        print "SPECIALIZED_INTRINSIC_FUNC[%a]" pp_token_string tok
     | EOF -> string "EOF"
     | t -> pp_token_string ppf t
 

--- a/src/lsp/cobol_parser/grammar_tokens_printer.ml
+++ b/src/lsp/cobol_parser/grammar_tokens_printer.ml
@@ -1,0 +1,96 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2023 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Cobol_common.Srcloc.INFIX
+open Cobol_common.Srcloc.TYPES
+open Grammar_tokens                              (* import token constructors *)
+
+(* --- *)
+
+let combined_tokens =
+  (* /!\ WARNING: None of the constituents of combined tokens may be
+     context-sensitive.
+
+     Rationale: this would considerably complicate retokenization (which is
+     necessary with the current solution to handle context-sensitive
+     keywords) *)
+  Hashtbl.of_seq @@
+  Seq.map (fun (a, b) -> b, a) @@
+  List.to_seq Text_keywords.combined_keywords
+
+let pp_alphanum_string_prefix ppf Cobol_ptree.{ hexadecimal; quotation; str;
+                                                runtime_repr } =
+  if runtime_repr = Null_terminated_bytes then Fmt.char ppf 'Z';
+  if hexadecimal then Fmt.char ppf 'X';
+  match quotation with
+  | Simple_quote -> Fmt.pf ppf "'%s" str
+  | Double_quote -> Fmt.pf ppf "\"%s" str
+
+let pp_token_string: token Pretty.printer = fun ppf ->
+  let string s = Pretty.string ppf s
+  and print format = Pretty.print ppf format in
+  function
+  | WORD w
+  | WORD_IN_AREA_A w
+  | PICTURE_STRING w
+  | INFO_WORD w
+  | DIGITS w
+  | SINTLIT w -> string w
+  | EIGHTY_EIGHT -> string "88"
+  | FIXEDLIT (i, sep, d) -> print "%s%c%s" i sep d
+  | FLOATLIT (i, sep, d, e) -> print "%s%c%sE%s" i sep d e
+  | ALPHANUM a -> Cobol_ptree.pp_alphanum ppf a
+  | ALPHANUM_PREFIX a -> pp_alphanum_string_prefix ppf a
+  | NATLIT s -> print "N\"%s\"" s
+  | BOOLIT b -> print "B\"%a\"" Cobol_ptree.pp_boolean b
+  | COMMENT_ENTRY e -> print "%a" Fmt.(list ~sep:sp string) e
+  | EXEC_BLOCK b -> Cobol_common.Exec_block.pp ppf b
+  | INTERVENING_ c -> print "%c" c
+  | t -> string @@
+      try Text_lexer.show_token t
+      with Not_found ->
+      try Hashtbl.find combined_tokens t
+      with Not_found -> "<unknown/unexpected token>"
+
+let pp_token: token Pretty.printer = fun ppf ->
+  let string s = Pretty.string ppf s
+  and print format = Pretty.print ppf format in
+  function
+    | WORD w -> print "WORD[%s]" w
+    | WORD_IN_AREA_A w -> print "WORD_IN_AREA_A[%s]" w
+    | PICTURE_STRING w -> print "PICTURE_STRING[%s]" w
+    | INFO_WORD s -> print "INFO_WORD[%s]" s
+    | COMMENT_ENTRY _ as t -> print "COMMENT_ENTRY[%a]" pp_token_string t
+    | EXEC_BLOCK _ as t -> print "EXEC_BLOCK[%a]" pp_token_string t
+    | DIGITS i -> print "DIGITS[%s]" i
+    | SINTLIT i -> print "SINT[%s]" i
+    | FIXEDLIT (i, sep, d) -> print "FIXED[%s%c%s]" i sep d
+    | FLOATLIT (i, sep, d, e) -> print "FLOAT[%s%c%sE%s]" i sep d e
+    | INTERVENING_ c -> print "<%c>" c
+    | tok when Text_keywords.is_intrinsic_token tok ->
+        print "INTRINSIC_FUNC[%a]" pp_token_string tok
+    | EOF -> string "EOF"
+    | t -> pp_token_string ppf t
+
+let pp_token': token with_loc Pretty.printer =
+  Cobol_common.Srcloc.pp_with_loc pp_token
+
+let pp_tokens : token with_loc list Pretty.printer =
+  Pretty.list ~fopen:"@[" ~fclose:"@]" pp_token'
+
+let pp_tokens_with_loc_info ?fsep : token with_loc list Pretty.printer =
+  Pretty.list ~fopen:"@[" ?fsep ~fclose:"@]" begin fun ppf t ->
+    Pretty.print ppf "%a@@%a"
+      pp_token' t
+      Cobol_common.Srcloc.pp_srcloc_struct ~@t
+  end

--- a/src/lsp/cobol_parser/keywords/gen_keywords.ml
+++ b/src/lsp/cobol_parser/keywords/gen_keywords.ml
@@ -174,10 +174,25 @@ let emit_intrinsic_functions_list ppf =
   Terminal.iter (emit_custom_intrinsics ppf);
   Fmt.pf ppf "@]@\n]@."
 
+let emit_is_intrinsic ppf =
+  if String.equal cmlyname "grammar.cmly" then
+  let is_intrinsic t =
+    intrinsic (Terminal.attributes t) |> Option.is_some
+  in
+  Fmt.pf ppf "@[<2>let is_intrinsic_token = %s.(function@." tokens_module;
+  Terminal.iter begin fun t ->
+    if is_intrinsic t
+    then Fmt.pf ppf "| %a@." pp_terminal t
+  end;
+  Fmt.pf ppf "| INTRINSIC_FUNC _ -> true@.";
+  Fmt.pf ppf "| _ -> false@]\n)@."
+
+
 let emit ppf =
   Fmt.pf ppf
     "(* Caution: this file was automatically generated from %s; do not edit *)\
      @\n[@@@@@@warning \"-33\"] (* <- do not warn on unused opens *)\
+     @\n%t\
      @\n%t\
      @\n%t\
      @\n%t\
@@ -192,6 +207,7 @@ let emit ppf =
     emit_intrinsic_functions_list
     emit_puncts_list
     emit_silenced_keywords_list
+    emit_is_intrinsic
 
 let () =
   emit Fmt.stdout

--- a/src/lsp/cobol_parser/keywords/gen_keywords.ml
+++ b/src/lsp/cobol_parser/keywords/gen_keywords.ml
@@ -13,6 +13,7 @@
 
 let cmlyname = ref None
 let external_tokens = ref ""
+let with_is_intrinsic = ref false
 
 let usage_msg = Fmt.str "%s [OPTIONS] file.cmly" Sys.argv.(0)
 let anon str = match !cmlyname with
@@ -23,6 +24,8 @@ let () =
   Arg.parse
     Arg.[
       ("--external-tokens", Set_string external_tokens,
+       "<module> Import token type definition from <module>");
+      ("--with-is-intrinsic", Set with_is_intrinsic,
        "<module> Import token type definition from <module>");
     ]
     anon usage_msg
@@ -175,16 +178,15 @@ let emit_intrinsic_functions_list ppf =
   Fmt.pf ppf "@]@\n]@."
 
 let emit_is_intrinsic ppf =
-  if String.equal cmlyname "grammar.cmly" then
+  if !with_is_intrinsic then
   let is_intrinsic t =
     intrinsic (Terminal.attributes t) |> Option.is_some
   in
-  Fmt.pf ppf "@[<2>let is_intrinsic_token = %s.(function@." tokens_module;
+  Fmt.pf ppf "@[<2>let is_known_intrinsic_token = %s.(function@." tokens_module;
   Terminal.iter begin fun t ->
     if is_intrinsic t
     then Fmt.pf ppf "| %a@." pp_terminal t
   end;
-  Fmt.pf ppf "| INTRINSIC_FUNC _ -> true@.";
   Fmt.pf ppf "| _ -> false@]\n)@."
 
 

--- a/src/lsp/cobol_parser/package.toml
+++ b/src/lsp/cobol_parser/package.toml
@@ -102,7 +102,7 @@ dune-trailer = """
   (action
     (with-stdout-to %{targets}
        (run %{exe:./keywords/gen_keywords.exe} %{deps}
-            --external-tokens Grammar_tokens))))
+            --external-tokens Grammar_tokens --with-is-intrinsic))))
 
 (rule
   (targets grammar_expect.ml)

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -163,7 +163,7 @@ let all_diags { preproc = { pp; diags; tokzr; _ }; _ } =
 
 (* --- *)
 
-let rec produce_tokens (ps: _ state as 's) : 's * Tokzr.token' list =
+let rec produce_tokens (ps: _ state as 's) : 's * Text_tokenizer.tokens =
   let text, pp = Cobol_preproc.next_chunk ps.preproc.pp in
   let { preproc = { pp; tokzr; _ }; _ } as ps = update_pp ps pp in
   assert (text <> []);
@@ -400,7 +400,7 @@ type ('a, 'm) stage =
     rewound. *)
 and ('a, 'm) interim_stage =
   'm state *
-  Tokzr.token' list *
+  Text_tokenizer.tokens *
   'a Grammar_interpr.env                     (* Always valid input_needed env. *)
 
 (** Final stage, at which the parser has stopped processing. *)

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -163,7 +163,7 @@ let all_diags { preproc = { pp; diags; tokzr; _ }; _ } =
 
 (* --- *)
 
-let rec produce_tokens (ps: _ state as 's) : 's * Text_tokenizer.tokens =
+let rec produce_tokens (ps: _ state as 's) : 's * Tokzr.token' list =
   let text, pp = Cobol_preproc.next_chunk ps.preproc.pp in
   let { preproc = { pp; tokzr; _ }; _ } as ps = update_pp ps pp in
   assert (text <> []);
@@ -400,7 +400,7 @@ type ('a, 'm) stage =
     rewound. *)
 and ('a, 'm) interim_stage =
   'm state *
-  Text_tokenizer.tokens *
+  Tokzr.token' list *
   'a Grammar_interpr.env                     (* Always valid input_needed env. *)
 
 (** Final stage, at which the parser has stopped processing. *)

--- a/src/lsp/cobol_parser/text_keywords.mli
+++ b/src/lsp/cobol_parser/text_keywords.mli
@@ -28,3 +28,5 @@ val silenced_keywords: string list
 
 (** Mapping from punctuations to their respective tokens *)
 val puncts: (string * Grammar_tokens.token) list
+
+val is_intrinsic_token: Grammar_tokens.token -> bool

--- a/src/lsp/cobol_parser/text_keywords.mli
+++ b/src/lsp/cobol_parser/text_keywords.mli
@@ -29,4 +29,4 @@ val silenced_keywords: string list
 (** Mapping from punctuations to their respective tokens *)
 val puncts: (string * Grammar_tokens.token) list
 
-val is_intrinsic_token: Grammar_tokens.token -> bool
+val is_known_intrinsic_token: Grammar_tokens.token -> bool

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -510,13 +510,17 @@ let reword_intrinsics s : tokens -> tokens =
      [Disabled_intrinsics] does not occur on a `FUNCTION` keyword (but that's
      unlikely). *)
   let keyword_of_token = Hashtbl.find Text_lexer.word_of_token in
+  let is_intrinsic_token = function
+    | INTRINSIC_FUNC _ -> true
+    | t when Text_keywords.is_known_intrinsic_token t -> true
+    | _ -> false in
   let rec aux rev_prefix suffix =
     match suffix with
     | [] ->
         List.rev rev_prefix
     | ({ payload = k1_token; _ } as k1) ::
       ({ payload = k2_token; _ } as k2) :: tl
-      when k1_token <> FUNCTION && Text_keywords.is_intrinsic_token k2_token ->
+      when k1_token <> FUNCTION && is_intrinsic_token k2_token ->
         aux (EzList.tail_map distinguish_words @@
              retokenize s (keyword_of_token k2_token &@<- k2) @
              k1 :: rev_prefix) tl

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -18,118 +18,16 @@ open Cobol_common.Srcloc.INFIX
 open Cobol_common.Srcloc.TYPES
 open Cobol_preproc.Text.TYPES
 open Grammar_tokens                              (* import token constructors *)
+open Grammar_tokens_printer
 open Parser_diagnostics
 
 (* --- *)
 
-type token' = Grammar_tokens.token with_loc
-type tokens = token' list
-
-let combined_tokens =
-  (* /!\ WARNING: None of the constituents of combined tokens may be
-     context-sensitive.
-
-     Rationale: this would considerably complicate retokenization (which is
-     necessary with the current solution to handle context-sensitive
-     keywords) *)
-  Hashtbl.of_seq @@
-  Seq.map (fun (a, b) -> b, a) @@
-  List.to_seq Text_keywords.combined_keywords
-
-let is_intrinsic_token = function
-  | BYTE_LENGTH_FUNC
-  | CHAR_FUNC
-  | CONTENT_OF_FUNC
-  | CONVERT_FUNC
-  | CURRENT_DATE_FUNC
-  | FORMATTED_DATETIME_FUNC
-  | FORMATTED_TIME_FUNC
-  | LENGTH_FUNC
-  | LOCALE_DATE_FUNC
-  | LOCALE_TIME_FROM_SECONDS_FUNC
-  | LOCALE_TIME_FUNC
-  | NUMVAL_C_FUNC
-  | RANDOM_FUNC
-  | RANGE_FUNC
-  | REVERSE_FUNC
-  | SIGN_FUNC
-  | SUM_FUNC
-  | TRIM_FUNC
-  | WHEN_COMPILED_FUNC
-  | INTRINSIC_FUNC _ -> true
-  | _ -> false
-
-let pp_alphanum_string_prefix ppf Cobol_ptree.{ hexadecimal; quotation; str;
-                                                runtime_repr } =
-  if runtime_repr = Null_terminated_bytes then Fmt.char ppf 'Z';
-  if hexadecimal then Fmt.char ppf 'X';
-  match quotation with
-  | Simple_quote -> Fmt.pf ppf "'%s" str
-  | Double_quote -> Fmt.pf ppf "\"%s" str
-
-let pp_token_string: Grammar_tokens.token Pretty.printer = fun ppf ->
-  let string s = Pretty.string ppf s
-  and print format = Pretty.print ppf format in
-  function
-  | WORD w
-  | WORD_IN_AREA_A w
-  | PICTURE_STRING w
-  | INFO_WORD w
-  | DIGITS w
-  | SINTLIT w -> string w
-  | EIGHTY_EIGHT -> string "88"
-  | FIXEDLIT (i, sep, d) -> print "%s%c%s" i sep d
-  | FLOATLIT (i, sep, d, e) -> print "%s%c%sE%s" i sep d e
-  | ALPHANUM a -> Cobol_ptree.pp_alphanum ppf a
-  | ALPHANUM_PREFIX a -> pp_alphanum_string_prefix ppf a
-  | NATLIT s -> print "N\"%s\"" s
-  | BOOLIT b -> print "B\"%a\"" Cobol_ptree.pp_boolean b
-  | COMMENT_ENTRY e -> print "%a" Fmt.(list ~sep:sp string) e
-  | EXEC_BLOCK b -> Cobol_common.Exec_block.pp ppf b
-  | INTERVENING_ c -> print "%c" c
-  | t -> string @@
-      try Text_lexer.show_token t
-      with Not_found ->
-      try Hashtbl.find combined_tokens t
-      with Not_found -> "<unknown/unexpected token>"
-
-let pp_token: Grammar_tokens.token Pretty.printer = fun ppf ->
-  let string s = Pretty.string ppf s
-  and print format = Pretty.print ppf format in
-  function
-    | WORD w -> print "WORD[%s]" w
-    | WORD_IN_AREA_A w -> print "WORD_IN_AREA_A[%s]" w
-    | PICTURE_STRING w -> print "PICTURE_STRING[%s]" w
-    | INFO_WORD s -> print "INFO_WORD[%s]" s
-    | COMMENT_ENTRY _ as t -> print "COMMENT_ENTRY[%a]" pp_token_string t
-    | EXEC_BLOCK _ as t -> print "EXEC_BLOCK[%a]" pp_token_string t
-    | DIGITS i -> print "DIGITS[%s]" i
-    | SINTLIT i -> print "SINT[%s]" i
-    | FIXEDLIT (i, sep, d) -> print "FIXED[%s%c%s]" i sep d
-    | FLOATLIT (i, sep, d, e) -> print "FLOAT[%s%c%sE%s]" i sep d e
-    | INTERVENING_ c -> print "<%c>" c
-    | tok when is_intrinsic_token tok ->
-        print "INTRINSIC_FUNC[%a]" pp_token_string tok
-    | EOF -> string "EOF"
-    | t -> pp_token_string ppf t
-
-let pp_token': token' Pretty.printer =
-  Cobol_common.Srcloc.pp_with_loc pp_token
-
-let pp_tokens =
-  Pretty.list ~fopen:"@[" ~fclose:"@]" pp_token'
-
-let pp_tokens_with_loc_info ?fsep =
-  Pretty.list ~fopen:"@[" ?fsep ~fclose:"@]" begin fun ppf t ->
-    Pretty.print ppf "%a@@%a"
-      pp_token' t
-      Cobol_common.Srcloc.pp_srcloc_struct ~@t
-  end
-
-(* --- *)
+type token = Grammar_tokens.token with_loc
+type tokens = token list
 
 let loc_in_area_a: srcloc -> bool = Cobol_common.Srcloc.in_area_a
-let token_in_area_a: token' -> bool = fun t -> loc_in_area_a ~@t
+let token_in_area_a: token -> bool = fun t -> loc_in_area_a ~@t
 
 (* --- *)
 
@@ -618,7 +516,7 @@ let reword_intrinsics s : tokens -> tokens =
         List.rev rev_prefix
     | ({ payload = k1_token; _ } as k1) ::
       ({ payload = k2_token; _ } as k2) :: tl
-      when k1_token <> FUNCTION && is_intrinsic_token k2_token ->
+      when k1_token <> FUNCTION && Text_keywords.is_intrinsic_token k2_token ->
         aux (EzList.tail_map distinguish_words @@
              retokenize s (keyword_of_token k2_token &@<- k2) @
              k1 :: rev_prefix) tl

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -18,13 +18,8 @@ open EzCompat
 (** {2 Compilation group tokens} *)
 
 (** Tokens passed to {!Parser}; can be obtained via {!tokenize_text}. *)
-type token' = Grammar_tokens.token Cobol_ptree.with_loc
-type tokens = token' list
-
-val pp_token: Grammar_tokens.token Pretty.printer
-val pp_token': token' Pretty.printer
-val pp_tokens: tokens Pretty.printer
-val pp_tokens_with_loc_info: ?fsep:Pretty.simple -> tokens Pretty.printer
+type token = Grammar_tokens.token Cobol_ptree.with_loc
+type tokens = token list
 
 (* --- *)
 
@@ -75,11 +70,11 @@ val tokenize_text
 val next_token
   : 'a state
   -> tokens
-  -> ('a state * token' * tokens) option
+  -> ('a state * token * tokens) option
 
 val put_token_back
   : 'a state
-  -> token'
+  -> token
   -> tokens
   -> 'a state * tokens
 
@@ -87,21 +82,21 @@ val put_token_back
 
 val enable_intrinsics
   : 'a state
-  -> token'
+  -> token
   -> tokens
-  -> 'a state * token' * tokens
+  -> 'a state * token * tokens
 
 val disable_intrinsics
   : 'a state
-  -> token'
+  -> token
   -> tokens
-  -> 'a state * token' * tokens
+  -> 'a state * token * tokens
 
 val reset_intrinsics
   : 'a state
-  -> token'
+  -> token
   -> tokens
-  -> 'a state * token' * tokens
+  -> 'a state * token * tokens
 
 val replace_intrinsics
   : 'a state
@@ -110,9 +105,9 @@ val replace_intrinsics
 
 val decimal_point_is_comma
   : 'a state
-  -> token'
+  -> token
   -> tokens
-  -> 'a state * token' * tokens
+  -> 'a state * token * tokens
 
 (* --- *)
 

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -18,11 +18,12 @@ open EzCompat
 (** {2 Compilation group tokens} *)
 
 (** Tokens passed to {!Parser}; can be obtained via {!tokenize_text}. *)
-type token = Grammar_tokens.token Cobol_ptree.with_loc
-type tokens = token list
-val pp_token: token Pretty.printer
-val pp_tokens: tokens Pretty.printer
-val pp_tokens': ?fsep:Pretty.simple -> tokens Pretty.printer
+type token' = Grammar_tokens.token Cobol_ptree.with_loc
+
+val pp_token: Grammar_tokens.token Pretty.printer
+val pp_token': token' Pretty.printer
+val pp_token'_list: token' list Pretty.printer
+val pp_tokens_with_loc_info: ?fsep:Pretty.simple -> token' list Pretty.printer
 
 (* --- *)
 
@@ -62,44 +63,44 @@ val diagnostics
 
 val parsed_tokens
   : Cobol_common.Behaviors.eidetic state
-  -> tokens Lazy.t
+  -> token' list Lazy.t
 
 val tokenize_text
   : source_format: Cobol_preproc.Src_format.any
   -> 'a state
   -> Cobol_preproc.Text.t
-  -> (tokens, [>`MissingInputs | `ReachedEOF of tokens]) result * 'a state
+  -> (token' list, [>`MissingInputs | `ReachedEOF of token' list]) result * 'a state
 
 val next_token
   : 'a state
-  -> tokens
-  -> ('a state * token * tokens) option
+  -> token' list
+  -> ('a state * token' * token' list) option
 
 val put_token_back
   : 'a state
-  -> token
-  -> tokens
-  -> 'a state * tokens
+  -> token'
+  -> token' list
+  -> 'a state * token' list
 
 (* --- *)
 
 val enable_intrinsics
   : 'a state
-  -> token
-  -> tokens
-  -> 'a state * token * tokens
+  -> token'
+  -> token' list
+  -> 'a state * token' * token' list
 
 val disable_intrinsics
   : 'a state
-  -> token
-  -> tokens
-  -> 'a state * token * tokens
+  -> token'
+  -> token' list
+  -> 'a state * token' * token' list
 
 val reset_intrinsics
   : 'a state
-  -> token
-  -> tokens
-  -> 'a state * token * tokens
+  -> token'
+  -> token' list
+  -> 'a state * token' * token' list
 
 val replace_intrinsics
   : 'a state
@@ -108,17 +109,17 @@ val replace_intrinsics
 
 val decimal_point_is_comma
   : 'a state
-  -> token
-  -> tokens
-  -> 'a state * token * tokens
+  -> token'
+  -> token' list
+  -> 'a state * token' * token' list
 
 (* --- *)
 
 val push_contexts
   : 'a state
-  -> tokens
+  -> token' list
   -> Grammar_contexts.context list
-  -> 'a state * tokens
+  -> 'a state * token' list
 
 val top_context
   : _ state
@@ -126,8 +127,8 @@ val top_context
 
 val pop_context
   : 'a state
-  -> tokens
-  -> 'a state * tokens
+  -> token' list
+  -> 'a state * token' list
 
 val enable_context_sensitive_tokens: _ state -> unit
 val disable_context_sensitive_tokens: _ state -> unit

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -19,11 +19,12 @@ open EzCompat
 
 (** Tokens passed to {!Parser}; can be obtained via {!tokenize_text}. *)
 type token' = Grammar_tokens.token Cobol_ptree.with_loc
+type tokens = token' list
 
 val pp_token: Grammar_tokens.token Pretty.printer
 val pp_token': token' Pretty.printer
-val pp_token'_list: token' list Pretty.printer
-val pp_tokens_with_loc_info: ?fsep:Pretty.simple -> token' list Pretty.printer
+val pp_tokens: tokens Pretty.printer
+val pp_tokens_with_loc_info: ?fsep:Pretty.simple -> tokens Pretty.printer
 
 (* --- *)
 
@@ -63,44 +64,44 @@ val diagnostics
 
 val parsed_tokens
   : Cobol_common.Behaviors.eidetic state
-  -> token' list Lazy.t
+  -> tokens Lazy.t
 
 val tokenize_text
   : source_format: Cobol_preproc.Src_format.any
   -> 'a state
   -> Cobol_preproc.Text.t
-  -> (token' list, [>`MissingInputs | `ReachedEOF of token' list]) result * 'a state
+  -> (tokens, [>`MissingInputs | `ReachedEOF of tokens]) result * 'a state
 
 val next_token
   : 'a state
-  -> token' list
-  -> ('a state * token' * token' list) option
+  -> tokens
+  -> ('a state * token' * tokens) option
 
 val put_token_back
   : 'a state
   -> token'
-  -> token' list
-  -> 'a state * token' list
+  -> tokens
+  -> 'a state * tokens
 
 (* --- *)
 
 val enable_intrinsics
   : 'a state
   -> token'
-  -> token' list
-  -> 'a state * token' * token' list
+  -> tokens
+  -> 'a state * token' * tokens
 
 val disable_intrinsics
   : 'a state
   -> token'
-  -> token' list
-  -> 'a state * token' * token' list
+  -> tokens
+  -> 'a state * token' * tokens
 
 val reset_intrinsics
   : 'a state
   -> token'
-  -> token' list
-  -> 'a state * token' * token' list
+  -> tokens
+  -> 'a state * token' * tokens
 
 val replace_intrinsics
   : 'a state
@@ -110,16 +111,16 @@ val replace_intrinsics
 val decimal_point_is_comma
   : 'a state
   -> token'
-  -> token' list
-  -> 'a state * token' * token' list
+  -> tokens
+  -> 'a state * token' * tokens
 
 (* --- *)
 
 val push_contexts
   : 'a state
-  -> token' list
+  -> tokens
   -> Grammar_contexts.context list
-  -> 'a state * token' list
+  -> 'a state * tokens
 
 val top_context
   : _ state
@@ -127,8 +128,8 @@ val top_context
 
 val pop_context
   : 'a state
-  -> token' list
-  -> 'a state * token' list
+  -> tokens
+  -> 'a state * tokens
 
 val enable_context_sensitive_tokens: _ state -> unit
 val disable_context_sensitive_tokens: _ state -> unit

--- a/test/cobol_parsing/parser_testing.ml
+++ b/test/cobol_parsing/parser_testing.ml
@@ -43,8 +43,8 @@ let show_parsed_tokens ?(parser_options = options ())
     Cobol_parser.parse_with_artifacts ~options:parser_options
   in
   (if with_locations
-   then Cobol_parser.INTERNAL.pp_tokens' ~fsep:"@\n"
-   else Cobol_parser.INTERNAL.pp_tokens) Fmt.stdout (Lazy.force tokens)
+   then Cobol_parser.Tokens.pp'_list_with_loc_info ~fsep:"@\n"
+   else Cobol_parser.Tokens.pp'_list) Fmt.stdout (Lazy.force tokens)
 
 let show_diagnostics ?(parser_options = options ())
     ?source_format ?filename contents =


### PR DESCRIPTION
The old `pp_token` of Text_tokenizer didn't have a prime even though it was a pretty printer for `token with_loc`