### PR TITLE
Always honor `BUILD_STATIC_EXECS`

### DIFF
--- a/.drom
+++ b/.drom
@@ -25,7 +25,7 @@ d369e2949d85dee79233d322ce6f7587:.
 
 # begin context for Makefile
 # file Makefile
-28e611f8892d700df75a7d222996d657:Makefile
+47a1f06175119e41d07c168651c1a645:Makefile
 # end context for Makefile
 
 # begin context for README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [_] Next release
 
 ### Fixed
+- Binaries included in VSIXs for Darwin [#383](https://github.com/OCamlPro/superbol-studio-oss/pull/383)
 - Name of debugger, to avoid conflicts with the official "gdb" [#381](https://github.com/OCamlPro/superbol-studio-oss/pull/381)
 
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ DUNE = opam exec -- dune
 DUNE_ARGS ?= --root=$$(pwd)
 DUNE_CROSS_ARGS = $(strip $(if $(filter  win32,${TARGET_PLAT}),-x windows)	\
 			  $(if $(filter darwin,${TARGET_PLAT}),-x osx))
+ifeq ($(BUILD_STATIC_EXECS),true)
+  export LINKING_MODE=static
+endif
 
 VERSION = 0.1.5
 DEV_DEPS := merlin ocamlformat odoc

--- a/Makefile.drom-tpl
+++ b/Makefile.drom-tpl
@@ -8,6 +8,9 @@ DUNE = opam exec -- dune
 DUNE_ARGS ?= --root=$$(pwd)
 DUNE_CROSS_ARGS = $(strip $(if $(filter  win32,${TARGET_PLAT}),-x windows)	\
 			  $(if $(filter darwin,${TARGET_PLAT}),-x osx))
+ifeq ($(BUILD_STATIC_EXECS),true)
+  export LINKING_MODE=static
+endif
 
 VERSION = !{version}
 DEV_DEPS := merlin ocamlformat odoc![if:gen:test] ppx_expect ppx_inline_test![fi]


### PR DESCRIPTION
This fixes binaries included in VSIXs for Darwin platforms.