### PR TITLE
Simplify restriction of Area a enforcement with `COBOL85` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [_] Next release
 
 ### Added
-- Enforcement of Area A checks only when the source format is `COBOL85` [#555](https://github.com/OCamlPro/superbol-studio-oss/pull/555)
+- Enforcement of Area A checks only when the source format is `COBOL85` [#555](https://github.com/OCamlPro/superbol-studio-oss/pull/555) [#556](https://github.com/OCamlPro/superbol-studio-oss/pull/556)
 - Support for COMP-6 usage [#548](https://github.com/OCamlPro/superbol-studio-oss/pull/548)
 
 ### Fixed

--- a/src/lsp/cobol_parser/text_tokenizer.ml
+++ b/src/lsp/cobol_parser/text_tokenizer.ml
@@ -229,11 +229,6 @@ let preproc_n_combine_tokens ~intrinsics_enabled ~source_format =
 
     | ALPHANUM_PREFIX { str; _ } :: _ -> missing_continuation_of str
 
-    | WORD_IN_AREA_A w as tok :: _    ->
-        if Cobol_preproc.Src_format.enforceable_area_a sf
-        then subst_n tok 1
-        else subst_n (WORD w) 1
-
     | tok :: _                        -> subst_n tok 1
 
 
@@ -373,10 +368,9 @@ let show tag { persist = { verbose; show_if_verbose; _ }; _ } =
 
 let distinguish_words: (Grammar_tokens.token with_loc as 't) -> 't = function
   | { payload = WORD w; loc } when loc_in_area_a loc ->
-      (* TODO: keep track of source format to filter this case out when Area A
-         checks are not enforceable. *)
       WORD_IN_AREA_A w &@ loc
-  | t -> t
+  | t ->
+      t
 
 
 let scan_exec_block

--- a/src/lsp/cobol_preproc/src_lexing.ml
+++ b/src/lsp/cobol_preproc/src_lexing.ml
@@ -119,7 +119,8 @@ let pos_column Lexing.{ pos_bol; pos_cnum; _ } =         (* count cols from 1 *)
 
 let raw_loc ~start_pos ~end_pos { newline; config = { source_format; _ }; _ } =
   let in_area_a =
-    newline && match Src_format.first_area_b_column source_format with
+    newline && Src_format.enforceable_area_a source_format &&
+    match Src_format.first_area_b_column source_format with
     | None -> false
     | Some c -> pos_column start_pos < c
   in

--- a/test/output-tests/gnucobol.ml
+++ b/test/output-tests/gnucobol.ml
@@ -167,7 +167,7 @@ let guess_source_format ~filename ~command =   (* hackish detection of format *)
     lazy (command_matchp free_flag_regexp),   Cobol_config.(SF SFFree);
     lazy (command_matchp fixd_format_regexp), Cobol_config.(SF SFFixed);
     lazy (command_matchp free_format_regexp), Cobol_config.(SF SFFree);
-    lazy (command_matchp cb85_format_regexp), Cobol_config.(SF SFFixed);
+    lazy (command_matchp cb85_format_regexp), Cobol_config.(SF SFCOBOL85);
     lazy (command_matchp vrbl_format_regexp), Cobol_config.(SF SFVariable);
     lazy (command_matchp xopn_format_regexp), Cobol_config.(SF SFXOpen);
     lazy (command_matchp xcrd_format_regexp), Cobol_config.(SF SFxCard);


### PR DESCRIPTION
After I remembered Area A information is attached to source locations:
- remove a useless comment;
- remove a useless token-rewriting.