### PR TITLE
Fix source location management during completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - COBOL language configuration for highlighting matching brackets and auto-insertion of line numbers in fixed-format code [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
 
 ### Fixed
+- Issues with completion requests in informational paragraphs [#374](https://github.com/OCamlPro/superbol-studio-oss/pull/374)
 - Improvements to the grammar [#331](https://github.com/OCamlPro/superbol-studio-oss/pull/331), [#353](https://github.com/OCamlPro/superbol-studio-oss/pull/353)
 - Word wrapping in presence of hyphens [#330](https://github.com/OCamlPro/superbol-studio-oss/pull/330)
 

--- a/src/lsp/cobol_common/srcloc.ml
+++ b/src/lsp/cobol_common/srcloc.ml
@@ -69,16 +69,17 @@ include TYPES
 
 (* For debugging: *)
 
+let pp_lexpos ppf Lexing.{ pos_fname; pos_lnum; pos_cnum; pos_bol } =
+  Pretty.print ppf "%s:%d-%d" pos_fname pos_lnum (pos_cnum - pos_bol)
+
 let pp_srcloc_struct: srcloc Pretty.printer =
-  let pp_lexloc ppf Lexing.{ pos_fname; pos_lnum; pos_cnum; pos_bol } =
-    Pretty.print ppf "%s:%d-%d" pos_fname pos_lnum (pos_cnum - pos_bol)
-  and pp_lexloc' ppf Lexing.{ pos_lnum; pos_cnum; pos_bol; _ } =
+  let pp_lexpos' ppf Lexing.{ pos_lnum; pos_cnum; pos_bol; _ } =
     Pretty.print ppf "%d-%d" pos_lnum (pos_cnum - pos_bol)
   in
   let rec pp: type t. t slt Pretty.printer = fun ppf -> function
     | Raw (s, e, _) ->
         Pretty.print ppf "<%a|%a>"
-          pp_lexloc s pp_lexloc' e
+          pp_lexpos s pp_lexpos' e
     | Cpy { copied; _ } ->
         Pretty.print ppf "Cpy { copied = %a }"
           pp copied

--- a/src/lsp/cobol_common/srcloc.mli
+++ b/src/lsp/cobol_common/srcloc.mli
@@ -39,6 +39,7 @@ module INFIX: sig
   val ( ~&@ ): 'a with_loc -> 'a * srcloc
 end
 
+val pp_lexpos: Lexing.position Pretty.printer
 val pp_srcloc: srcloc Pretty.printer
 val pp_srcloc_struct: srcloc Pretty.printer
 val pp_file_loc: srcloc Pretty.printer

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -722,13 +722,14 @@ let rewind_and_parse { rewind_n_parse; _ } rewind_preproc ~position =
 
 (* Rewinding for inspection *)
 
-let rewind_for_inspection { rewind_n_parse; _ } rewind_preproc ~position =
-  let { result = _, { last_env_stage; _ }; _ } =
-    Overlay_manager.with_temporary_copy ~f:begin fun () ->
+let rewind_for_inspection { rewind_n_parse; _ } rewind_preproc
+    ~position ~inspect =
+  Overlay_manager.with_temporary_copy ~f:begin fun () ->
+    let { result = _, { last_env_stage; _ }; _ } =
       rewind_n_parse ~stop_before_eof:true rewind_preproc ~position
-    end ()
-  in
-  last_env_stage
+    in
+    inspect last_env_stage
+  end ()
 
 (* Extracting artifacts *)
 

--- a/src/lsp/cobol_parser/parser_engine.mli
+++ b/src/lsp/cobol_parser/parser_engine.mli
@@ -125,11 +125,12 @@ type inspectable_parser_state =
   | Env: 'a Grammar.MenhirInterpreter.env -> inspectable_parser_state
   | Sink
 
+(** Note: given parser state should not escapre [inspect]. *)
 val rewind_for_inspection
   : 'x rewinder
   -> preprocessor_rewind
   -> position: position
-  -> inspectable_parser_state
+  -> inspect: (inspectable_parser_state -> 'a) -> 'a
 
 (** {1 Accessing artifacts} *)
 

--- a/src/lsp/cobol_preproc/src_overlay.ml
+++ b/src/lsp/cobol_preproc/src_overlay.ml
@@ -17,11 +17,11 @@ let debug_oc = ref None
 
 (*
 let message fmt =
-  Printf.kprintf (fun s ->
+  Format.kasprintf (fun s ->
       match !debug_oc with
       | None -> ()
       | Some oc ->
-        Printf.fprintf oc "OVERLAY: %s\n%!" s) fmt
+          Printf.fprintf oc "OVERLAY: %s\n%!" s) fmt
 *)
 
 module TYPES = struct
@@ -116,9 +116,9 @@ let limits: manager -> srcloc -> limit * limit = fun ctx loc ->
       HLnks.add ctx.right_of left (loc, right);
       left, right
 
-(** WLnks token limits *)
+(** Links token limits *)
 let link_limits ctx left right =
-  (* Replace to deal with overriding of limits during recovery. *)
+  (* Replace to deal with overriding of limits during recovery/rewind. *)
   HLnks.replace ctx.over_right_gap left right
 
 (** Returns a source location that spans between two given limits; returns a
@@ -166,12 +166,11 @@ let join_limits: manager -> limit * limit -> srcloc = fun ctx (s, e) ->
     else try_cache_from s
   in
   let join_failure (s, e) =
-    let loc = Cobol_common.Srcloc.raw (s, e) in
     Pretty.error "@[<2>%a:@ Internal@ warning:@ unable@ to@ join@ locations@ \
                   via@ limits@ in@ `%s.join_limits`@ [ctx=%s]@]@."
-      Cobol_common.Srcloc.pp_file_loc loc __MODULE__ ctx.id;
+      Cobol_common.Srcloc.pp_lexpos s __MODULE__ ctx.id;
     (* Printexc.(print_raw_backtrace Stdlib.stderr @@ get_callstack 10); *)
-    loc
+    Cobol_common.Srcloc.raw (e, e)
   in
   try   (* first attempt assumes proper token limits: `s` is a left and `e` is a
            right of tokens *)

--- a/test/cobol_parsing/tokens.ml
+++ b/test/cobol_parsing/tokens.ml
@@ -50,3 +50,18 @@ let%expect_test "token-locations" =
     DIGITS[1]@<prog.cob:1-5|1-6>
     )@<prog.cob:1-6|1-7>
     EOF@<prog.cob:1-7|1-7> |}];;
+
+let%expect_test "token-locations-with-missing-comment-paragraph" =
+  Parser_testing.show_parsed_tokens ~source_format:Auto ~with_locations:true
+    ~parser_options:(Parser_testing.options ~verbose:true ())
+    "IDENTIFICATION DIVISION.\nAUTHOR.";
+  [%expect {|
+    Tks: IDENTIFICATION, DIVISION, .
+    Tks: AUTHOR, ., COMMENT_ENTRY[], EOF
+    IDENTIFICATION@<prog.cob:1-0|1-14>
+    DIVISION@<prog.cob:1-15|1-23>
+    .@<prog.cob:1-23|1-24>
+    AUTHOR@<prog.cob:2-0|2-6>
+    .@<prog.cob:2-6|2-7>
+    COMMENT_ENTRY[]@<prog.cob:2-7|2-7>
+    EOF@<prog.cob:2-7|2-7> |}];;

--- a/test/lsp/lsp_inspect.ml
+++ b/test/lsp/lsp_inspect.ml
@@ -30,7 +30,10 @@ let inspect_positions (doc, positions) : string -> unit =
       location_as_srcloc#pp location
       Fmt.(option ~none:nop (string ++ sp)) position_name
       position.line position.character;
-    match LSP.Document.inspect_at ~position doc with
+    (* Note: parser state escapes [f], but that should be avoided to avoid
+       messing up with the internal overlay manager.  Ok for these simple tests
+       though. *)
+    match LSP.Document.inspect_at ~position doc ~f:Fun.id with
     | None ->
         Pretty.error "failed inspection@."
     | Some Sink ->


### PR DESCRIPTION
Removes a potential infinite loop with comment entries that are not terminated (reaching end of input); also avoids source location errors during parser exploration by LSP completion code.