### PR TITLE
Add basic language definition for toggling line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [_] Next release
 
+### Added
+- Basic language definition for toggling line comments [#463](https://github.com/OCamlPro/superbol-studio-oss/pull/463)
+
 
 ## [0.2.2] Second release (2025-11-17)
 

--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -5,6 +5,9 @@
     ["[", "]"],
     ["(", ")"]
   ],
+  "comments": {
+    "lineComment": "*>"
+  },
   "onEnterRules": [
     {
       "beforeText": "^[0-9]{6}.*",


### PR DESCRIPTION
Source-format-agnostic version for now.

Preliminary fix for #461.