### PR TITLE
Add binding for the showOpenDialog function of Vscode.Window

### DIFF
--- a/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.ml
+++ b/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.ml
@@ -2195,6 +2195,37 @@ module MessageOptions = struct
     val create : ?modal:bool -> unit -> t [@@js.builder]]
 end
 
+module OpenDialogOptions = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val canSelectFiles : t -> bool option [@@js.get]
+
+    val canSelectFolders : t -> bool option [@@js.get]
+
+    val canSelectMany : t -> bool option [@@js.get]
+
+    val defaultUri : t -> string option [@@js.get]
+
+    val filters : t -> (string * string list) list [@@js.get]
+
+    val openLabel : t -> string [@@js.get]
+
+    val title : t -> string option [@@js.get]
+
+    val create :
+         ?canSelectFiles:bool
+      -> ?canSelectFolders:bool
+      -> ?canSelectMany:bool
+      -> ?defaultUri:string
+      -> ?filters:((string * string list) list)
+      -> ?openLabel:string
+      -> ?title:string
+      -> unit
+      -> t [@@js.builder]]
+end
+
 module Progress = struct
   include Interface.Make ()
 
@@ -3103,6 +3134,12 @@ module Window = struct
       -> unit
       -> MessageItem.t or_undefined Promise.t
       [@@js.global "vscode.window.showErrorMessage"]
+
+    val showOpenDialog :
+         ?options:OpenDialogOptions.t
+      -> unit
+      -> Uri.t array option Promise.t
+      [@@js.global "vscode.window.showOpenDialog"]
 
     val showQuickPickItems :
          choices:QuickPickItem.t list

--- a/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.mli
+++ b/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.mli
@@ -1709,6 +1709,36 @@ module MessageOptions : sig
   val create : ?modal:bool -> unit -> t
 end
 
+
+module OpenDialogOptions : sig
+  include Js.T
+
+  val canSelectFiles : t -> bool option
+
+  val canSelectFolders : t -> bool option
+
+  val canSelectMany : t -> bool option
+
+  val defaultUri : t -> string option
+
+  val filters : t -> (string * string list) list
+
+  val openLabel : t -> string
+
+  val title : t -> string option
+
+  val create :
+       ?canSelectFiles:bool
+    -> ?canSelectFolders:bool
+    -> ?canSelectMany:bool
+    -> ?defaultUri:string
+    -> ?filters:((string * string list) list)
+    -> ?openLabel:string
+    -> ?title:string
+    -> unit
+    -> t
+end
+
 module Progress : sig
   include Js.T
 
@@ -2372,6 +2402,11 @@ module Window : sig
     -> ?choices:(string * 'a) list
     -> unit
     -> 'a option Promise.t
+
+  val showOpenDialog :
+       ?options:OpenDialogOptions.t
+    -> unit
+    -> Uri.t array option Promise.t
 
   val showQuickPickItems :
        choices:(QuickPickItem.t * 'a) list


### PR DESCRIPTION
A binding for the `showOpenDialog` function of `Vscode.Window` has been added. It uses a `OpenDialogOptions` module for its arguments. I took inspiration from the `MessageOptions` module (just above).