### PR TITLE
Support INDEXED BY and sort direction in any order in OCCURS clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [_] Next release
 
 ### Added
+- Support INDEXED BY and sort direction in any order in OCCURS clause [#526](https://github.com/OCamlPro/superbol-studio-oss/pull/526)
 - Support for debugging programs launched via custom COBOL runtimes [#522](https://github.com/OCamlPro/superbol-studio-oss/pull/522)
 - Parse `OR` in inspect regions [#519](https://github.com/OCamlPro/superbol-studio-oss/pull/519)
 - Support `NOT OPTIONAL` argument for `SELECT` [#517](https://github.com/OCamlPro/superbol-studio-oss/pull/517)

--- a/test/output-tests/run_misc.expected
+++ b/test/output-tests/run_misc.expected
@@ -5585,16 +5585,6 @@ run_misc.at-12175-cmod.c:81.22-110.0:
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12175:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12264:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12360:0
-run_misc.at-12360-prog.cob:26.18-26.27:
-  23              05  DBI-RECORD-NAMES
-  24                     OCCURS 7 TIMES
-  25                     INDEXED BY REC-NAME-IDX
-  26 >                   ASCENDING KEY IS DBI-RECORD-NAME
-----                     ^^^^^^^^^
-  27                     .
-  28                10  DBI-RECORD-NAME PIC X(30).
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12428:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12527:0
 Considering: import/gnucobol/tests/testsuite.src/run_misc.at:12591:0

--- a/test/output-tests/syn_occurs.expected
+++ b/test/output-tests/syn_occurs.expected
@@ -46,44 +46,4 @@ syn_occurs.at-339-prog2.cob:12.19-12.28:
 Considering: import/gnucobol/tests/testsuite.src/syn_occurs.at:418:0
 Considering: import/gnucobol/tests/testsuite.src/syn_occurs.at:503:0
 Considering: import/gnucobol/tests/testsuite.src/syn_occurs.at:590:0
-syn_occurs.at-590-prog.cob:10.18-10.27:
-   7              05  TAB-ENTRY1
-   8                     OCCURS 5 TIMES
-   9                     INDEXED BY IDX1
-  10 >                   ASCENDING KEY IS X1
-----                     ^^^^^^^^^
-  11                     DESCENDING Y1.
-  12                10  X1 PIC 9(4).
->> Error: Invalid syntax
-
-syn_occurs.at-590-prog.cob:11.18-11.28:
-   8                     OCCURS 5 TIMES
-   9                     INDEXED BY IDX1
-  10                     ASCENDING KEY IS X1
-  11 >                   DESCENDING Y1.
-----                     ^^^^^^^^^^
-  12                10  X1 PIC 9(4).
-  13                10  Y1 PIC X.
->> Error: Invalid syntax
-
-syn_occurs.at-590-prog.cob:17.18-17.28:
-  14              05  TAB-ENTRY
-  15                     OCCURS 2 TIMES
-  16                     INDEXED BY IDX2
-  17 >                   DESCENDING KEY IS X2
-----                     ^^^^^^^^^^
-  18                     ASCENDING  Y2.
-  19                10  X2 PIC 9(4).
->> Error: Invalid syntax
-
-syn_occurs.at-590-prog.cob:18.18-18.27:
-  15                     OCCURS 2 TIMES
-  16                     INDEXED BY IDX2
-  17                     DESCENDING KEY IS X2
-  18 >                   ASCENDING  Y2.
-----                     ^^^^^^^^^
-  19                10  X2 PIC 9(4).
-  20                10  Y2 PIC X.
->> Error: Invalid syntax
-
 Considering: import/gnucobol/tests/testsuite.src/syn_occurs.at:617:0


### PR DESCRIPTION
In the `OCCURS` clause, the `INDEXED BY` clause and sort directions (`ASCENDING KEY IS` and `DESCENDING KEY IS`) can be used in any order but only one order was supported.