### PR TITLE
Avoid compilation failure when querying static linking flags outside Alpine

### DIFF
--- a/.drom
+++ b/.drom
@@ -490,7 +490,7 @@ a5532d6c7af2e136d35911021b8fb980:src/lsp/sql_preproc/version.mlt
 
 # begin context for src/lsp/superbol-free/linking_flags.sh
 # file src/lsp/superbol-free/linking_flags.sh
-19b3af846294c26b2c4019ee1ed7e7cf:src/lsp/superbol-free/linking_flags.sh
+236a0354fe949a020f31913b39b31663:src/lsp/superbol-free/linking_flags.sh
 # end context for src/lsp/superbol-free/linking_flags.sh
 
 # begin context for src/lsp/superbol_free_lib/dune

--- a/src/lsp/superbol-free/linking_flags.sh
+++ b/src/lsp/superbol-free/linking_flags.sh
@@ -58,8 +58,9 @@ case "$1" in
                 echo2 ' -cclib -static)'
                 ;;
             *)
-                echo2 "Error: static linking is only supported in Alpine, to avoids glibc constraints (use scripts/static-build.sh to build through an Alpine Docker container)" >&2
-                exit 3
+                echo2 "Warning: static linking is only supported in Alpine, to avoids glibc constraints (use scripts/static-build.sh to build through an Alpine Docker container)" >&2
+                echo2 "()"
+                # exit 3
         esac
         ;;
     macosx)

--- a/src/lsp/superbol-free/linking_flags.sh.drom-tpl
+++ b/src/lsp/superbol-free/linking_flags.sh.drom-tpl
@@ -58,8 +58,9 @@ case "$1" in
                 echo2 ' -cclib -static)'
                 ;;
             *)
-                echo2 "Error: static linking is only supported in Alpine, to avoids glibc constraints (use scripts/static-build.sh to build through an Alpine Docker container)" >&2
-                exit 3
+                echo2 "Warning: static linking is only supported in Alpine, to avoids glibc constraints (use scripts/static-build.sh to build through an Alpine Docker container)" >&2
+                echo2 "()"
+                # exit 3
         esac
         ;;
     macosx)


### PR DESCRIPTION
Included changes turn errors about invalid requests of static linking flags (calls to `linking_flags.sh`) into warnings.  At the moment these requests are also performed for js_of_ocaml compilation modes, which prevents one from globally setting `LINKING_MODE=static`.