### PR TITLE
Attempt at fixing Text_tokenizer.tokenize_after

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -82,6 +82,10 @@ test-syntax-promote:
 	-$(MAKE) test-syntax	# To avoid promoting past tests
 	\! opam exec -- autofonce 2>/dev/null || opam exec -- autofonce promote -t syntax --apply
 
+.PHONY: test-deps
+test-deps:
+	opam install opam/*.opam --deps-only --with-test
+
 MASTER_REMOTE ?= origin
 
 .PHONY: build-master

--- a/src/lsp/cobol_cfg/cfg_builder.ml
+++ b/src/lsp/cobol_cfg/cfg_builder.ml
@@ -271,8 +271,8 @@ let do_collapse_fallthru g =
       end cfg node cfg in
     let id_map = IdMap.update pred.id
         begin function
-          | None -> Some NEL.(n_names @ pred_names)
-          | Some names -> Some NEL.(n_names @ names)
+          | None -> Some (NEL.append n_names pred_names)
+          | Some names -> Some (NEL.append n_names names)
         end id_map in
     Cfg.remove_vertex cfg node, id_map
   in

--- a/src/lsp/cobol_common/basics.ml
+++ b/src/lsp/cobol_common/basics.ml
@@ -44,6 +44,56 @@ module LIST = struct
     in
     aux acc l
 
+  let check = false
+  let check_10 fname ~loc l =
+    if check then
+      let len = List.length l in
+      if len > 50 then
+        Printf.eprintf "%s %d %s\n%!" fname len
+          (match loc with
+           | None -> ""
+           | Some loc -> loc)
+
+  let append ?loc a b =
+    match a,b with
+    | [], _
+    | [_], _
+    | _, [] -> a @ b
+    | _ ->
+      check_10 "append" ~loc a;
+      a @ b
+
+  let rev_map ?loc f list =
+    check_10 "rev_map" ~loc list;
+    List.rev_map f list
+  let map ?loc f list =
+    check_10 "map" ~loc list;
+    List.map f list
+  let rev_append ?loc list b =
+    check_10 "rev_append" ~loc list;
+    List.rev_append list b
+  let rev ?loc l =
+    check_10 "rev" ~loc l;
+    List.rev l
+  let hd = List.hd
+  let tl = List.tl
+  let split ?loc l =
+    check_10 "split" ~loc l;
+    List.split l
+  let rev_map2 ?loc f l1 l2 =
+    check_10 "rev_map2" ~loc l1;
+    List.rev_map2 f l1 l2
+  let mem ?loc x l =
+    check_10 "mem" ~loc l;
+    List.mem x l
+  let fold_left f a b  =
+    List.fold_left f a b
+  let concat_map ?loc f l =
+    check_10 "concat_map" ~loc l;
+    List.concat_map f l
+  let tail_map ?loc f l =
+    check_10 "tail_map" ~loc l;
+    EzList.tail_map f l
 end
 
 (** Representation for non-empty lists *)
@@ -117,7 +167,7 @@ module NEL = struct
         | One x -> x :: acc
         | x :: tl -> aux (x::acc) tl
       in aux (One hd) tl
-  let ( @ ) a b =
+  let append a b =
     let rec aux b = function
       | One x -> x :: b
       | x :: tl -> x :: aux b tl

--- a/src/lsp/cobol_parser/grammar_tokens_printer.ml
+++ b/src/lsp/cobol_parser/grammar_tokens_printer.ml
@@ -57,7 +57,7 @@ let pp_token_string: token Pretty.printer = fun ppf ->
   | EXEC_BLOCK b -> Cobol_common.Exec_block.pp ppf b
   | INTERVENING_ c -> print "%c" c
   | t -> string @@
-      try Text_lexer.show_token t
+      try Text_lexer.string_of_token t
       with Not_found ->
       try Hashtbl.find combined_tokens t
       with Not_found -> "<unknown/unexpected token>"

--- a/src/lsp/cobol_parser/parser_diagnostics.ml
+++ b/src/lsp/cobol_parser/parser_diagnostics.ml
@@ -12,6 +12,7 @@
 (**************************************************************************)
 
 open Cobol_common.Srcloc.TYPES
+module LIST = Cobol_common.Basics.LIST
 
 type error =
   | Caught_exception of { msg: string }
@@ -112,8 +113,8 @@ let none =
   }
 let union d1 d2 =
   {
-    errors = d1.errors @ d2.errors;
-    customs = d1.customs @ d2.customs;
+    errors = LIST.append ~loc:__LOC__ d1.errors d2.errors;
+    customs = LIST.append ~loc:__LOC__ d1.customs d2.customs;
   }
 let add_error e diags =
   { diags with errors = e :: diags.errors }

--- a/src/lsp/cobol_parser/parser_engine.ml
+++ b/src/lsp/cobol_parser/parser_engine.ml
@@ -273,7 +273,9 @@ let pop_context ({ preproc = { tokzr; _ }; _ } as ps) tokens =
 let on_shift ps tokens e1 e2 =
   let ps, tokens =
     if leaving_context_on_shift ps e1 e2
-    then pop_context ps tokens
+    then begin
+      pop_context ps tokens
+    end
     else ps, tokens
   in
   let tokzr, tokens =
@@ -285,7 +287,9 @@ let on_shift ps tokens e1 e2 =
 
 let on_reduction ps tokens prod =
   if leaving_context_on_reduction ps prod
-  then pop_context ps tokens
+  then begin
+    pop_context ps tokens
+  end
   else ps, tokens
 
 (* --- *)

--- a/src/lsp/cobol_parser/recovery.ml
+++ b/src/lsp/cobol_parser/recovery.ml
@@ -37,6 +37,8 @@
 
 (* Note that's heavily inspired from merlin's own code for recovery *)
 
+module LIST = Cobol_common.Basics.LIST
+
 module Make
     (Parser: MenhirLib.IncrementalEngine.EVERYTHING)
     (Recovery: sig
@@ -200,7 +202,7 @@ struct
           | [] ->
               None, acc
           | ({ env; visited; assumed } :: _) as candidates ->
-              aux (candidates @ acc) (env, visited, assumed)
+              aux (LIST.append ~loc:__LOC__ candidates acc) (env, visited, assumed)
           | exception Not_found ->
               None, acc
           | exception (E.Result v) ->

--- a/src/lsp/cobol_parser/text_lexer.mli
+++ b/src/lsp/cobol_parser/text_lexer.mli
@@ -22,14 +22,15 @@ include module type of TYPES
 module TokenHandles: sig
   include Set.S with type elt = keyword_handle
   val mem_text_token: Grammar_tokens.token -> t -> bool
+  val union_ : t -> normalize:t -> t
 end
 
 module IntrinsicHandles: Set.S with type elt = intrinsic_handle
 
 (* --- *)
 
-val show_token: Grammar_tokens.token -> string
-val show_token_of_handle: keyword_handle -> string
+val string_of_token: Grammar_tokens.token -> string
+val string_of_keyword_handle: keyword_handle -> string
 val pp_tokens_via_handles: TokenHandles.t Pretty.printer
 
 (** Only for debugging *)

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -18,13 +18,30 @@ open Cobol_common.Srcloc.INFIX
 open Cobol_common.Srcloc.TYPES
 open Cobol_preproc.Text.TYPES
 open Grammar_tokens                              (* import token constructors *)
-open Grammar_tokens_printer
 open Parser_diagnostics
 
 (* --- *)
 
+type lexer_update =
+  | Enabled_keywords of Text_lexer.TokenHandles.t
+  | Disabled_keywords of Text_lexer.TokenHandles.t
+  | Enabled_intrinsics
+  | Disabled_intrinsics
+  | CommaBecomesDecimalPoint
+
 type token = Grammar_tokens.token with_loc
-type tokens = token list
+type stream = {
+  toks : token list ;
+  enabled_keywords : Text_lexer.TokenHandles.t ;
+}
+
+type tokens = {
+  former_stream : stream ;
+  new_stream : stream ;
+}
+
+let pp_tokens ppf { former_stream ; _ } =
+  Grammar_tokens_printer.pp_tokens ppf former_stream.toks
 
 let loc_in_area_a: srcloc -> bool = Cobol_common.Srcloc.in_area_a
 let token_in_area_a: token -> bool = fun t -> loc_in_area_a ~@t
@@ -59,40 +76,39 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
               Hashtbl.find Text_lexer.word_of_token t)
          with Not_found -> t)
   and comment_entry revtoks =
-    COMMENT_ENTRY (List.rev_map (Pretty.to_string "%a" pp_token_string) revtoks)
+    COMMENT_ENTRY (LIST.rev_map (Pretty.to_string "%a" Grammar_tokens_printer.pp_token_string) revtoks)
   in
-  let open List in
   let rec skip ((p', l', dgs) as acc) ((p, l) as pl) = function
     | 0 -> acc, pl
-    | i -> skip (hd p :: p', hd l :: l', dgs) (tl p, tl l) (i - 1)
+    | i -> skip (LIST.hd p :: p', LIST.hd l :: l', dgs) (LIST.tl p, LIST.tl l) (i - 1)
   and aux acc (p, l) =
     let subst_n x y =
       let rec cons x ((p', l', dgs) as _acc) (p, l) = function
         | 0 -> assert false
-        | 1 -> aux (x :: p', hd l :: l', dgs) (tl p, tl l)
-        | i -> cons x acc (tl p, hd l +@+ hd (tl l) :: tl (tl l)) (i - 1)
+        | 1 -> aux (x :: p', LIST.hd l :: l', dgs) (LIST.tl p, LIST.tl l)
+        | i -> cons x acc (LIST.tl p, LIST.hd l +@+ LIST.hd (LIST.tl l) :: LIST.tl (LIST.tl l)) (i - 1)
       in
       cons x acc (p, l) y
     and info_word_after n =
       let (p', l', dgs), (p, l) = skip acc (p, l) n in
       match p with
       | [] -> Result.Error `MissingInputs
-      | t :: _ -> aux (info_word t :: p', hd l :: l', dgs) (tl p, tl l)
+      | t :: _ -> aux (info_word t :: p', LIST.hd l :: l', dgs) (LIST.tl p, LIST.tl l)
     and function_name_after n =
       let (p', l', dgs), (p, l) = skip acc (p, l) n in
       match p with
       | [] -> Result.Error `MissingInputs
-      | t :: _ -> aux (function_name t :: p', hd l :: l', dgs) (tl p, tl l)
+      | t :: _ -> aux (function_name t :: p', LIST.hd l :: l', dgs) (LIST.tl p, LIST.tl l)
     and missing_continuation_of str =
       let (p', l', diags), pl = skip acc (p, l) 1 in
-      let error = Missing { loc = hd l; stuff = Continuation_of str } in
+      let error = Missing { loc = LIST.hd l; stuff = Continuation_of str } in
       aux (p', l', Parser_diagnostics.add_error error diags) pl
     and comment_entry_after n =
       let acc, ((p, l) as suff) = skip acc (p, l) n in
       if p = [] then Result.Error `MissingInputs else
         let consume_comment = match comment_entry_termination with
           | Newline ->
-              comment_line ~init_pos:(Cobol_common.Srcloc.start_pos @@ hd l)
+              comment_line ~init_pos:(Cobol_common.Srcloc.start_pos @@ LIST.hd l)
           | Period ->
               comment_paragraph ?stop_column:None
           | AreaB { first_area_b_column } ->
@@ -100,7 +116,7 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
         and at_end ~loc ~revtoks (p', l', diags) =
           comment_entry revtoks :: p', loc :: l', diags
         in
-        consume_comment ~loc:(hd l) ~revtoks:[] ~at_end
+        consume_comment ~loc:(LIST.hd l) ~revtoks:[] ~at_end
           Comment_entry acc suff
     in
     match p with
@@ -208,8 +224,8 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
               ~some:(fun col -> pos_cnum - pos_bol + 1 < col) ~none:false) ->
         aux (at_end ~loc ~revtoks acc) (p, l)
     | t :: tlp, l ->
-        comment_paragraph ?stop_column ~at_end descr acc (tlp, tl l)
-          ~loc:(loc +@+ hd l) ~revtoks:(t :: revtoks)
+        comment_paragraph ?stop_column ~at_end descr acc (tlp, LIST.tl l)
+          ~loc:(loc +@+ LIST.hd l) ~revtoks:(t :: revtoks)
 
   and comment_line ~init_pos ~loc ~revtoks ~at_end descr acc = function
     | [], _ ->                  (* found no word starting on anther line (yet) *)
@@ -222,17 +238,17 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
             pos_fname <> init_pos.pos_fname) ->
         aux (at_end ~loc ~revtoks acc) (p, l)
     | t :: tlp, l ->
-        comment_line ~init_pos ~at_end descr acc (tlp, tl l)
-          ~loc:(loc +@+ hd l) ~revtoks:(t :: revtoks)
+        comment_line ~init_pos ~at_end descr acc (tlp, LIST.tl l)
+          ~loc:(loc +@+ LIST.hd l) ~revtoks:(t :: revtoks)
 
   in
   fun tokens ->
-    let p, srclocs = split @@ map (~&@) tokens in
+    let p, srclocs = LIST.split @@ LIST.map (~&@) tokens in
     match aux ([], [], Parser_diagnostics.none) (p, srclocs) with
     | Ok (p, l, dgs) ->
-        Ok (rev_map2 (&@) p l, dgs)
+        Ok (LIST.rev_map2 (&@) p l, dgs)
     | Error (`ReachedEOF (loc, descr, dgs, p, l)) ->
-        Error (`ReachedEOF (loc, descr, dgs, rev_map2 (&@) p l))
+        Error (`ReachedEOF (loc, descr, dgs, LIST.rev_map2 (&@) p l))
     | Error `MissingInputs ->
         Error `MissingInputs
 
@@ -240,13 +256,13 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
 
 type 'a memory =
   | Amnesic: Cobol_common.Behaviors.amnesic memory
-  | Eidetic: tokens -> Cobol_common.Behaviors.eidetic memory
+  | Eidetic: token list -> Cobol_common.Behaviors.eidetic memory
 
 type 'm state =
   {
     lexer_state: Text_lexer.lexer_state;
-    leftover_tokens: tokens; (* non-empty only when [preproc_n_combine_tokens]
-                                errors out for lack of input tokens. *)
+    leftover_tokens: token list; (* non-empty only when [preproc_n_combine_tokens]
+                                    errors out for lack of input tokens. *)
     memory: 'm memory;
     context_stack: Context.stack;
     registered_intrinsics: Text_lexer.IntrinsicHandles.t;
@@ -296,7 +312,7 @@ let init
   in
   {
     lexer_state = Text_lexer.initial_state;
-    leftover_tokens = [];
+    leftover_tokens = [] ;
     memory;
     context_stack = Context.empty_stack;
     registered_intrinsics = default_intrinsics;
@@ -311,16 +327,16 @@ let init
         exec_scanners;
         verbose;
         show_if_verbose =
-          (if List.mem `Tks show_if_verbose then [`Tks] else []) @
-          (if List.mem `Ctx show_if_verbose then [`Ctx] else []);
+          (if LIST.mem `Tks show_if_verbose then [`Tks] else []) @
+          (if LIST.mem `Ctx show_if_verbose then [`Ctx] else []);
       }
   }
 
 let diagnostics { diags; _ } = diags
-let parsed_tokens { memory = Eidetic tokens; _ } = lazy (List.rev tokens)
+let parsed_tokens { memory = Eidetic tokens ; _ } = lazy ( LIST.rev tokens )
 
 let show tag { persist = { verbose; show_if_verbose; _ }; _ } =
-  verbose && List.mem tag show_if_verbose
+  verbose && LIST.mem tag show_if_verbose
 
 (* --- *)
 
@@ -375,7 +391,7 @@ let acc_tokens_of_text_word (rev_prefix_tokens, state) { payload = c; loc } =
     let tokens, lexer_state =
       Text_lexer.read_tokens lexer lexer_state (w &@ loc)
     in
-    List.rev_map distinguish_words tokens @ rev_prefix_tokens,
+    LIST.append ~loc:__LOC__ ( LIST.rev_map distinguish_words tokens ) rev_prefix_tokens,
     if lexer_state != state.lexer_state
     then { state with lexer_state }
     else state
@@ -445,27 +461,37 @@ let acc_tokens_of_text_word (rev_prefix_tokens, state) { payload = c; loc } =
   then pic_string state
   else nominal state
 
+let new_stream toks = { toks ;
+                     enabled_keywords = Text_lexer.TokenHandles.empty }
+
+let new_tokens toks = {
+  former_stream = new_stream toks ;
+  new_stream = new_stream toks ;
+}
 
 let tokens_of_text: 'a state -> text -> tokens * 'a state = fun state text ->
-  let tokens, state = List.fold_left acc_tokens_of_text_word ([], state) text in
-  List.rev tokens, state
+  let tokens, state = LIST.fold_left acc_tokens_of_text_word ([], state) text in
+  new_tokens ( LIST.rev tokens ), state
 
+let remaining_tokens stream =
+  stream.former_stream.toks
 
 let tokenize_text ~source_format ({ leftover_tokens; _ } as state) text =
   let state = { state with leftover_tokens = [] } in
-  let new_tokens, state = tokens_of_text state text in
-  let tokens = leftover_tokens @ new_tokens in
+  let tokens, state = tokens_of_text state text in
+  let tokens = LIST.append ~loc:__LOC__ leftover_tokens
+      (remaining_tokens tokens) in
   let intrinsics_enabled = state.intrinsics_enabled in
   match preproc_n_combine_tokens ~intrinsics_enabled ~source_format tokens with
   | Ok (tokens, diags) ->
       if show `Tks state then
-        Pretty.error "Tks: %a@." pp_tokens tokens;
+        Pretty.error "Tks: %a@." Grammar_tokens_printer.pp_tokens tokens;
       let diags = Parser_diagnostics.union diags state.diags in
-      Ok tokens, { state with diags }
+      Ok ( new_tokens tokens ), { state with diags }
   | Error `MissingInputs ->
       Error `MissingInputs, { state with leftover_tokens = tokens }
   | Error (`ReachedEOF (loc, unterminated_item, diags, tokens)) ->
-      Error (`ReachedEOF tokens),
+      Error (`ReachedEOF ( new_tokens tokens )),
       let error = Unterminated { loc; stuff = unterminated_item } in
       let diags = Parser_diagnostics.union diags state.diags in
       { state with diags = add_error error diags }
@@ -473,39 +499,17 @@ let tokenize_text ~source_format ({ leftover_tokens; _ } as state) text =
 let emit_token (type m) (s: m state) tok : m state =
   match s.memory with
   | Amnesic -> s
-  | Eidetic toks -> { s with memory = Eidetic (tok :: toks) }
+  | Eidetic toks -> { s with memory = Eidetic ( tok :: toks ) }
 
 let put_token_back (type m) (s: m state) : m state =
   match s.memory with
   | Amnesic -> s
-  | Eidetic [] -> Fmt.invalid_arg "put_token_back: unexpected memory state"
-  | Eidetic (_ :: toks) -> { s with memory = Eidetic toks }
+  | Eidetic  [] -> Fmt.invalid_arg "put_token_back: unexpected memory state"
+  | Eidetic  ( _ :: toks ) -> { s with memory = Eidetic toks }
 
 let rec skip_redundant_periods = function
     | { payload = PERIOD; _ } :: rest -> skip_redundant_periods rest
     | rest -> rest
-
-let next_token (s: _ state) =
-  let rec aux = function
-    | { payload = INTERVENING_(',' | ';'); _ } :: tokens ->
-        aux tokens
-    | { payload = INTERVENING_ '.'; loc } as token :: tokens ->
-        Some (emit_token s (PERIOD &@ loc), token, tokens)
-    | { payload = PERIOD; _ } as token :: tokens ->
-        Some (emit_token s token, token, skip_redundant_periods tokens)
-    | token :: tokens ->
-        Some (emit_token s token, token, tokens)
-    | [] ->
-        None
-  in
-  aux
-
-type lexer_update =
-  | Enabled_keywords of Text_lexer.TokenHandles.t
-  | Disabled_keywords of Text_lexer.TokenHandles.t
-  | Enabled_intrinsics
-  | Disabled_intrinsics
-  | CommaBecomesDecimalPoint
 
 let retokenize { lexer_state; persist = { lexer; _ }; _ } w =
   (* Note: for now we can forget the lexer state that is returned on rescan of
@@ -514,11 +518,53 @@ let retokenize { lexer_state; persist = { lexer; _ }; _ } w =
      (handling of DECIMAL POINT).  *)
   fst @@ Text_lexer.read_tokens lexer lexer_state w
 
-let reword_intrinsics s : tokens -> tokens =
+let comma_becomes_decimal_point s toks =
+  (* This may only happen when the comma becomes a decimal separator in
+     numerical literals, instead of periods.  Before this (irreversible)
+     change, any intervening comma is represented with a special
+     [INTERVENING_ ','] token in the list of tokens procuded by
+     {!tokenize_text}. *)
+  (* Find any INTERVENING_COMMA and retokenize with the two adjacent words
+     if they are SINTLIT on the left, and DIGITS (or FLOATLIT) on the
+     right (possible combinations are generated in {!Text_lexer.token}).
+     To deal with periods, we need to retokenize any FIXEDLIT and
+     FLOATLIT. *)
+  let show_fixed (i, c, d) = Pretty.to_string "%s%c%s" i c d in
+  let show_float (i, c, d, e) = Pretty.to_string "%s%c%sE%s" i c d e in
+  let rec aux rev_prefix suffix =
+    match rev_prefix, suffix with
+    | { payload = SINTLIT l; loc = lloc } :: rev_prefix,
+      { payload = INTERVENING_ ','; loc = cloc } ::
+      { payload = DIGITS r; loc = rloc } :: suffix ->
+      retokenize_with_comma rev_prefix suffix
+        l lloc cloc r rloc
+    | { payload = SINTLIT l; loc = lloc } :: rev_prefix,
+      { payload = INTERVENING_ ','; loc = cloc } ::
+      { payload = FLOATLIT f; loc = rloc } :: suffix ->
+      retokenize_with_comma rev_prefix suffix
+        l lloc cloc (show_float f) rloc
+    | _, { payload = FIXEDLIT f; loc } :: suffix ->
+      let toks = retokenize s (show_fixed f &@ loc) in
+      aux (LIST.rev_append toks rev_prefix) suffix
+    | _, { payload = FLOATLIT f; loc } :: suffix ->
+      let toks = retokenize s (show_float f &@ loc) in
+      aux (LIST.rev_append toks rev_prefix) suffix
+    | _, [] ->
+      LIST.rev rev_prefix
+    | _, x :: tl ->
+      aux (x :: rev_prefix) tl
+  and retokenize_with_comma rev_prefix suffix l l_loc sep_loc r r_loc =
+    let loc = Cobol_common.Srcloc.(concat (concat l_loc sep_loc) r_loc) in
+    let tks = retokenize s (Pretty.to_string "%s,%s" l r &@ loc) in
+    aux (LIST.rev_append tks rev_prefix) suffix
+  in
+  aux [] toks
+
+let reword_intrinsics s tokens =
   (* Some intrinsics NOT preceded with FUNCTION may now be words; assumes
      [Disabled_intrinsics] does not occur on a `FUNCTION` keyword (but that's
      unlikely). *)
-  let keyword_of_token = Hashtbl.find Text_lexer.word_of_token in
+  let keyword_of_token token = Hashtbl.find Text_lexer.word_of_token token in
   let is_intrinsic_token = function
     | INTRINSIC_FUNC _ -> true
     | t when Text_keywords.is_known_intrinsic_token t -> true
@@ -526,94 +572,245 @@ let reword_intrinsics s : tokens -> tokens =
   let rec aux rev_prefix suffix =
     match suffix with
     | [] ->
-        List.rev rev_prefix
+      LIST.rev rev_prefix
     | ({ payload = k1_token; _ } as k1) ::
       ({ payload = k2_token; _ } as k2) :: tl
       when k1_token <> FUNCTION && is_intrinsic_token k2_token ->
-        aux (EzList.tail_map distinguish_words @@
-             retokenize s (keyword_of_token k2_token &@<- k2) @
-             k1 :: rev_prefix) tl
+      aux (LIST.tail_map ~loc:__LOC__ distinguish_words @@
+           retokenize s (keyword_of_token k2_token &@<- k2) @
+           k1 :: rev_prefix) tl
     | k1 :: tl ->
-        aux (k1 :: rev_prefix) tl
+      aux (k1 :: rev_prefix) tl
   in
-  aux []
+  aux [] tokens
 
-(** Retokenizes the tokens {e after} the given operation has been perfomed on
-    {!module:Text_lexer}. *)
-(* TODO: Find whether everything related to Area A and comma-retokenization
-   could be moved to Text_lexer *)
-let retokenize_after: lexer_update -> _ state -> tokens -> tokens = fun update s ->
-  match update with
-  | Enabled_keywords tokens
-  | Disabled_keywords tokens
-    when Text_lexer.TokenHandles.is_empty tokens ->
-      Fun.id
-  | Enabled_keywords _
-  | Enabled_intrinsics ->          (* <- some words may have become intrinsics *)
-      List.concat_map begin fun token -> match ~&token with
+module type INTERFACE = sig
+
+  val retokenize_after : lexer_update -> 'a state -> stream -> stream
+  val next_token :
+    'a state ->
+    stream ->
+    ('a state * Grammar_tokens.token with_loc * stream) option
+
+  val put_back_token : token -> stream -> stream
+
+end
+
+module FORMER_IMPLEMENTATION : INTERFACE = struct
+
+  (** Retokenizes the tokens {e after} the given operation has been perfomed on
+      {!module:Text_lexer}. *)
+  (* TODO: Find whether everything related to Area A and comma-retokenization
+     could be moved to Text_lexer *)
+  let retokenize_after = fun update s stream ->
+    let toks = stream.toks in
+    let toks =
+      match update with
+      | Enabled_keywords tokens
+      | Disabled_keywords tokens
+        when Text_lexer.TokenHandles.is_empty tokens ->
+        toks
+      | Enabled_keywords _
+      | Enabled_intrinsics ->          (* <- some words may have become intrinsics *)
+        LIST.concat_map ~loc:__LOC__ ( fun token -> match ~&token with
+            | WORD_IN_AREA_A w
+            | WORD w ->
+              (* translate WORD in a area_a to WORD_IN_AREA_A *)
+              LIST.tail_map ~loc:__LOC__ distinguish_words
+              @@
+              (* why would we need to retokenize this WORD differently ? *)
+              retokenize s (w &@<- token)
+            | _ ->
+              [token]
+          ) toks
+      | Disabled_keywords tokens ->
+        (*
+        Printf.eprintf "Disabled_keywords:\n%!";
+        Text_lexer.TokenHandles.iter (fun s ->
+            Printf.eprintf "   * %S\n%!"
+              (Text_lexer.string_of_keyword_handle s)) tokens;
+           *)
+        (* When removing these keywords, translate back any such keyword to
+           the corresponding WORD/WORD_IN_AREA_A *)
+        LIST.tail_map ~loc:__LOC__ ( fun token ->
+            if Text_lexer.TokenHandles.mem_text_token ~&token tokens
+            then
+              let w = Hashtbl.find Text_lexer.word_of_token ~&token in
+              if token_in_area_a token then WORD_IN_AREA_A w &@<- token
+              else WORD w &@<- token
+            else token
+          ) toks
+      | Disabled_intrinsics ->
+        reword_intrinsics s toks
+      | CommaBecomesDecimalPoint -> comma_becomes_decimal_point s toks
+    in
+    (* We don't store updates as we have already applied them ! *)
+    {  toks = toks ; enabled_keywords = Text_lexer.TokenHandles.empty }
+
+  let rec next_token (s: _ state) stream =
+    match stream.toks with
+    | { payload = INTERVENING_(',' | ';'); _ } :: tokens ->
+      next_token s { stream with toks = tokens }
+    | { payload = INTERVENING_ '.'; loc } as token :: tokens ->
+      Some (emit_token s (PERIOD &@ loc), token, { stream with toks = tokens })
+    | { payload = PERIOD; _ } as token :: tokens ->
+      let tokens = skip_redundant_periods tokens in
+      Some (emit_token s token, token, { stream with toks = tokens  } )
+    | token :: tokens ->
+      Some (emit_token s token, token, { stream with toks = tokens })
+    | [] ->
+      None
+
+  let put_back_token token stream =
+    { stream with toks = token :: stream.toks }
+
+end
+
+module NEW_IMPLEMENTATION : INTERFACE = struct
+
+  (** Retokenizes the tokens {e after} the given operation has been perfomed on
+      {!module:Text_lexer}. *)
+  (* TODO: Find whether everything related to Area A and comma-retokenization
+     could be moved to Text_lexer *)
+  let retokenize_after = fun update s stream ->
+      match update with
+      | Enabled_keywords tokens ->
+        let enabled_keywords = stream.enabled_keywords in
+        let enabled_keywords =
+          Text_lexer.TokenHandles.union_
+            enabled_keywords ~normalize:tokens in
+        (*
+        Printf.eprintf "Newly Enabled_keywords:\n%!";
+          Text_lexer.TokenHandles.iter (fun s ->
+              Printf.eprintf "   * %S\n%!"
+                (Text_lexer.string_of_keyword_handle s)) enabled_keywords;
+           *)
+        { stream with enabled_keywords }
+      | Disabled_keywords tokens -> 
+        let enabled_keywords = stream.enabled_keywords in
+        (*
+        if not @@ Text_lexer.TokenHandles.subset tokens enabled_keywords then begin
+          Printf.eprintf "NEW Disabled_keywords:\n%!";
+          Text_lexer.TokenHandles.iter (fun s ->
+              Printf.eprintf "   * %S\n%!"
+                (Text_lexer.string_of_keyword_handle s)) tokens;
+          Printf.eprintf "Formerly Enabled_keywords:\n%!";
+          Text_lexer.TokenHandles.iter (fun s ->
+              Printf.eprintf "   * %S\n%!"
+                (Text_lexer.string_of_keyword_handle s)) enabled_keywords;
+        end; *)
+        let enabled_keywords =
+          Text_lexer.TokenHandles.diff enabled_keywords tokens in
+        { stream with enabled_keywords }
+      | _ ->
+        FORMER_IMPLEMENTATION.retokenize_after update s stream
+
+  let rec next_token (s: _ state) stream =
+    match stream.toks with
+    | [] -> None
+    | token :: toks ->
+      let token =
+        match ~&token with
         | WORD_IN_AREA_A w
         | WORD w ->
-            EzList.tail_map distinguish_words @@
-            retokenize s (w &@<- token)
+          (* translate WORD in a area_a to WORD_IN_AREA_A *)
+              LIST.tail_map ~loc:__LOC__ distinguish_words
+              @@
+              (* why would we need to retokenize this WORD differently ? *)
+              retokenize
+                { s with
+                  lexer_state =
+                    Text_lexer.cancel_picture_string_expectation s.lexer_state }
+                (w &@<- token)
         | _ ->
-            [token]
-      end
-  | Disabled_keywords tokens ->
-      let keyword_of_token = Hashtbl.find Text_lexer.word_of_token in
-      EzList.tail_map begin fun token ->
-        if Text_lexer.TokenHandles.mem_text_token ~&token tokens
-        then match token_in_area_a token, keyword_of_token ~&token with
-          | true, w -> WORD_IN_AREA_A w &@<- token
-          | false, w -> WORD w &@<- token
-        else token
-      end
-  | Disabled_intrinsics ->
-      reword_intrinsics s
-  | CommaBecomesDecimalPoint ->
-      (* This may only happen when the comma becomes a decimal separator in
-         numerical literals, instead of periods.  Before this (irreversible)
-         change, any intervening comma is represented with a special
-         [INTERVENING_ ','] token in the list of tokens procuded by
-         {!tokenize_text}. *)
-      (* Find any INTERVENING_COMMA and retokenize with the two adjacent words
-         if they are SINTLIT on the left, and DIGITS (or FLOATLIT) on the
-         right (possible combinations are generated in {!Text_lexer.token}).
-         To deal with periods, we need to retokenize any FIXEDLIT and
-         FLOATLIT. *)
-      let show_fixed (i, c, d) = Pretty.to_string "%s%c%s" i c d in
-      let show_float (i, c, d, e) = Pretty.to_string "%s%c%sE%s" i c d e in
-      let rec aux rev_prefix suffix =
-        match rev_prefix, suffix with
-        | { payload = SINTLIT l; loc = lloc } :: rev_prefix,
-          { payload = INTERVENING_ ','; loc = cloc } ::
-          { payload = DIGITS r; loc = rloc } :: suffix ->
-            retokenize_with_comma rev_prefix suffix
-              l lloc cloc r rloc
-        | { payload = SINTLIT l; loc = lloc } :: rev_prefix,
-          { payload = INTERVENING_ ','; loc = cloc } ::
-          { payload = FLOATLIT f; loc = rloc } :: suffix ->
-            retokenize_with_comma rev_prefix suffix
-              l lloc cloc (show_float f) rloc
-        | _, { payload = FIXEDLIT f; loc } :: suffix ->
-            let toks = retokenize s (show_fixed f &@ loc) in
-            aux (List.rev_append toks rev_prefix) suffix
-        | _, { payload = FLOATLIT f; loc } :: suffix ->
-            let toks = retokenize s (show_float f &@ loc) in
-            aux (List.rev_append toks rev_prefix) suffix
-        | _, [] ->
-            List.rev rev_prefix
-        | _, x :: tl ->
-            aux (x :: rev_prefix) tl
-      and retokenize_with_comma rev_prefix suffix l l_loc sep_loc r r_loc =
-        let loc = Cobol_common.Srcloc.(concat (concat l_loc sep_loc) r_loc) in
-        let tks = retokenize s (Pretty.to_string "%s,%s" l r &@ loc) in
-        aux (List.rev_append tks rev_prefix) suffix
+          [token]
       in
-      aux []
+      let token = match token with
+        | [] -> assert false
+        | [ token ] -> token
+        | _ -> assert false
+      in
+      let loc = token.Cobol_common.Srcloc.loc in
+      match token.payload with
+      | INTERVENING_(',' | ';') -> next_token s { stream with toks }
+      | INTERVENING_ '.' ->
+        Some (emit_token s (PERIOD &@ loc), token, { stream with toks })
+      | PERIOD ->
+        let toks = skip_redundant_periods toks in
+        Some (emit_token s token, token, { stream with toks  } )
+      | _ ->
+        Some (emit_token s token, token, { stream with toks })
+
+  let put_back_token token stream =
+    { stream with toks = token :: stream.toks }
+
+end
+
+module COMPARISON = struct
+  let retokenize_after enable state { former_stream ; new_stream } =
+    let former_stream = FORMER_IMPLEMENTATION.retokenize_after
+        enable state former_stream in
+    let new_stream = NEW_IMPLEMENTATION.retokenize_after
+        enable state new_stream in
+    { former_stream ; new_stream }
+
+  let put_back_token token  { former_stream ; new_stream } =
+    let former_stream = FORMER_IMPLEMENTATION.put_back_token token former_stream in
+    let new_stream = NEW_IMPLEMENTATION.put_back_token token new_stream in
+    { former_stream ; new_stream }
+
+  let next_token state { former_stream ; new_stream } =
+    let output1 = FORMER_IMPLEMENTATION.next_token state former_stream in
+    let output2 = NEW_IMPLEMENTATION.next_token state new_stream in
+    match output1 with
+    | None -> None
+    | Some (state1, token1, former_stream) ->
+      match output2 with
+      | None -> assert false
+      | Some (state2, token2, new_stream) ->
+        if token1.payload <> token2.payload then begin
+          Printf.eprintf "former_stream returned %s\n%!"
+            ( Text_lexer.string_of_token token1.payload);
+          Printf.eprintf "new_stream returned %s\n%!"
+            ( Text_lexer.string_of_token token2.payload);
+          assert false
+        end;
+        (*
+        Printf.eprintf "next_token returned %s\n%!"
+          ( Text_lexer.string_of_token token1.payload);
+           *)
+        ignore (state1, state2);
+        Some (state2, token2, { former_stream ; new_stream })
+
+end
+
+module ONE_IMPLEMENTATION = struct
+  let retokenize_after enable state { former_stream ; new_stream } =
+    let new_stream = NEW_IMPLEMENTATION.retokenize_after
+        enable state new_stream in
+    { former_stream ; new_stream }
+
+  let put_back_token token  { former_stream ; new_stream } =
+    let new_stream = NEW_IMPLEMENTATION.put_back_token token new_stream in
+    { former_stream ; new_stream }
+
+  let next_token state { former_stream ; new_stream } =
+    let output2 = NEW_IMPLEMENTATION.next_token state new_stream in
+    match output2 with
+    | None -> None
+    | Some (state, token2, new_stream) ->
+        Some (state, token2, { former_stream ; new_stream })
+
+end
+
+include COMPARISON
+
 
 (** Enable incoming tokens w.r.t the lexer, and retokenize awaiting tokens
     (i.e. that may have been tokenized according to out-of-date rules) *)
-let enable_tokens state tokens incoming_tokens =
+let enable_tokens
+  : 'a state -> tokens -> Text_lexer.TokenHandles.t -> 'a state * tokens =
+  fun state tokens incoming_tokens ->
   Text_lexer.enable_keywords incoming_tokens;
   state, retokenize_after (Enabled_keywords incoming_tokens) state tokens
 
@@ -635,35 +832,29 @@ let unregister_intrinsics { persist = { lexer; _ }; registered_intrinsics; _ } =
 let save_intrinsics state =
   unregister_intrinsics state
 
-
 let restore_intrinsics ({ intrinsics_enabled; _ } as state) =
   if intrinsics_enabled
   then register_intrinsics state
 
-
-let enable_intrinsics state token tokens =
-  if state.intrinsics_enabled then state, token, tokens else        (* error? *)
+let enable_intrinsics state token stream =
+  if state.intrinsics_enabled then state, token, stream else        (* error? *)
     let state = put_token_back { state with intrinsics_enabled = true } in
     register_intrinsics state;
-    let tokens = token :: tokens in
-    let tokens = retokenize_after Enabled_intrinsics state tokens in
-    let token, tokens = List.hd tokens, List.tl tokens in
-    if show `Tks state then
-      Pretty.error "Tks': %a@." pp_tokens tokens;
-    emit_token state token, token, tokens
+    let stream = put_back_token token stream in
+    let stream = retokenize_after Enabled_intrinsics state stream in
+    match next_token state stream with
+    | None -> assert false
+    | Some (state, token, stream) -> state, token, stream
 
-
-let disable_intrinsics state token tokens =
-  if not state.intrinsics_enabled then state, token, tokens else      (* error? *)
+let disable_intrinsics state token stream =
+  if not state.intrinsics_enabled then state, token, stream else      (* error? *)
     let state = put_token_back { state with intrinsics_enabled = false } in
     unregister_intrinsics state;
-    let tokens = token :: tokens in
-    let tokens = retokenize_after Disabled_intrinsics state tokens in
-    let token, tokens = List.hd tokens, List.tl tokens in
-    if show `Tks state then
-      Pretty.error "Tks': %a@." pp_tokens tokens;
-    emit_token state token, token, tokens
-
+    let stream = put_back_token token stream in
+    let stream = retokenize_after Disabled_intrinsics state stream in
+    match next_token state stream with
+    | None -> assert false
+    | Some (state, token, stream) -> state, token, stream
 
 let reset_intrinsics state token tokens =
   let state, token, tokens = disable_intrinsics state token tokens in
@@ -681,27 +872,26 @@ let replace_intrinsics state intrinsics =
     | None ->
         state.persist.default_intrinsics
     | Some s ->
-        Text_lexer.intrinsic_handles state.persist.lexer (List.map (~&) s)
+        Text_lexer.intrinsic_handles state.persist.lexer (LIST.map (~&) s)
   in
   { state with registered_intrinsics }
 
 
-let decimal_point_is_comma (type m) (state: m state) token tokens =
+let decimal_point_is_comma (type m) (state: m state) token stream =
   let state = put_token_back state in
   let state =
     { state with
       lexer_state = Text_lexer.decimal_point_is_comma state.lexer_state }
   in
-  let tokens = token :: tokens in
-  let tokens = retokenize_after CommaBecomesDecimalPoint state tokens in
-  let token, tokens = List.hd tokens, List.tl tokens in
-  if show `Tks state then
-    Pretty.error "Tks': %a@." pp_tokens tokens;
-  emit_token state token, token, tokens
+  let stream = put_back_token token stream in
+  let stream = retokenize_after CommaBecomesDecimalPoint state stream in
+  match next_token state stream with
+  | None -> assert false
+  | Some (state, token, stream) -> state, token, stream
 
 
-let put_token_back state token tokens =
-  put_token_back state, token :: tokens
+let put_token_back state token stream =
+  put_token_back state, put_back_token token stream
 
 (* --- *)
 
@@ -713,9 +903,9 @@ let push_contexts state tokens : Context.t list -> 's * 'a = function
   | [] ->
       state, tokens
   | contexts ->
-      let context_stack, tokens_set =
+    let context_stack, tokens_set =
         let context_tokens = state.persist.context_tokens in
-        List.fold_left begin fun (stack, set) ctx ->
+        LIST.fold_left begin fun (stack, set) ctx ->
           if show `Ctx state then
             Pretty.error "Incoming: %a@."
               (Context.pp_context context_tokens) ctx;
@@ -731,7 +921,6 @@ let push_contexts state tokens : Context.t list -> 's * 'a = function
       let state, tokens = enable_tokens state tokens tokens_set in
       if show `Tks state then
         Pretty.error "Tks': %a@." pp_tokens tokens;
-
       with_context_stack state context_stack, tokens
 
 let top_context state =

--- a/src/lsp/cobol_parser/text_tokenizer.mli
+++ b/src/lsp/cobol_parser/text_tokenizer.mli
@@ -19,7 +19,7 @@ open EzCompat
 
 (** Tokens passed to {!Parser}; can be obtained via {!tokenize_text}. *)
 type token = Grammar_tokens.token Cobol_ptree.with_loc
-type tokens = token list
+type tokens
 
 (* --- *)
 
@@ -59,7 +59,7 @@ val diagnostics
 
 val parsed_tokens
   : Cobol_common.Behaviors.eidetic state
-  -> tokens Lazy.t
+  -> token list Lazy.t
 
 val tokenize_text
   : source_format: Cobol_preproc.Src_format.any

--- a/src/lsp/cobol_preproc/preproc_diagnostics.ml
+++ b/src/lsp/cobol_preproc/preproc_diagnostics.ml
@@ -13,6 +13,7 @@
 
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
+module LIST = Cobol_common.Basics.LIST
 
 type error =
   | Copybook_lookup_error of { copyloc: srcloc option;
@@ -275,8 +276,8 @@ type diagnostics =
 type t = diagnostics
 let none = { errors = []; warnings = [] }
 let union d1 d2 =
-  { errors = d1.errors @ d2.errors;
-    warnings = d1.warnings @ d2.warnings }
+  { errors = LIST.append ~loc:__LOC__ d1.errors d2.errors;
+    warnings = LIST.append ~loc:__LOC__ d1.warnings d2.warnings }
 let add_error e diags = { diags with errors = e :: diags.errors }
 let add_warning w diags = { diags with warnings = w :: diags.warnings }
 let has_errors diags = diags.errors <> []

--- a/src/lsp/cobol_preproc/preproc_state.ml
+++ b/src/lsp/cobol_preproc/preproc_state.ml
@@ -15,6 +15,7 @@ open Cobol_common.Srcloc.TYPES
 open Text.TYPES
 
 module NEL = Cobol_common.Basics.NEL
+module LIST = Cobol_common.Basics.LIST
 
 type state =
   | AllowAll
@@ -95,7 +96,7 @@ let find_phrase first_word ?(prefix = `Same) text : _ result =
 let find_full_phrase all_words
     ?(prefix = `Same) ?(search_deep = false) ?(try_hard = false)
   : text -> _ result =
-  let all_words = all_words @ ["."] in
+  let all_words = LIST.append ~loc:__LOC__ all_words ["."] in
   let split_at_first = Cobol_common.Basics.LIST.split_at_first in
   let split_before_word first_word =
     split_at_first ~prefix ~where:`Before (Text.textword_eqp ~eq:first_word)
@@ -136,9 +137,9 @@ let find_full_phrase all_words
             | Error _ as e, _ ->
                 e
             | Ok phrase, `Same ->
-                Ok { phrase with prefix = prefix_text @ phrase.prefix }
+                Ok { phrase with prefix = LIST.append ~loc:__LOC__ prefix_text phrase.prefix }
             | Ok phrase, `Rev ->
-                Ok { phrase with prefix = phrase.prefix @ prefix_text }
+                Ok { phrase with prefix = LIST.append ~loc:__LOC__ phrase.prefix prefix_text }
   in
   if search_deep
   then try_from

--- a/src/lsp/cobol_preproc/src_reader.ml
+++ b/src/lsp/cobol_preproc/src_reader.ml
@@ -204,11 +204,11 @@ let fold_lines
         (fun tok -> loc_lnum tok > cur_lnum) chunk
     with
     | Error () ->                                    (* still on the same line *)
-        (acc, cur_lnum, cur_prefix @ chunk)
+        (acc, cur_lnum, LIST.append ~loc:__LOC__ cur_prefix chunk)
     | Ok (prefix, []) ->           (* should not happen (in case, just append) *)
-        (acc, cur_lnum, cur_prefix @ prefix)
+        (acc, cur_lnum, LIST.append ~loc:__LOC__ cur_prefix prefix)
     | Ok (prefix, (tok :: _ as suffix)) ->                (* terminating a line *)
-        let acc = f cur_lnum (cur_prefix @ prefix) acc in
+        let acc = f cur_lnum (LIST.append ~loc:__LOC__ cur_prefix prefix) acc in
         let new_lnum = loc_lnum tok in
         let acc = spit_empty_lines ~until_lnum:new_lnum (succ cur_lnum) acc in
         spit_chunk suffix (acc, new_lnum, [])

--- a/src/lsp/cobol_preproc/text_processor.ml
+++ b/src/lsp/cobol_preproc/text_processor.ml
@@ -383,11 +383,11 @@ let apply_replacing k repl log =
     fun k done_text log text ->
       match k, try_replacing_phrase k repl text, text with
       | OnPartText, Ok (done_text', le, []), _ ->
-          Ok (done_text @ done_text', Preproc_trace.append le log)
+          Ok (LIST.append ~loc:__LOC__ done_text done_text', Preproc_trace.append le log)
       | OnFullText, Ok (done_text', le, []), _ ->
-          done_text @ done_text', Preproc_trace.append le log
+          LIST.append ~loc:__LOC__ done_text done_text', Preproc_trace.append le log
       | _, Ok (done_text', le, text), _ ->
-          aux k (done_text @ done_text') (Preproc_trace.append le log) text
+          aux k (LIST.append ~loc:__LOC__ done_text done_text') (Preproc_trace.append le log) text
       | OnPartText, Error `MissingText, _ ->
           Error (`MissingText (done_text, log, text))
       | OnPartText, Error `NoReplacement, [] ->
@@ -395,7 +395,32 @@ let apply_replacing k repl log =
       | OnFullText, Error `NoReplacement, [] ->
           done_text, log
       | _, Error _, x :: text ->
-          aux k (done_text @ [x]) log text
+          aux k (LIST.append ~loc:__LOC__ done_text [x]) log text
+  in
+  aux k [] log
+
+(** [apply_replacing attempt repl text] applies the replacing clauses [repl] to
+    [text], and returns a result that depends on whether the given text may be
+    continued ([attempt = OnPartText]) or not ([attempt = OnFullText]). *)
+let apply_replacing k repl log =
+  let rec aux: type p q. (p, q) repl_attempt -> text -> log -> text -> q =
+    fun k rev_done_text log text ->
+
+      match k, try_replacing_phrase k repl text, text with
+      | OnPartText, Ok (done_text', le, []), _ ->
+          Ok (LIST.append ~loc:__LOC__ (List.rev done_text') rev_done_text, Preproc_trace.append le log)
+      | OnFullText, Ok (done_text', le, []), _ ->
+          LIST.append ~loc:__LOC__ (List.rev done_text') rev_done_text , Preproc_trace.append le log
+      | _, Ok (done_text', le, text), _ ->
+          aux k (LIST.append ~loc:__LOC__ (List.rev done_text') rev_done_text ) (Preproc_trace.append le log) text
+      | OnPartText, Error `MissingText, _ ->
+          Error (`MissingText (List.rev rev_done_text, log, text))
+      | OnPartText, Error `NoReplacement, [] ->
+          Ok (List.rev rev_done_text, log)
+      | OnFullText, Error `NoReplacement, [] ->
+          List.rev rev_done_text, log
+      | _, Error _, x :: text ->
+          aux k (x :: rev_done_text) log text
   in
   aux k [] log
 

--- a/src/lsp/cobol_ptree/operands.ml
+++ b/src/lsp/cobol_ptree/operands.ml
@@ -14,6 +14,8 @@
 open Common
 open Terms
 
+module LIST = Cobol_common.Basics.LIST
+
 (* Used in ENVIRONMENT, and SORT/MERGE statements *)
 
 type alphabet_specification =                      (* At least one is required *)
@@ -282,7 +284,7 @@ let pp_divide_operands ppf = function
     let pair = if into then divisor, dividend else dividend, divisor in
     pp_arithmetic_operands ~sep:(if into then "INTO" else "BY")
       pp_scalar pp_scalar
-      ppf (pair, pp_giving giving @ pp_remainder_opt remainder)
+      ppf (pair, LIST.append ~loc:__LOC__ (pp_giving giving) (pp_remainder_opt remainder))
 
 
 (* EVALUATE *)

--- a/src/lsp/cobol_typeck/typeck_clauses.ml
+++ b/src/lsp/cobol_typeck/typeck_clauses.ml
@@ -261,7 +261,7 @@ let to_usage_n_value ~item_name ~item_loc ~picture_config item_clauses =
         | Ok pic ->
             diags, Some (Ok pic)
         | Error diags' ->
-            diags' @ diags, Some (Error picture_clause)
+            LIST.append ~loc:__LOC__ diags' diags, Some (Error picture_clause)
   in
   let usage_clause = match item_clauses.usage with
     | Some usage ->

--- a/src/lsp/cobol_typeck/typeck_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_diagnostics.ml
@@ -14,6 +14,7 @@
 open Cobol_common.Srcloc.TYPES
 
 module DIAGS = Cobol_common.Diagnostics
+module LIST = Cobol_common.Basics.LIST
 
 (** more general diagnostics *)
 type diagnostic =
@@ -30,7 +31,7 @@ type diagnostic =
 type diagnostics = diagnostic list
 type t = diagnostics
 let none: diagnostics = []
-let union d1 d2 = d2 @ d1
+let union d1 d2 = LIST.append ~loc:__LOC__ d2 d1
 
 let diagnostic_severity = function
   | Config_error _

--- a/src/lsp/cobol_typeck/typeck_outputs.ml
+++ b/src/lsp/cobol_typeck/typeck_outputs.ml
@@ -13,6 +13,7 @@
 
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
+module LIST = Cobol_common.Basics.LIST
 
 type qualrefmap = srcloc list Cobol_unit.Qual.MAP.t
 type references_in_unit =
@@ -82,7 +83,7 @@ let none: t =
   }
 
 let merge_qualrefmaps: qualrefmap -> qualrefmap -> qualrefmap =
-  Cobol_unit.Qual.MAP.union (fun _ a b -> Some (b @ a))   (* keep reversed order *)
+  Cobol_unit.Qual.MAP.union (fun _ a b -> Some (LIST.append ~loc:__LOC__ b a))   (* keep reversed order *)
 
 let register_qualref qn ~loc refs =
   Cobol_unit.Qual.MAP.update qn


### PR DESCRIPTION
This function is called repeatedly when entering/leaving grammar contexts with Enabled_keywords/Disabled_keywords, but everytime, it updates the whole list of tokens, most of the time redoing/undoing what it had done before.

In this attempt, in the case of Enabled_keywords/Disabled_keywords, we don't update the list of tokens, instead we keep the list of enabled keywords and translate them on the fly when the next token is asked.

This version has a 10x speedup on problematic file.

HOWEVER, it does pass the testsuite, and, unfortunately, the testsuite lacks documentation on how to fix problems using it (i.e. how do you run a specific test in isolation ?).

I left a lot of debug stuff in the code, especially, it currently compares its output with the former implementation and fails if they disagree. Should ease testing...