### PR TITLE
Support STOP RUN RETURNING syntax with scalar argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [_] Next release
 
 ### Added
+- Support STOP RUN RETURNING syntax with scalar argument [#529](https://github.com/OCamlPro/superbol-studio-oss/pull/529)
 - Support INDEXED BY and sort direction in any order in OCCURS clause [#526](https://github.com/OCamlPro/superbol-studio-oss/pull/526)
 - Support for debugging programs launched via custom COBOL runtimes [#522](https://github.com/OCamlPro/superbol-studio-oss/pull/522)
 - Parse `OR` in inspect regions [#519](https://github.com/OCamlPro/superbol-studio-oss/pull/519)

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -3490,12 +3490,12 @@ let when_other [@default []] :=
 (* EXIT STATEMENT *)
 
 let returning :=
- | ~ = scalar; <ReturningScalar>
- | or_(GIVING, RETURNING); o(ADDRESS; OF); ~ = qualident;
+ | ~ = scalar;
+    <ReturningScalar>
+ | or_(GIVING, RETURNING); ~ = scalar;
+    <ReturningScalar>
+ | or_(GIVING, RETURNING); ADDRESS; OF?; ~ = qualident;
     <ReturningAddress>
- | or_(GIVING, RETURNING); v = integer;
-    { ReturningInt { value = Integer v;
-                     size = None } }
  | or_(GIVING, RETURNING); v = integer; s = pf(SIZE; IS, integer);
     { ReturningInt { value = Integer v;
                      size = Some (Integer s) } }
@@ -4195,13 +4195,11 @@ let stop_statement :=
   | STOP; ~ = stop_body; < >
 let stop_body [@context stop_stmt] := (* with context: should not accept empty *)
   | a = stop_with_arg; { StopArg (Some a) }             (* RM/COBOL extension *)
-  | RUN; ~ = o(stop_run_returning_body); <StopRun>
+  | RUN; { StopRun None }
+  | RUN; r = returning; { StopRun (Some (StopReturning r)) }
+  | RUN; s = with_status; { StopRun (Some (StopWithStatus s)) }
   | ERROR; { StopError }                                              (* GCOS *)
   | THREAD; ~ = o(qualident); <StopThread>
-
-let stop_run_returning_body :=
-  | ~ = returning; <StopReturning>
-  | ~ = with_status; <StopWithStatus>
 
 let stop_with_arg :=
   | ~ = qualident; <StopWithQualIdent>                   (* ~COB85, -COB2002 *)


### PR DESCRIPTION
I also did a bit of refactoring. There're a few duplicated tokens but I thought it was more readable that way...

Reference: https://docs.rocketsoftware.com/fr-FR/bundle/cobolit_compiler_suite_reference_rg_411/page/procedure-division-statements-stop.html

and GnuCOBOL's `parser.y` (STOP statement section).