### PR TITLE
Stop flagging built VSIXs as pre-releases

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -47,9 +47,9 @@ endif
 YARN = npx --yes yarn 
 
 VSCE_ARGS = --yarn -t $(TARGET_SPEC)
-VSCE_PACKAGE_ARGS ?= --pre-release
-VSCE_PUBLISH_ARGS ?= --pre-release
-OVSX_PUBLISH_ARGS ?= --pre-release
+VSCE_PACKAGE_ARGS ?=
+VSCE_PUBLISH_ARGS ?=
+OVSX_PUBLISH_ARGS ?=
 
 # Emacs lsp-mode source directory (https://github.com/emacs-lsp/lsp-mode):
 # (could be a submodule)


### PR DESCRIPTION
People say that extension is better than most officially released ones; let's trust people.