### PR TITLE
Extend ADD and SUBTRACT argument to x (scalar) type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [_] Next release
 
 ### Added
+- Support for `ADD` and `SUBTRACT` with `LENGTH OF` argument [#503](https://github.com/OCamlPro/superbol-studio-oss/pull/503)
 - Support for `MOVE` with `LENGTH OF` sender [#494](https://github.com/OCamlPro/superbol-studio-oss/pull/494)
 - Support for Hexadecimal literals using 'H' and 'h' prefix [#499](https://github.com/OCamlPro/superbol-studio-oss/pull/499)
 - Support for `OCCURS N DEPENDING` syntax [#497](https://github.com/OCamlPro/superbol-studio-oss/pull/497)

--- a/src/lsp/cobol_lsp/lsp_lookup.ml
+++ b/src/lsp/cobol_lsp/lsp_lookup.ml
@@ -323,12 +323,12 @@ let type_at_pos ~filename (pos: Lsp.Types.Position.t) group : approx_typing_info
         begin match o with
           | ArithSimple { sources; targets } ->
             acc
-            |> Numeric @>@ fold_list ~fold:fold_ident_or_numlit v sources
+            |> Numeric @>@ fold_list ~fold:fold_scalar v sources
             |> Numeric @>@ fold_rounded_idents v targets
           | ArithGiving { sources; to_or_from_item; targets } ->
             acc
-            |> Numeric @>@ fold_list ~fold:fold_ident_or_numlit v sources
-            |> Numeric @>@ fold_ident_or_numlit v to_or_from_item
+            |> Numeric @>@ fold_list ~fold:fold_scalar v sources
+            |> Numeric @>@ fold_scalar v to_or_from_item
             |> [Numeric; NumericEdited] @>>@ fold_rounded_idents v targets
           | ArithCorresponding { source; target } ->
             acc

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -2475,14 +2475,12 @@ literal_no_all:
 
 
 
-
 let numeric_literal [@symbol "<numeric literal>"] :=
  | i = integer;  { Integer i : numlit }
  | f = fixedlit; { Fixed f }
  | f = floatlit; { Floating f }
  | ZERO;         { NumFig Zero }
 (* Note: numeric literals do NOT allow figurative constants with ALL *)
-
 
 
 
@@ -2550,18 +2548,17 @@ let qualname_or_literal :=
  | n = qualname; { UPCAST.qualname_with_literal n }
  | l = literal;  { UPCAST.literal_with_qualdatname l }
 
-(* Used in ADD, DIVIDE, MULTIPLY, PERFORM, SUBTRACT *)
-
-let ident_or_numeric :=
- | i = ident;           { UPCAST.ident_with_numeric i }
- | l = numeric_literal; { UPCAST.numeric_with_ident l }
-let idents_or_numerics == ~ = rnel(ident_or_numeric); < >
-
 let x == scalar                                       (* alias, as in GnuCOBOL *)
 let scalar :=
- | i = scalar_ident;    { UPCAST.scalar_ident_as_scalar i }
- | l = literal;         { UPCAST.literal_as_scalar l }
- | l = length_of_expr;  { l }
+ | i = scalar_ident;       { UPCAST.scalar_ident_as_scalar i }
+ | l = numeric_literal;    { UPCAST.numeric_as_scalar l }
+ | l = length_of_expr;     { l }
+
+(* Used in MOVE *)
+let scalar_or_nonnumeric :=
+ | i = scalar_ident;       { UPCAST.scalar_ident_as_scalar i }
+ | l = literal;            { UPCAST.literal_as_scalar l }
+ | l = length_of_expr;     { l }
 
 (* Used in CALL *)
 let name_or_string :=
@@ -3101,12 +3098,12 @@ let accept_with_clause [@recovery AcceptAttribute Highlight] [@symbol "<accept-w
 
 %public let unconditional_action := ~ = add_statement; < >
 add_statement:
- | ADD inl = idents_or_numerics TO irl = rounded_idents
+ | ADD inl = rnel(x) TO irl = rounded_idents
    h = handler_opt(ON_SIZE_ERROR,NOT_ON_SIZE_ERROR) end_add
    { Add { basic_arith_operands =
              ArithSimple { sources = inl; targets = irl };
            basic_arith_on_size_error = h } }
- | ADD inl = idents_or_numerics TO in_ = ident_or_numeric
+ | ADD inl = rnel(x) TO in_ = x
    GIVING irl = rounded_idents
    h = handler_opt(ON_SIZE_ERROR,NOT_ON_SIZE_ERROR) end_add
    { Add { basic_arith_operands =
@@ -3114,7 +3111,7 @@ add_statement:
                            to_or_from_item = in_;
                            targets = irl };
            basic_arith_on_size_error = h } }
- | ADD inl = idents_or_numerics (* Same as above without 'TO' *)
+ | ADD inl = rnel(x) (* Same as above without 'TO' *)
    GIVING irl = rounded_idents
    h = handler_opt(ON_SIZE_ERROR,NOT_ON_SIZE_ERROR) end_add
    { let in_, inl = split_last inl in
@@ -3657,7 +3654,7 @@ let merge_statement :=
 
 %public let unconditional_action := ~ = move_statement; < >
 let move_statement :=
- | MOVE; from = x; TO; to_ = idents;
+ | MOVE; from = scalar_or_nonnumeric; TO; to_ = idents;
    { Move (MoveSimple { from; to_ }) }
  | MOVE; CORRESPONDING; from = ident; TO; to_ = idents;
    { Move (MoveCorresponding { from; to_ }) }
@@ -4187,12 +4184,12 @@ let s_delimited_by :=
 
 %public let unconditional_action := ~ = subtract_statement; < >
 let subtract_statement :=
- | SUBTRACT; inl = idents_or_numerics; FROM; irl = rounded_idents;
+ | SUBTRACT; inl = rnel(x); FROM; irl = rounded_idents;
    h = handler_opt(ON_SIZE_ERROR,NOT_ON_SIZE_ERROR); end_subtract;
    { Subtract { basic_arith_operands =
                   ArithSimple { sources = inl; targets = irl };
                 basic_arith_on_size_error = h } }
- | SUBTRACT; inl = idents_or_numerics; FROM; in_ = ident_or_numeric;
+ | SUBTRACT; inl = rnel(x); FROM; in_ = x;
    GIVING; irl = rounded_idents;
    h = handler_opt(ON_SIZE_ERROR,NOT_ON_SIZE_ERROR); end_subtract;
    { Subtract { basic_arith_operands =

--- a/src/lsp/cobol_ptree/operands.ml
+++ b/src/lsp/cobol_ptree/operands.ml
@@ -202,13 +202,13 @@ let pp_date_time ppf = function
 type basic_arithmetic_operands =
   | ArithSimple of
       {
-        sources: ident_or_numlit list;
+        sources: scalar list;
         targets: rounded_idents;
       }
   | ArithGiving of
       {
-        sources: ident_or_numlit list;
-        to_or_from_item: ident_or_numlit;
+        sources: scalar list;
+        to_or_from_item: scalar;
         targets: rounded_idents;
       }
   | ArithCorresponding of
@@ -229,13 +229,13 @@ let pp_giving targets =
   [ Fmt.(any "GIVING@ " ++ const (box pp_rounded_idents) targets) ]
 
 let pp_basic_arithmetic_operands ?(sep = "TO") ppf bao =
-  let pp_sources = Fmt.(list ~sep:sp pp_ident_or_numlit) in
+  let pp_sources = Fmt.(list ~sep:sp pp_scalar) in
   match bao with
   | ArithSimple { sources; targets } ->
     pp_arithmetic_operands ~sep pp_sources pp_rounded_idents
       ppf ((sources, targets), [])
   | ArithGiving { sources; to_or_from_item; targets } ->
-    pp_arithmetic_operands ~sep pp_sources pp_ident_or_numlit
+    pp_arithmetic_operands ~sep pp_sources pp_scalar
       ppf ((sources, to_or_from_item), pp_giving targets)
   | ArithCorresponding { source; target } ->
     pp_arithmetic_operands ~modifier:"CORRESPONDING" ~sep

--- a/src/lsp/cobol_ptree/operands_visitor.ml
+++ b/src/lsp/cobol_ptree/operands_visitor.ml
@@ -89,11 +89,11 @@ let fold_basic_arithmetic_operands (v: _ #folder) =
   handle v#fold_basic_arithmetic_operands
     ~continue:begin fun o x -> match o with
       | ArithSimple { sources; targets } -> x
-          >> fold_list ~fold:fold_ident_or_numlit v sources
+          >> fold_list ~fold:fold_scalar v sources
           >> fold_rounded_idents v targets
       | ArithGiving { sources; to_or_from_item; targets } -> x
-          >> fold_list ~fold:fold_ident_or_numlit v sources
-          >> fold_ident_or_numlit v to_or_from_item
+          >> fold_list ~fold:fold_scalar v sources
+          >> fold_scalar v to_or_from_item
           >> fold_rounded_idents v targets
       | ArithCorresponding { source; target } -> x
           >> fold_qualname v source

--- a/src/lsp/cobol_ptree/terms.ml
+++ b/src/lsp/cobol_ptree/terms.ml
@@ -1319,6 +1319,14 @@ module UPCAST = struct
     | Floating _ as v -> v
     | NumFig _ as v -> v
 
+  let nonnumlit_as_scalar: nonnumlit -> scalar = function
+    | Alphanum _ as v -> v
+    | National _ as v -> v
+    | Boolean _ as v -> v
+    | Fig _ as v -> v
+    | StrConcat _ as v -> v
+    | Concat _ as v -> v
+
   let literal_as_scalar: literal -> scalar = function
     | Alphanum _ as v -> v
     | National _ as v -> v

--- a/test/lsp/lsp_completion.ml
+++ b/test/lsp/lsp_completion.ml
@@ -3545,7 +3545,7 @@ let%expect_test "semantic-completion" =
       15             DISPLAY ANYY.
       16             UNSTRING ALPHA INTO ANYY.
     (line 13, character 14):
-    Basic (16 entries):
+    Basic (17 entries):
         NUM Numeric
         ALPHA Alphanum (unexpected here)
         ANYY Boolean (unexpected here)
@@ -3555,6 +3555,7 @@ let%expect_test "semantic-completion" =
         CORRESPONDING
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL
@@ -3562,7 +3563,7 @@ let%expect_test "semantic-completion" =
         SELF
         SUPER
         ZEROS
-    Eager (16 entries):
+    Eager (17 entries):
         NUM Numeric
         ALPHA Alphanum (unexpected here)
         ANYY Boolean (unexpected here)
@@ -3572,6 +3573,7 @@ let%expect_test "semantic-completion" =
         CORRESPONDING
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL
@@ -3588,7 +3590,7 @@ let%expect_test "semantic-completion" =
       15             DISPLAY ANYY.
       16             UNSTRING ALPHA INTO ANYY.
     (line 13, character 21):
-    Basic (15 entries):
+    Basic (16 entries):
         NUM Numeric
         ALPHA Alphanum (unexpected here)
         ANYY Boolean (unexpected here)
@@ -3597,6 +3599,7 @@ let%expect_test "semantic-completion" =
         ADDRESS
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL
@@ -3604,7 +3607,7 @@ let%expect_test "semantic-completion" =
         SELF
         SUPER
         ZEROS
-    Eager (15 entries):
+    Eager (16 entries):
         NUM Numeric
         ALPHA Alphanum (unexpected here)
         ANYY Boolean (unexpected here)
@@ -3613,6 +3616,7 @@ let%expect_test "semantic-completion" =
         ADDRESS OF
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL
@@ -3909,7 +3913,7 @@ let%expect_test "semantic-while-writing-completion" =
       11
       12             DISPLAY
     (line 9, character 14):
-    Basic (14 entries):
+    Basic (15 entries):
         NUM Numeric
         ALPHA Alphanum
         ANYY Boolean
@@ -3917,6 +3921,7 @@ let%expect_test "semantic-while-writing-completion" =
         CORRESPONDING
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL
@@ -3924,7 +3929,7 @@ let%expect_test "semantic-while-writing-completion" =
         SELF
         SUPER
         ZEROS
-    Eager (14 entries):
+    Eager (15 entries):
         NUM Numeric
         ALPHA Alphanum
         ANYY Boolean
@@ -3932,6 +3937,7 @@ let%expect_test "semantic-while-writing-completion" =
         CORRESPONDING
         EXCEPTION-OBJECT
         FUNCTION
+        LENGTH
         LINAGE-COUNTER
         LINE-COUNTER
         NULL

--- a/test/output-tests/run_extensions.expected
+++ b/test/output-tests/run_extensions.expected
@@ -360,26 +360,6 @@ run_extensions.at-445-prog.cob:79.37-79.43:
   81              END-IF
 >> Error: Invalid syntax
 
-run_extensions.at-445-prog.cob:87.23-87.29:
-  84                 END-DISPLAY
-  85              END-IF
-  86              IF LENGTH OF L + 2 NOT = 8
-  87 >               ADD 2 TO LENGTH OF L GIVING L
-----                          ^^^^^^
-  88                 DISPLAY "Length 5 + 2" L
-  89                 END-DISPLAY
->> Error: Invalid syntax
-
-run_extensions.at-445-prog.cob:92.23-92.29:
-  89                 END-DISPLAY
-  90              END-IF
-  91              IF LENGTH L + 2 NOT = 8
-  92 >               ADD 2 TO LENGTH L GIVING L
-----                          ^^^^^^
-  93                 DISPLAY "Length 5a + 2 " L
-  94                 END-DISPLAY
->> Error: Invalid syntax
-
 run_extensions.at-445-prog.cob:97.19-97.25:
   94                 END-DISPLAY
   95              END-IF


### PR DESCRIPTION
The type of arguments for `ADD` and `SUBTRACT` has been changed from `numeric_literal` to `x` (scalar). Consequently, some unused rules have been removed.