### PR TITLE
Update bindings for VSCode open dialog

### DIFF
--- a/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.ml
+++ b/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.ml
@@ -2208,7 +2208,7 @@ module OpenDialogOptions = struct
 
     val defaultUri : t -> string option [@@js.get]
 
-    val filters : t -> (string * string list) list [@@js.get]
+    val filters : t -> string list Dict.t [@@js.get]
 
     val openLabel : t -> string [@@js.get]
 
@@ -2219,7 +2219,7 @@ module OpenDialogOptions = struct
       -> ?canSelectFolders:bool
       -> ?canSelectMany:bool
       -> ?defaultUri:string
-      -> ?filters:((string * string list) list)
+      -> ?filters:(string list Dict.t)
       -> ?openLabel:string
       -> ?title:string
       -> unit

--- a/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.mli
+++ b/src/vendor/vscode-ocaml-platform/src-bindings/vscode/vscode.mli
@@ -1721,7 +1721,7 @@ module OpenDialogOptions : sig
 
   val defaultUri : t -> string option
 
-  val filters : t -> (string * string list) list
+  val filters : t -> string list Interop.Dict.t
 
   val openLabel : t -> string
 
@@ -1732,7 +1732,7 @@ module OpenDialogOptions : sig
     -> ?canSelectFolders:bool
     -> ?canSelectMany:bool
     -> ?defaultUri:string
-    -> ?filters:((string * string list) list)
+    -> ?filters:(string list Interop.Dict.t)
     -> ?openLabel:string
     -> ?title:string
     -> unit


### PR DESCRIPTION
`Dict` is actually more correct than lists for the filters of open dialog.

In https://code.visualstudio.com/api/references/vscode-api#OpenDialogOptions we notice that `filters?` expects a `Record` (delimited with `{ }`) instead of a list.