### PR TITLE
Add "COBOL" keyword in descriptions of configuration settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         },
         "superbol.cobol.copybooks": {
           "title": "Copybook Paths",
-          "markdownDescription": "List of copybooks paths.\n\n*(May be overriden in project-specific `superbol.toml` files)*.",
+          "markdownDescription": "List of paths to copybooks.\n\n*(May be overriden in project-specific `superbol.toml` files)*.",
           "type": "array",
           "default": [
             {
@@ -151,7 +151,7 @@
         },
         "superbol.lsp-path": {
           "title": "SuperBOL Executable",
-          "markdownDescription": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise. Leave empty to use the bundled `superbol-free`, if available.",
+          "markdownDescription": "Name of the `superbol-free` executable if available in PATH; may be an absolute path otherwise. Leave empty to use the bundled `superbol-free`, if available.\n<!-- COBOL -->",
           "type": "string",
           "default": "",
           "scope": "machine",
@@ -164,16 +164,16 @@
           "order": 21
         },
         "superbol.cacheInGlobalStorage": {
-          "markdownDescription": "Use storage provided by Visual Studio Code for caching.  When this setting is set to *false*, the cache related to the contents of a given workspace folder *f* is stored in a file named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not removed automatically, whatever their location.",
+          "markdownDescription": "Use storage provided by Visual Studio Code for caching. When this setting is set to *false*, the cache related to the contents of a given workspace folder *f* is stored in a file named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not removed automatically, whatever their location.\n<!-- COBOL -->",
           "type": "boolean",
           "default": false,
           "order": 22
         },
         "superbol.debugger.display-variable-attributes": {
           "title": "Display Variable Attributes",
+          "markdownDescription": "Display storage property and field attributes (e.g. size of alphanumerics, digits and scale of numerics).\n<!-- COBOL -->",
           "type": "boolean",
           "default": false,
-          "description": "Display storage property and field attributes (e.g. size of alphanumerics, digits and scale of numerics).",
           "scope": "resource",
           "order": 31
         },
@@ -189,9 +189,9 @@
         },
         "superbol.debugger.gdb-path": {
           "title": "GNU Debugger Executable",
+          "markdownDescription": "Path to the GNU debugger executable.\n<!-- COBOL -->",
           "type": "string",
           "default": "gdb",
-          "description": "Path to the GNU debugger executable.",
           "scope": "machine-overridable",
           "order": 33
         }

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -306,6 +306,11 @@ let contributes =
     ~configuration:
       (let with_superbol_toml_note md =
          md ^ "\n\n*(May be overriden in project-specific `superbol.toml` files)*."
+       and with_extra_keyword_commment md =
+         (* Be sure to include "COBOL" in descriptions, as users are more likely
+            to type "cobol" than "superbol" when searching for extension
+            settings. *)
+         md ^ "\n<!-- COBOL -->"
        in
        Manifest.configuration ~title:"SuperBOL"
          [
@@ -354,7 +359,7 @@ let contributes =
                  ];
                ])
              ~markdownDescription:
-               (with_superbol_toml_note "List of copybooks paths.")
+               (with_superbol_toml_note "List of paths to copybooks.")
              ~order:3;
 
            Manifest.PROPERTY.strings "superbol.cobol.copyexts"
@@ -378,9 +383,10 @@ let contributes =
              ~default:""
              ~scope:"machine"
              ~markdownDescription:
-               "Name of the `superbol-free` executable if available in PATH; may \
-                be an absolute path otherwise. Leave empty to use the bundled \
-                `superbol-free`, if available."
+               (with_extra_keyword_commment
+                  "Name of the `superbol-free` executable if available in PATH; \
+                   may be an absolute path otherwise. Leave empty to use the \
+                   bundled `superbol-free`, if available.")
              ~order:12;
 
            (* Flags *)
@@ -395,11 +401,12 @@ let contributes =
            Manifest.PROPERTY.bool "superbol.cacheInGlobalStorage"
              ~default:false
              ~markdownDescription:
-               "Use storage provided by Visual Studio Code for caching.  When \
-                this setting is set to *false*, the cache related to the \
-                contents of a given workspace folder *f* is stored in a file \
-                named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not \
-                removed automatically, whatever their location."
+               (with_extra_keyword_commment
+                  "Use storage provided by Visual Studio Code for caching. When \
+                   this setting is set to *false*, the cache related to the \
+                   contents of a given workspace folder *f* is stored in a file \
+                   named *f*`/_superbol/lsp-cache`.\n\nNote: cache files are not \
+                   removed automatically, whatever their location.")
              ~order:22;
 
            (* Debugger-specific: *)
@@ -409,9 +416,10 @@ let contributes =
              ~title:"Display Variable Attributes"
              ~default:false
              ~scope:"resource"
-             ~description:"Display storage property and field attributes \
-                           (e.g. size of alphanumerics, digits and scale of \
-                           numerics)."
+             ~markdownDescription:
+               (with_extra_keyword_commment
+                  "Display storage property and field attributes (e.g. size of \
+                   alphanumerics, digits and scale of numerics).")
              ~order:31;
 
            Manifest.PROPERTY.null_string "superbol.debugger.libcob-path"
@@ -424,7 +432,9 @@ let contributes =
              ~title:"GNU Debugger Executable"
              ~default:"gdb"
              ~scope:"machine-overridable"
-             ~description:"Path to the GNU debugger executable."
+             ~markdownDescription:
+               (with_extra_keyword_commment
+                  "Path to the GNU debugger executable.")
              ~order:33;
 
          ])


### PR DESCRIPTION
This enables every settings of the extension to appear in VSCode's interface, when searching for "COBOL".

Closes #399 