### PR TITLE
switch problemMatcher patterns from line to locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,33 +507,33 @@
         "name": "gnucobol",
         "regexp": "^(.*): ?(\\d+): (error|warning): ([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "location": 2,
         "severity": 3,
         "code": 6,
+        "location": 2,
         "message": 4
       },
       {
         "name": "gnucobol-warning",
         "regexp": "^(.*):(\\d+):\\s?(warning|Warnung|[wW]aarschuwing|[aA]lerta|avertissement|упозорење)\\s?:([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "location": 2,
         "code": 6,
+        "location": 2,
         "message": 4
       },
       {
         "name": "gnucobol-error",
         "regexp": "^(.*): ?(\\d+):\\s?(error|Fehler|[fF]out|[eE]rrores|[eE]rrores|erreur|грешка)\\s?:\\s?([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "location": 2,
         "code": 6,
+        "location": 2,
         "message": 4
       },
       {
         "name": "gnucobol-note",
         "regexp": "^(.*): ?(\\d+): (note|Anmerkung|[nN]ota): ([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "location": 2,
         "code": 6,
+        "location": 2,
         "message": 4
       }
     ],

--- a/package.json
+++ b/package.json
@@ -507,7 +507,7 @@
         "name": "gnucobol",
         "regexp": "^(.*): ?(\\d+): (error|warning): ([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "line": 2,
+        "location": 2,
         "severity": 3,
         "code": 6,
         "message": 4
@@ -516,7 +516,7 @@
         "name": "gnucobol-warning",
         "regexp": "^(.*):(\\d+):\\s?(warning|Warnung|[wW]aarschuwing|[aA]lerta|avertissement|упозорење)\\s?:([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "line": 2,
+        "location": 2,
         "code": 6,
         "message": 4
       },
@@ -524,7 +524,7 @@
         "name": "gnucobol-error",
         "regexp": "^(.*): ?(\\d+):\\s?(error|Fehler|[fF]out|[eE]rrores|[eE]rrores|erreur|грешка)\\s?:\\s?([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "line": 2,
+        "location": 2,
         "code": 6,
         "message": 4
       },
@@ -532,7 +532,7 @@
         "name": "gnucobol-note",
         "regexp": "^(.*): ?(\\d+): (note|Anmerkung|[nN]ota): ([^[]*)(\\[(.*)\\])?$",
         "file": 1,
-        "line": 2,
+        "location": 2,
         "code": 6,
         "message": 4
       }

--- a/src/lsp/superbol_free_lib/vscode_extension.ml
+++ b/src/lsp/superbol_free_lib/vscode_extension.ml
@@ -511,7 +511,7 @@ let contributes =
         (Some "^(.*): ?(\\d+): (error|warning): ([^[]*)(\\[(.*)\\])?$")
         ~name:"gnucobol"
         ~file:1
-        ~line:2
+        ~location:2
         ~severity:3
         ~message:4
         ~code:6;
@@ -519,21 +519,21 @@ let contributes =
         (Some "^(.*):(\\d+):\\s?(warning|Warnung|[wW]aarschuwing|[aA]lerta|avertissement|упозорење)\\s?:([^[]*)(\\[(.*)\\])?$")
         ~name:"gnucobol-warning"
         ~file:1
-        ~line:2
+        ~location:2
         ~message:4
         ~code:6;
       Manifest.problemPattern
         (Some "^(.*): ?(\\d+):\\s?(error|Fehler|[fF]out|[eE]rrores|[eE]rrores|erreur|грешка)\\s?:\\s?([^[]*)(\\[(.*)\\])?$")
         ~name:"gnucobol-error"
         ~file:1
-        ~line:2
+        ~location:2
         ~message:4
         ~code:6;
       Manifest.problemPattern
         (Some "^(.*): ?(\\d+): (note|Anmerkung|[nN]ota): ([^[]*)(\\[(.*)\\])?$")
         ~name:"gnucobol-note"
         ~file:1
-        ~line:2
+        ~location:2
         ~message:4
         ~code:6;
     ]


### PR DESCRIPTION
which should highlight the complete line and reference not only column 1 in the problem pane

warning: this is untested, it just worked when I tested it locally with my own problemMatcher definitions (and got that hint from a vscode dev); obviously "some day" we should emit columns from cobc as well - but if we do it the gcc way "location" should handle those fine (we likely will need to adjust the regex, when the time comes)

... maybe I try the CI build of this PR some day to test the result, but there's possibly someone else faster :-)