### PR TITLE
Fix handling of queries about items given in `USING` phrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support for COMP-6 usage [#548](https://github.com/OCamlPro/superbol-studio-oss/pull/548)
 
 ### Fixed
+- Handling of queries about `LINKAGE` items given in `USING` phrases [#561](https://github.com/OCamlPro/superbol-studio-oss/pull/561)
 - Parsing of LSP CLI arguments, that notably prevented caching in global storage [#549](https://github.com/OCamlPro/superbol-studio-oss/pull/549) (fix for [Issue #547](https://github.com/OCamlPro/superbol-studio-oss/issues/547))
 - Size reported for numeric items with `SIGN SEPARATE` clause [#545](https://github.com/OCamlPro/superbol-studio-oss/pull/545) [#552](https://github.com/OCamlPro/superbol-studio-oss/pull/552) [#553](https://github.com/OCamlPro/superbol-studio-oss/pull/553)
 - Internal logic of the parser to limit the amount of text rescans [#544](https://github.com/OCamlPro/superbol-studio-oss/pull/544)

--- a/src/lsp/cobol_cfg/cfg_builder.ml
+++ b/src/lsp/cobol_cfg/cfg_builder.ml
@@ -191,7 +191,7 @@ let cfg_of ~(cu: cobol_unit) =
           build_node ~is_section ~cu p :: acc,
           false
         end (acc, true) section_paragraphs.list
-    end [] cu.unit_procedure.list
+    end [] cu.unit_procedure.procedure_blocks.list
   in
   List.rev nodes
   |> begin function (* adding entry point if not already present *)
@@ -225,7 +225,7 @@ let graph_material_of_doc ({ group; _ }: Cobol_typeck.Outputs.t) =
                 Cobol_ptree.pp_qualname' ~&sec.section_name
                 ((~&) cu.unit_name) in
             Some (name, `Section (cu, ~&sec))
-        end cu.unit_procedure.list in
+        end cu.unit_procedure.procedure_blocks.list in
       let cu_name = (~&)cu.unit_name in
       (cu_name, `Cu cu) :: section_graphs @ acc
     end group []

--- a/src/lsp/cobol_cfg/cfg_jumps.ml
+++ b/src/lsp/cobol_cfg/cfg_jumps.ml
@@ -19,7 +19,7 @@ type jumps =
   | Go of qualname
   | GoDepending of qualname
   | Perform of qualname
-  | Call of Cobol_ptree.call_prefix
+  | Call of Cobol_ptree.call_target
   | Entry of Cobol_ptree.entry_stmt
 
 module Jumps = Set.Make(struct
@@ -36,13 +36,13 @@ module Jumps = Set.Make(struct
       | Go qn1, Go qn2
       | GoDepending qn1, GoDepending qn2
       | Perform qn1, Perform qn2 -> Cobol_ptree.compare_qualname qn1 qn2
-      | Call cp1, Call cp2 -> Cobol_ptree.compare_call_prefix cp1 cp2
+      | Call cp1, Call cp2 -> Cobol_ptree.compare_call_target cp1 cp2
       | Entry en1 , Entry en2 -> Cobol_ptree.compare_entry_stmt en1 en2
       | _ -> to_int j2 - to_int j1
   end)
 
 let full_qn ~cu qn =
-  (Qualmap.find_binding qn cu.unit_procedure.named).full_qn
+  (Qualmap.find_binding qn cu.unit_procedure.procedure_blocks.named).full_qn
 
 let full_qn' ~cu qn = full_qn ~cu ~&qn
 
@@ -153,8 +153,8 @@ module JumpsCollector = struct
       let start = full_qn' ~cu payload.perform_target.procedure_start in
       skip { acc with jumps = Jumps.add (Perform start) acc.jumps }
 
-    method! fold_call' { payload = { call_prefix; _ }; _ } acc =
-      skip { acc with jumps = Jumps.add (Call call_prefix) acc.jumps }
+    method! fold_call' { payload = { call_target; _ }; _ } acc =
+      skip { acc with jumps = Jumps.add (Call call_target) acc.jumps }
 
     method! fold_entry' { payload; _ } acc =
       skip { acc with jumps = Jumps.add (Entry payload) acc.jumps }

--- a/src/lsp/cobol_common/diagnostics.ml
+++ b/src/lsp/cobol_common/diagnostics.ml
@@ -208,7 +208,7 @@ include Cont
 (* --- *)
 
 let result ?(diags = Set.none) result = { result; diags }
-(* let result_only { result; _ } = result *)
+let result_only { result; _ } = result
 let with_diag r d = result ~diags:(Set.one d) r
 (* let with_diags r diags = result ~diags r *)
 let with_more_diags ~diags { result; diags = diags' } =
@@ -226,6 +226,7 @@ let cons_option_result = function
   | { result = None; diags } -> with_more_diags ~diags
   | { result = Some r; diags } -> more_result ~f:(fun tl -> result ~diags @@ r :: tl)
 let forget_result { diags; _ } = diags
+let forget_diags = result_only
 (* let merge_results ~f r1 r2 = *)
 (*   result (f r1.result r2.result) ~diags:(Set.union r1.diags r2.diags) *)
 let show_n_forget ?(set_status = true) ?(min_level = Hint)
@@ -233,6 +234,7 @@ let show_n_forget ?(set_status = true) ?(min_level = Hint)
   Set.pp_above ~level:min_level ?platform ppf diags;
   if set_status && Set.has_errors diags then Exit_status.raise ();
   result
+let show_diags = show_n_forget
 let sink_result ?set_status ?platform ?ppf r =
   ignore @@ show_n_forget ?set_status ?platform ?ppf r
 

--- a/src/lsp/cobol_common/diagnostics.mli
+++ b/src/lsp/cobol_common/diagnostics.mli
@@ -105,7 +105,7 @@ include module type of Cont
 (* --- *)
 
 val result: ?diags:diagnostics -> 'a -> 'a with_diags
-(* val result_only: 'a with_diags -> 'a *)
+val result_only: 'a with_diags -> 'a
 (* val with_diag: 'a -> diagnostic -> 'a with_diags *)
 (* val with_diags: 'a -> diagnostics -> 'a with_diags *)
 val with_more_diags: diags:diagnostics -> 'a with_diags -> 'a with_diags
@@ -118,8 +118,14 @@ val map_some_result: f:('a -> 'b) -> 'a option with_diags -> 'b option with_diag
 val more_result: f:('a -> 'b with_diags) -> 'a with_diags -> 'b with_diags
 val cons_option_result: 'a option with_diags -> 'a list with_diags -> 'a list with_diags
 val forget_result: _ with_diags -> diagnostics
+val forget_diags: 'a with_diags -> 'a
 (* val merge_results: f:('a -> 'b -> 'c) -> 'a with_diags -> 'b with_diags -> 'c with_diags *)
 val show_n_forget
+  : ?set_status:bool
+  -> ?min_level:severity
+  -> ?platform:platform
+  -> ?ppf:Format.formatter -> 'a with_diags -> 'a
+val show_diags
   : ?set_status:bool
   -> ?min_level:severity
   -> ?platform:platform

--- a/src/lsp/cobol_common/srcloc.ml
+++ b/src/lsp/cobol_common/srcloc.ml
@@ -64,6 +64,9 @@ module TYPES = struct
   type 'a with_loc = { payload: 'a; loc: srcloc [@compare fun _ _ -> 0] }
   [@@ deriving ord]
 
+  let pp pe ppf e = pe ppf e.payload            (* ignore source localization *)
+  let pp_with_loc = pp
+  let show_with_loc pe l = Pretty.to_string "%a" (pp pe) l
 end
 include TYPES
 
@@ -684,8 +687,6 @@ let sub loc ~pos ~len =
 
 (** {2 Manipulating localized values} *)
 
-let pp pe ppf e = pe ppf e.payload              (* ignore source localization *)
-let pp_with_loc = pp
 let flagit payload loc = { payload; loc }
 let payload: 'a with_loc -> 'a = fun e -> e.payload
 let loc: 'a with_loc -> srcloc = fun e -> e.loc

--- a/src/lsp/cobol_common/srcloc.mli
+++ b/src/lsp/cobol_common/srcloc.mli
@@ -15,7 +15,7 @@ module TYPES: sig
   type lexloc = Lexing.position * Lexing.position
   type srcloc
   type copylocs
-  type 'a with_loc = { payload: 'a; loc: srcloc; }                [@@deriving ord]
+  type 'a with_loc = { payload: 'a; loc: srcloc; }          [@@deriving ord, show]
 end
 type lexloc = TYPES.lexloc
 type srcloc = TYPES.srcloc

--- a/src/lsp/cobol_data/data_item.ml
+++ b/src/lsp/cobol_data/data_item.ml
@@ -72,3 +72,24 @@ let def_qualname = function
       Some ~&(~&def.condition_name_qualname)
   | Table_index { qualname; _ } ->
       Some ~&qualname
+
+let def_record: data_definition -> record = function
+  | Data_field { record; _}
+  | Data_renaming { record; _}
+  | Data_condition { record; _}
+  | Table_index { record; _ } -> record
+
+let def_storage: data_definition -> data_storage = fun def ->
+  (def_record def).record_storage
+
+let def_size: data_definition -> Data_memory.size = function
+  | Data_field { def; _} -> ~&def.field_size
+  | Data_renaming { def; _} -> ~&def.renaming_size
+  | Data_condition { field; _} -> ~&field.field_size
+  | Table_index { table; _ } -> ~&table.table_size
+
+let def_offset: data_definition -> Data_memory.offset = function
+  | Data_field { def; _} -> ~&def.field_offset
+  | Data_renaming { def; _} -> ~&def.renaming_offset
+  | Data_condition { field; _} -> ~&field.field_offset
+  | Table_index { table; _ } -> ~&table.table_offset

--- a/src/lsp/cobol_data/data_printer.ml
+++ b/src/lsp/cobol_data/data_printer.ml
@@ -23,9 +23,15 @@ let pp_int' = Cobol_ptree.pp_with_loc Fmt.int
 let pp_int'_opt = Fmt.option pp_int'
 let pp_qualname'_opt = Fmt.option Cobol_ptree.pp_qualname'
 let pp_qualname'_list = Fmt.(hbox (list ~sep:comma Cobol_ptree.pp_qualname'))
-  (* Pretty.list ~fopen:"@[<h>" ~fsep:",@;" ~fclose:"@]" Cobol_ptree.pp_qualname' *)
+(* Pretty.list ~fopen:"@[<h>" ~fsep:",@;" ~fclose:"@]" Cobol_ptree.pp_qualname' *)
 let pp_literal'_opt = Fmt.option Cobol_ptree.pp_literal'
 let pp_literal'_list = Fmt.list Cobol_ptree.pp_literal'
+
+let pp_data_storage ppf = function
+  | File n -> Fmt.pf ppf "FILE@ %a" Cobol_ptree.pp_name' n
+  | Local_storage -> Fmt.string ppf "LOCAL-STORAGE"
+  | Working_storage -> Fmt.string ppf "WORKING-STORAGE"
+  | Linkage -> Fmt.string ppf "LINKAGE"
 
 (* usage *)
 
@@ -288,11 +294,11 @@ let pp_data_definition ppf = function
         I'(~&field.field_qualname <> None,
            Fmt.field "field" (fun () -> ~&field.field_qualname) pp_qualname'_opt,
            Fmt.field "field-offset" (fun () -> ~&field.field_offset) pp_offset);
-  T (Pretty.vfield "def" (fun () -> def) pp_condition_name');
+        T (Pretty.vfield "def" (fun () -> def) pp_condition_name');
       ] ppf ()
   | Table_index { table; record = { record_name; _ }; _ } ->
       Pretty.record_with_conditional_fields [
         T Fmt.(styled `Yellow @@ any "table index");
         T (Fmt.field "record" (fun () -> record_name) Fmt.string);
-  T (Pretty.vfield "table" (fun () -> table) pp_table_definition');
+        T (Pretty.vfield "table" (fun () -> table) pp_table_definition');
       ] ppf ()

--- a/src/lsp/cobol_data/data_types.ml
+++ b/src/lsp/cobol_data/data_types.ml
@@ -61,12 +61,6 @@ type data_storage =
   | Working_storage
   | Linkage                                                          (* file? *)
 
-let pp_data_storage ppf = function
-  | File n -> Fmt.pf ppf "FILE@ %a" Cobol_ptree.pp_name' n
-  | Local_storage -> Fmt.string ppf "LOCAL-STORAGE"
-  | Working_storage -> Fmt.string ppf "WORKING-STORAGE"
-  | Linkage -> Fmt.string ppf "LINKAGE"
-
 type length_variability =
   | Fixed_length
   | Variable_length

--- a/src/lsp/cobol_lsp/lsp_completion.ml
+++ b/src/lsp/cobol_lsp/lsp_completion.ml
@@ -168,7 +168,7 @@ let procedures_proposal ~filename pos group =
         List.map (fun s -> typ, s) @@ to_string qn
       | _ -> []
     in
-    cu.unit_procedure.list
+    cu.unit_procedure.procedure_blocks.list
     |> List.rev_map begin function
       | Cobol_unit.Types.Paragraph p ->
         to_string_with_type "Paragraph" p

--- a/src/lsp/cobol_lsp/lsp_lookup.ml
+++ b/src/lsp/cobol_lsp/lsp_lookup.ml
@@ -197,6 +197,10 @@ let element_at_position ~uri pos group : element_at_position =
       | Procedure _ ->            (* for now, no more info, data-name expected *)
           on_data_name qn acc
 
+    method! fold_resolved_name { resolved_name; _ } acc =
+      let qn = qualname_at_pos ~filename (Name resolved_name) pos in
+      Visitor.skip_children @@ on_data_name qn acc
+
     method! fold_procedure_name qn acc =
       Visitor.skip_children @@
       on_proc_name (qualname_at_pos ~filename qn pos) acc
@@ -230,16 +234,6 @@ let element_at_position ~uri pos group : element_at_position =
   end group init |> result
 
 (* --- *)
-
-(* Using Lsp_position.sieve would be overkill for nodes that are close to the AST root, like COBOL units *)
-let cobol_unit_at_pos ~filename pos group =
-  Cobol_unit.Visitor.fold_unit_group object
-    inherit [_] Cobol_unit.Visitor.folder
-    method! fold_cobol_unit' cu acc =
-      if Lsp_position.is_in_srcloc ~filename pos ~@cu
-      then Visitor.skip_children @@ Some ~&cu
-      else Visitor.skip_children acc
-  end group None
 
 let last_cobol_unit_before_pos ~filename pos group =
   Cobol_unit.Visitor.fold_unit_group object
@@ -353,7 +347,7 @@ let type_at_pos ~filename (pos: Lsp.Types.Position.t) group : approx_typing_info
         |> Pointer @>@ fold_ident'_opt v al.allocate_returning
         |> skip
 
-      method! fold_call_prefix p acc =
+      method! fold_call_target p acc =
         begin match p with
           | CallGeneral i ->
             acc
@@ -545,7 +539,7 @@ let proc_at_pos ~filename (pos: Lsp.Types.Position.t) group : procedure_at_posit
       let proc_name = match cu, paragraph_name with
         | Some cu, Some qn ->
           Some (Cobol_unit.Qualmap.find_binding
-                  ~&qn cu.unit_procedure.named).full_qn
+                  ~&qn cu.unit_procedure.procedure_blocks.named).full_qn
         | _ -> None
       in
       skip { cu; proc_name }

--- a/src/lsp/cobol_lsp/lsp_semtoks.ml
+++ b/src/lsp/cobol_lsp/lsp_semtoks.ml
@@ -274,19 +274,18 @@ let semtoks_from_ptree ~filename ?range ptree =
       |> Visitor.skip_children
 
     (* procedure using *)
-    method! fold_by_reference { by_reference;
-                                by_reference_optional } acc = acc
-      |> add_name' by_reference Parameter
+    method! fold_procedure_by_reference_arg { by_reference_arg_name;
+                                              by_reference_arg_optional } acc =
+      acc
+      |> add_name' by_reference_arg_name Parameter
       (*|> Visitor.do_children*)
-      |> fold_bool self by_reference_optional
+      |> fold_bool self by_reference_arg_optional
       |> Visitor.skip_children
 
-    method! fold_procedure_by_clause = function
-      | ByReference _ ->
-          Visitor.do_children
-      | ByValue l -> fun x -> x
-        |> add_list add_name' l Parameter
-        |> Visitor.skip_children
+    method! fold_procedure_by_value_arg { by_value_arg_name } acc =
+      acc
+      |> add_name' by_value_arg_name Parameter
+      |> Visitor.skip_children
 
     (* inline call of function *)
     method! fold_inline_call c x = match c with
@@ -336,11 +335,11 @@ let semtoks_from_ptree ~filename ?range ptree =
       |> add_option add_ident' allocate_returning VarModif
       |> Visitor.skip_children
 
-    method! fold_call' {payload = { call_static; call_prefix;
+    method! fold_call' {payload = { call_static; call_target;
                                     call_using; call_returning;
                                     call_error_handler }; _} acc = acc
       |> fold_bool self call_static
-      |> fold_call_prefix self call_prefix
+      |> fold_call_target self call_target
       |> fold_list ~fold:fold_call_using_clause' self call_using
       |> add_option add_ident' call_returning VarModif
       |> fold_option ~fold:fold_call_error_handler self call_error_handler

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -273,7 +273,7 @@ let compilation_group :=
             | None -> ul
             | Some pd -> ul @ [((Program ~&pd): compilation_unit) &@<- pd] } }
 
-let simple_program := 
+let simple_program :=
   | opo = ro(loc(options_paragraph));
     edo = ro(loc(environment_division));
     ddo = ro(loc(non_empty_data_division));
@@ -2083,12 +2083,12 @@ let procedure_division_header [@post.procedure_division_header] :=
 
 let procedure_division [@post.procedure_division] :=
  | procedure_division_header;
-   procedure_args = ro(procedure_args);
+   procedure_using_phrase = ro(loc(procedure_using_clause));
    ro = ro(returning_ident);                                            (* +COB2002 *)
    rl = ilo(raising_phrase); ".";                                 (* +COB2002 *)
    dl = lo(declaratives);
    sl = rl(loc(section_paragraph));
-   { { procedure_args;
+   { { procedure_using_phrase;
        procedure_returning = ro;
        procedure_raising_phrases = rl;
        procedure_declaratives = dl;
@@ -2096,21 +2096,21 @@ let procedure_division [@post.procedure_division] :=
 
 let program_procedure_division [@post.procedure_division] :=
  | procedure_division_header;
-   procedure_args = ro(procedure_args);
+   procedure_using_phrase = ro(loc(procedure_using_clause));
    ro = ro(returning_ident);                                            (* +COB2002 *)
    rl = ilo(raising_phrase); ".";                                 (* +COB2002 *)
    dl = lo(declaratives);
    sl = section_paragraphs;
-   { { procedure_args;
+   { { procedure_using_phrase;
        procedure_returning = ro;
        procedure_raising_phrases = rl;
        procedure_declaratives = dl;
        procedure_paragraphs = sl } }
 
-let procedure_args :=
+let procedure_using_clause :=
  | style = loc(procedure_calling_style); args = rnel(loc(procedure_by_clause));
   { { procedure_calling_style = style;
-      procedure_by_clause = args} }
+      procedure_args = args} }
 
 let procedure_calling_style ==
  | USING; { ProcedureArgsUsed }
@@ -2122,10 +2122,11 @@ let object_procedure_division [@post.method_definitions] := (* +COB2002 *)
 (* COB85: only USING ident+ (in the IPC module, P541) *)
 let procedure_by_clause :=
  | io(BY?; REFERENCE);
-   ~ = nell(o = ibo(OPTIONAL); n = name; { { by_reference_optional = o;
-                                             by_reference = n } });
-   %prec lowest                             <ByReference>
- | BY?; VALUE; ~ = nell(name); %prec lowest <ByValue>
+   ~ = nell(o = ibo(OPTIONAL); n = name; { { by_reference_arg_optional = o;
+                                             by_reference_arg_name = n } });
+   %prec lowest <ByReference>
+ | BY?; VALUE; ~ = nell(n = name; { { by_value_arg_name = n } });
+   %prec lowest <ByValue>
 
 (* Ambiguous, only class name may have factory *)
 let raising_phrase :=
@@ -2979,12 +2980,12 @@ COB2002:
 *)
 
 let using_by :=
- | b = call_using_by?; e = arithmetic_term;
+ | b = call_using_by?; e = loc(arithmetic_term);
+   { { call_using_by = b;                       (* COB85: ident, COB2002: exp *)
+       call_using_expr = Cobol_common.Srcloc.map_payload Option.some e } }
+ | b = call_using_by?; omitted = loc(OMITTED);
    { { call_using_by = b;
-       call_using_expr = Some e } }             (* COB85: ident, COB2002: exp *)
- | b = call_using_by?; OMITTED;
-   { { call_using_by = b;
-       call_using_expr = None } }                                 (* +COB2002 *)
+       call_using_expr = None &@<- omitted } }                    (* +COB2002 *)
 
 let call_using_by [@recovery CallUsingByReference] :=
  | BY?; REFERENCE; {CallUsingByReference}
@@ -3238,17 +3239,17 @@ let alter_statement :=
 
 %public let unconditional_action := ~ = call_statement; < >
 let call_statement [@context call_stmt] :=
-  | CALL; so = bo(STATIC); cp = call_prefix;
+  | CALL; so = bo(STATIC); cp = call_target;
     ul = lo(pf(USING,rnel(loc(using_by))));
     ro = ro(returning_or_giving); oeho = io(overflow_or_exception_handler);
     oterm_(END_CALL);
     { Call { call_static = so; (* STATIC is GnuCOBOL extension *)
-             call_prefix = cp;
+             call_target = cp;
              call_using = ul;
              call_returning = ro;
              call_error_handler = oeho } }
 
-let call_prefix :=
+let call_target :=
   | i = ident_or_string; <CallGeneral>
   | ian = ident_or_string; AS; in_ = ident_or_nested;
     { CallProto { called = Some ian; prototype = in_ } }

--- a/src/lsp/cobol_ptree/branching_statements.ml
+++ b/src/lsp/cobol_ptree/branching_statements.ml
@@ -426,13 +426,13 @@ CALL (id/lit AS)? NESTED/id USING...? RETURNING...? (program-prototype)
 and call_stmt =
   {
     call_static: bool;                                            (* GnuCOBOL *)
-    call_prefix: call_prefix;
+    call_target: call_target;
     call_using: call_using_clause with_loc list;
     call_returning: ident with_loc option;
     call_error_handler: call_error_handler option;
   }
 
-and call_prefix =
+and call_target =
   | CallGeneral of ident_or_strlit
   | CallProto of
       {
@@ -564,11 +564,12 @@ let pp_call_proto ppf = function
   | CallProtoIdent i -> pp_ident ppf i
   | CallProtoNested -> Fmt.pf ppf "NESTED"
 
-let pp_call_prefix ppf = function
-  | CallGeneral i -> pp_ident_or_strlit ppf i
+let pp_call_target ppf = function
+  | CallGeneral i ->
+      pp_ident_or_strlit ppf i
   | CallProto { called; prototype } ->
-    Fmt.(option (pp_ident_or_strlit ++ any "@ AS@ ")) ppf called;
-    pp_call_proto ppf prototype
+      Fmt.(option (pp_ident_or_strlit ++ any "@ AS@ ")) ppf called;
+      pp_call_proto ppf prototype
 
 let pp_dual_handler pp ?close ?(on = Fmt.any "ON EXCEPTION") ?off ppf
   { dual_handler_pos = p; dual_handler_neg = n }
@@ -851,7 +852,7 @@ and pp_basic_arithmetic_stmt ~sep op ppf
 
 and pp_call_stmt ppf
   { call_static = cs
-  ; call_prefix = cp
+  ; call_target = ct
   ; call_using = cu
   ; call_returning = returning
   ; call_error_handler = cho }
@@ -867,7 +868,7 @@ and pp_call_stmt ppf
   in
   Fmt.pf ppf "@[CALL %s"
     (if cs then "STATIC " else "");
-  pp_call_prefix ppf cp;
+  pp_call_target ppf ct;
   if cu != [] then
     Fmt.pf ppf "@ USING@ %a"
       Fmt.(list ~sep:sp (pp_with_loc pp_call_using_clause)) cu;

--- a/src/lsp/cobol_ptree/common.ml
+++ b/src/lsp/cobol_ptree/common.ml
@@ -83,4 +83,3 @@ let iter_trio trio tuple (fa, fb, fc) =
 let iter_quartet quartet tuple (fa, fb, fc, fd) =
   fold_quartet quartet tuple
     (unit_acc fa, unit_acc fb, unit_acc fc, unit_acc fd) ()
-

--- a/src/lsp/cobol_ptree/operands.ml
+++ b/src/lsp/cobol_ptree/operands.ml
@@ -87,8 +87,7 @@ let pp_position ppf = function
 type call_using_clause =
   {
     call_using_by: call_using_by option;
-    call_using_expr: expression option;(* [@compare
-    fun a b -> Option.compare compare_expression a b] *)                (** OMITTED if [None] *)
+    call_using_expr: expression option with_loc;        (** OMITTED if [None] *)
   }
 [@@deriving ord]
 
@@ -105,7 +104,7 @@ let pp_call_using_by ppf = function
 
 let pp_call_using_clause ppf { call_using_by = cub; call_using_expr = cue } =
   Fmt.(option (pp_call_using_by ++ sp)) ppf cub;
-  Fmt.(option ~none:(const string "OMITTED") pp_expression) ppf cue
+  Fmt.(pp_with_loc @@ option ~none:(any "OMITTED") pp_expression) ppf cue
 
 
 (* DELETE, OPEN, REWRITE, WRITE, READ (through on_lock_or_retry) *)

--- a/src/lsp/cobol_ptree/operands_visitor.ml
+++ b/src/lsp/cobol_ptree/operands_visitor.ml
@@ -107,7 +107,7 @@ let fold_call_using_clause (v: _ #folder) =
   handle v#fold_call_using_clause
     ~continue:begin fun { call_using_by; call_using_expr } x -> x
       >> fold_option ~fold:fold_call_using_by v call_using_by
-      >> fold_option ~fold:fold_expr v call_using_expr
+      >> fold' ~fold:(fold_option ~fold:fold_expr) v call_using_expr
     end
 
 let fold_call_using_clause' (v: _ #folder) =

--- a/src/lsp/cobol_ptree/proc_division.ml
+++ b/src/lsp/cobol_ptree/proc_division.ml
@@ -19,31 +19,36 @@ open Statements
 
 type procedure_division =
   {
-    procedure_args: procedure_args option;
+    procedure_using_phrase: procedure_using_phrase with_loc option;
     procedure_returning: ident with_loc option;
     procedure_raising_phrases: raising_phrase with_loc list;
     procedure_declaratives: declarative with_loc list;
     procedure_paragraphs: paragraph with_loc list;
   }
 
-and procedure_by_clause =
-  | ByReference of by_reference list
-  | ByValue of name with_loc list
+and procedure_using_phrase =
+  {
+    procedure_calling_style: procedure_calling_style with_loc;
+    procedure_args: procedure_args with_loc list;
+  }
 
 and procedure_calling_style =
   | ProcedureArgsUsed
   | ProcedureArgsChained
 
 and procedure_args =
+  | ByReference of procedure_by_reference_arg list
+  | ByValue of procedure_by_value_arg list
+
+and procedure_by_reference_arg =
   {
-    procedure_calling_style: procedure_calling_style with_loc;
-    procedure_by_clause: procedure_by_clause with_loc list
+    by_reference_arg_name: name with_loc;
+    by_reference_arg_optional: bool;
   }
 
-and by_reference =
+and procedure_by_value_arg =
   {
-    by_reference: name with_loc;
-    by_reference_optional: bool;
+    by_value_arg_name: name with_loc;
   }
 
 and raising_phrase =
@@ -169,38 +174,41 @@ let pp_declaratives ppf = function
       Fmt.pf ppf "DECLARATIVES.%a@ END DECLARATIVES."
         Fmt.(list ~sep:nop (sp ++ pp_with_loc pp_declarative)) pd
 
-let pp_by_reference ppf { by_reference = n;
-                          by_reference_optional = o } =
-  if o then Fmt.pf ppf "OPTIONAL ";
-  pp_name' ppf n
-
 let pp_procedure_calling_style ppf = function
   | ProcedureArgsUsed -> Fmt.pf ppf "USING"
   | ProcedureArgsChained -> Fmt.pf ppf "CHAINING"
 
-let pp_procedure_by_clause ppf = function
-  | ByReference ubrs ->
-      Fmt.(list ~sep:sp pp_by_reference) ppf ubrs
-  | ByValue ns ->
-      Fmt.pf ppf "BY VALUE %a" Fmt.(list ~sep:sp pp_name') ns
+let pp_procedure_arg_reference ppf { by_reference_arg_name = n;
+                                     by_reference_arg_optional = o } =
+  if o then Fmt.pf ppf "OPTIONAL ";
+  pp_name' ppf n
 
-let pp_procedure_args ppf
-  {procedure_calling_style=style; procedure_by_clause=args} =
+let pp_procedure_arg_value ppf { by_value_arg_name = n } =
+  pp_name' ppf n
+
+let pp_procedure_args ppf = function
+  | ByReference ubrs ->
+      Fmt.(list ~sep:sp pp_procedure_arg_reference) ppf ubrs
+  | ByValue ns ->
+      Fmt.pf ppf "BY VALUE %a" Fmt.(list ~sep:sp pp_procedure_arg_value) ns
+
+let pp_procedure_args ppf {procedure_calling_style = style;
+                           procedure_args = args} =
   Fmt.pf ppf "%a%a"
     Fmt.(sp ++ pp_with_loc pp_procedure_calling_style) style
-    Fmt.(list ~sep:nop (sp ++ pp_with_loc pp_procedure_by_clause)) args
+    Fmt.(list ~sep:nop (sp ++ pp_with_loc pp_procedure_args)) args
 
 let pp_raising_phrase ppf { raising; raising_factory } =
   if raising_factory then Fmt.pf ppf "FACTORY ";
   pp_name' ppf raising
 
-let pp_procedure_division ppf { procedure_args = pargs;
+let pp_procedure_division ppf { procedure_using_phrase = pargs;
                                 procedure_returning = pur;
                                 procedure_raising_phrases = prp;
                                 procedure_declaratives = pd;
                                 procedure_paragraphs = pp } =
   Fmt.pf ppf "PROCEDURE DIVISION%a%a%a.%a@;<1 2>@[<hv>%a@]"
-    Fmt.(option pp_procedure_args) pargs
+    Fmt.(option (pp_with_loc pp_procedure_args)) pargs
     Fmt.(option (any "@ RETURNING " ++ pp_with_loc pp_ident)) pur
     Fmt.(if prp == [] then nop
          else any "RAISING " ++

--- a/src/lsp/cobol_ptree/proc_division_visitor.ml
+++ b/src/lsp/cobol_ptree/proc_division_visitor.ml
@@ -30,16 +30,18 @@ class virtual ['a] folder = object
   method fold_declarative'                : (declarative with_loc             , 'a) fold = default
   method fold_paragraph                   : (paragraph                        , 'a) fold = default
   method fold_paragraph'                  : (paragraph with_loc               , 'a) fold = default
-  method fold_procedure_by_clause         : (procedure_by_clause              , 'a) fold = default
-  method fold_procedure_by_clause'        : (procedure_by_clause with_loc     , 'a) fold = default
-  method fold_by_reference                : (by_reference                     , 'a) fold = default
+  method fold_procedure_args              : (procedure_args                   , 'a) fold = default
+  method fold_procedure_args'             : (procedure_args with_loc          , 'a) fold = default
+  method fold_procedure_by_reference_arg  : (procedure_by_reference_arg       , 'a) fold = default
+  method fold_procedure_by_value_arg      : (procedure_by_value_arg           , 'a) fold = default
   method fold_declarative_use             : (declarative_use                  , 'a) fold = default
   method fold_use_after_exception         : (use_after_exception              , 'a) fold = default
   method fold_use_for_debugging_target    : (use_for_debugging_target         , 'a) fold = default
   method fold_raising_phrase              : (raising_phrase                   , 'a) fold = default
   method fold_raising_phrase'             : (raising_phrase with_loc          , 'a) fold = default
   method fold_procedure_calling_style     : (procedure_calling_style          , 'a) fold = default
-  method fold_procedure_args              : (procedure_args                   , 'a) fold = default
+  method fold_procedure_using_phrase      : (procedure_using_phrase           , 'a) fold = default
+  method fold_procedure_using_phrase'     : (procedure_using_phrase with_loc  , 'a) fold = default
 end
 
 let fold_use_exception_on (v: _ #folder) = function
@@ -106,23 +108,29 @@ let fold_paragraph (v: _ #folder) =
 let fold_paragraph' (v: _ #folder) =
   handle' v#fold_paragraph' ~fold:fold_paragraph v
 
-let fold_by_reference (v: _ #folder) =
-  handle v#fold_by_reference
-    ~continue:begin fun { by_reference;
-                          by_reference_optional } x -> x
-      >> fold_name' v by_reference
-      >> fold_bool v by_reference_optional
+let fold_procedure_by_reference_arg (v: _ #folder) =
+  handle v#fold_procedure_by_reference_arg
+    ~continue:begin fun { by_reference_arg_name;
+                          by_reference_arg_optional } x -> x
+      >> fold_name' v by_reference_arg_name
+      >> fold_bool v by_reference_arg_optional
     end
 
-let fold_procedure_by_clause (v: _ #folder) =
-  handle v#fold_procedure_by_clause
+let fold_procedure_by_value_arg (v: _ #folder) =
+  handle v#fold_procedure_by_value_arg
+    ~continue:begin fun { by_value_arg_name } x -> x
+      >> fold_name' v by_value_arg_name
+    end
+
+let fold_procedure_args (v: _ #folder) =
+  handle v#fold_procedure_args
     ~continue:begin function
-      | ByReference l -> fold_list ~fold:fold_by_reference v l
-      | ByValue l -> fold_name'_list v l
+      | ByReference l -> fold_list ~fold:fold_procedure_by_reference_arg v l
+      | ByValue l -> fold_list ~fold:fold_procedure_by_value_arg v l
     end
 
-let fold_procedure_by_clause' (v: _ #folder) =
-  handle' v#fold_procedure_by_clause' ~fold:fold_procedure_by_clause v
+let fold_procedure_args' (v: _ #folder) =
+  handle' v#fold_procedure_args' ~fold:fold_procedure_args v
 
 let fold_raising_phrase (v: _ #folder) =
   handle v#fold_raising_phrase
@@ -137,20 +145,23 @@ let fold_raising_phrase' (v: _ #folder) =
 let fold_procedure_calling_style (v: _ #folder) =
   leaf v#fold_procedure_calling_style
 
-let fold_procedure_args (v: _ #folder) =
-  handle v#fold_procedure_args
+let fold_procedure_using_phrase (v: _ #folder) =
+  handle v#fold_procedure_using_phrase
     ~continue:begin fun { procedure_calling_style = style;
-                          procedure_by_clause = args } x -> x 
+                          procedure_args = args } x -> x
       >> fold' ~fold:fold_procedure_calling_style v style
-      >> fold_list ~fold:fold_procedure_by_clause' v args
+      >> fold_list ~fold:fold_procedure_args' v args
     end
+
+let fold_procedure_using_phrase' (v: _ #folder) =
+  handle' v#fold_procedure_using_phrase' ~fold:fold_procedure_using_phrase v
 
 let fold_procedure_division (v: _ #folder) =
   handle v#fold_procedure_division
-    ~continue:begin fun { procedure_args; procedure_returning;
+    ~continue:begin fun { procedure_using_phrase; procedure_returning;
                           procedure_raising_phrases; procedure_declaratives;
                           procedure_paragraphs } x -> x
-      >> fold_option ~fold:fold_procedure_args v procedure_args
+      >> fold_option ~fold:fold_procedure_using_phrase' v procedure_using_phrase
       >> fold_ident'_opt v procedure_returning
       >> fold_list ~fold:fold_raising_phrase' v procedure_raising_phrases
       >> fold_list ~fold:fold_declarative' v procedure_declaratives

--- a/src/lsp/cobol_ptree/statements_visitor.ml
+++ b/src/lsp/cobol_ptree/statements_visitor.ml
@@ -37,7 +37,7 @@ class virtual ['a] folder = object
   method fold_accept_with_clause' : (accept_with_clause with_loc, 'a) fold = default
   method fold_allocate_kind       : (allocate_kind           , 'a) fold = default
   method fold_alter_operands'     : (alter_operands with_loc , 'a) fold = default
-  method fold_call_prefix         : (call_prefix             , 'a) fold = default
+  method fold_call_target         : (call_target             , 'a) fold = default
   method fold_call_proto          : (call_proto              , 'a) fold = default
   method fold_close_format        : (close_format            , 'a) fold = default
   method fold_close_phrase        : (close_phrase            , 'a) fold = default
@@ -199,8 +199,8 @@ let fold_call_proto (v: _ #folder) =
       | CallProtoNested -> Fun.id
     end
 
-let fold_call_prefix (v: _ #folder) =
-  handle v#fold_call_prefix
+let fold_call_target (v: _ #folder) =
+  handle v#fold_call_target
     ~continue:begin fun p x -> match p with
       | CallGeneral i -> x
           >> fold_ident_or_strlit v i
@@ -900,10 +900,10 @@ and fold_add' (v: _ #folder) : basic_arithmetic_stmt with_loc -> 'a -> 'a =
 
 and fold_call' (v: _ #folder) : call_stmt with_loc -> 'a -> 'a =
   handle' v#fold_call' v
-    ~fold:begin fun v { call_static; call_prefix; call_using;
+    ~fold:begin fun v { call_static; call_target; call_using;
                         call_returning; call_error_handler } x -> x
       >> fold_bool v call_static
-      >> fold_call_prefix v call_prefix
+      >> fold_call_target v call_target
       >> fold_list ~fold:fold_call_using_clause' v call_using
       >> fold_ident'_opt v call_returning
       >> fold_option ~fold:fold_call_error_handler v call_error_handler

--- a/src/lsp/cobol_typeck/cobol_typeck.ml
+++ b/src/lsp/cobol_typeck/cobol_typeck.ml
@@ -23,3 +23,6 @@ module Outputs = Typeck_outputs
 module Diagnostics = Typeck_diagnostics
 module Results = Typeck_results
 include Typeck_engine
+
+(* Additional: *)
+module References = Typeck_references

--- a/src/lsp/cobol_typeck/cobol_typeck.mli
+++ b/src/lsp/cobol_typeck/cobol_typeck.mli
@@ -27,3 +27,5 @@ module Outputs = Typeck_outputs
 module Diagnostics = Typeck_diagnostics
 module Results = Typeck_results
 include module type of Typeck_engine
+
+module References = Typeck_references

--- a/src/lsp/cobol_typeck/typeck_config.ml
+++ b/src/lsp/cobol_typeck/typeck_config.ml
@@ -16,7 +16,6 @@ open Cobol_common.Srcloc.INFIX
 
 module Visitor = Cobol_common.Visitor
 module CharSet = Cobol_common.Basics.CharSet
-module DIAGS = Cobol_common.Diagnostics
 
 type output = Cobol_unit.Types.unit_config
 

--- a/src/lsp/cobol_typeck/typeck_config_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_config_diagnostics.ml
@@ -14,8 +14,6 @@
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-module DIAGS = Cobol_common.Diagnostics
-
 type error =
   | Invalid_picture_symbol of string with_loc
 

--- a/src/lsp/cobol_typeck/typeck_data_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_data_diagnostics.ml
@@ -14,7 +14,6 @@
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-module DIAGS = Cobol_common.Diagnostics
 module NEL = Cobol_data.Types.NEL
 
 type entry =
@@ -223,7 +222,7 @@ let pp_error ppf = function
                               or@ numeric-edited")
   | Item_not_allowed_in_section { level; section } ->
       Pretty.print ppf "%d-level@ item@ not@ allowed@ in@ %a@ section" ~&level
-        Cobol_data.Types.pp_data_storage section
+        Cobol_data.Printer.pp_data_storage section
   | Invalid_level_number { level } ->
       Pretty.print ppf "Invalid@ level@ number:@ %02d" ~&level
   | Unexpected_level_number { level; expected } ->

--- a/src/lsp/cobol_typeck/typeck_engine.ml
+++ b/src/lsp/cobol_typeck/typeck_engine.ml
@@ -13,15 +13,12 @@
 
 (** Type-checking and validation of COBOL compilation groups *)
 
-module DIAGS = Cobol_common.Diagnostics
-
-let compilation_group
-    (type m) : ?config: _ ->
-  fold_exec_block': Typeck_outputs.fold_exec_block' ->
-  m Cobol_parser.Outputs.parsed_compilation_group -> _
-  = fun ?(config = Cobol_config.default) ~fold_exec_block' ->
-    function
-    | Only None | WithArtifacts (None, _) ->
+let compilation_group (type m) : ?config: _
+  -> fold_exec_block': Typeck_outputs.exec_block_folder
+  -> m Cobol_parser.Outputs.parsed_compilation_group
+  -> _ = fun ?(config = Cobol_config.default) ~fold_exec_block' ->
+  function
+  | Only None | WithArtifacts (None, _) ->
       Typeck_results.simple_result Typeck_outputs.none
-    | Only Some cg | WithArtifacts (Some cg, _) ->
+  | Only Some cg | WithArtifacts (Some cg, _) ->
       Typeck_units.of_compilation_group config ~fold_exec_block' cg

--- a/src/lsp/cobol_typeck/typeck_engine.mli
+++ b/src/lsp/cobol_typeck/typeck_engine.mli
@@ -13,6 +13,6 @@
 
 val compilation_group
   : ?config: Cobol_config.t
-  -> fold_exec_block':Typeck_outputs.fold_exec_block'
+  -> fold_exec_block':Typeck_outputs.exec_block_folder
   -> _ Cobol_parser.Outputs.parsed_compilation_group
   -> Typeck_outputs.t Typeck_results.with_diags

--- a/src/lsp/cobol_typeck/typeck_outputs.ml
+++ b/src/lsp/cobol_typeck/typeck_outputs.ml
@@ -13,6 +13,7 @@
 
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
+open Cobol_common.Exec_block.TYPES
 module LIST = Cobol_common.Basics.LIST
 
 type qualrefmap = srcloc list Cobol_unit.Qual.MAP.t
@@ -43,9 +44,9 @@ type outputs =
   }
 type t = outputs
 
-
-(* An accumulator for fold_exec_block', used to collect references in
-   EXEC blocks *)
+(* TODO: move those types to a new `Typeck_external/plugins/extensions' module *)
+(* An accumulator for {!exec_block_folder}, used to collect references in EXEC
+   blocks *)
 type references_acc =
   {
     current_section: Cobol_unit.Types.procedure_section option;
@@ -53,13 +54,11 @@ type references_acc =
     diags: Typeck_diagnostics.t;
   }
 
-type fold_exec_block' =
-  register_name:(string
-                   Cobol_common.Srcloc.TYPES.with_loc ->
-                 references_acc -> references_acc) ->
-  Cobol_common.Exec_block.TYPES.exec_block
-    Cobol_common.Srcloc.TYPES.with_loc ->
-  references_acc -> references_acc
+type exec_block_folder
+  = data_definitions: Cobol_unit.Types.data_definitions
+  -> exec_block with_loc
+  -> references_acc
+  -> references_acc
 
 (* --- *)
 

--- a/src/lsp/cobol_typeck/typeck_procedure.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure.ml
@@ -11,6 +11,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Typeck_outputs                                     (* for references_acc *)
+open Typeck_procedure_diagnostics
 open Cobol_unit.Types
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
@@ -24,7 +26,70 @@ type output =
     references: Typeck_outputs.references_in_unit;
   }
 
-let procedure_of_compilation_unit cu' =
+let baseloc_of_qualname: Cobol_ptree.qualname -> srcloc = function
+  | Name name
+  | Qual (name, _) -> ~@name
+
+let error acc err =
+  { acc with diags = Proc_error err :: acc.diags }
+
+let resolve_procedure_args ~data_definitions ~refs pa =
+  let open struct
+    type procedure_args_accumulator =
+      {
+        rev_args: procedure_arg with_loc list;
+        refs: references_acc;
+      }
+  end in
+
+  let error acc err = { acc with refs = error acc.refs err } in
+
+  let resolve_arg_name_ref ~arg_name ~arg_passing_style acc =
+    let register_linkage_record ~arg_data_definition acc =
+      match Cobol_data.Item.def_storage arg_data_definition.resolved with
+      | Linkage ->
+          { acc with
+            rev_args = ({ arg_data_definition;
+                          arg_passing_style } &@<- arg_name) :: acc.rev_args }
+      | actual_storage ->
+          error acc @@ Invalid_proc_arg_storage { arg_name; actual_storage }
+    in
+    match
+      (* CHECKME: may need to only lookup among records (maybe also only in
+         LINKAGE), not among every data def. *)
+      let arg_data_definition, refs =
+        Typeck_references.resolve_record_name arg_name acc.refs
+          ~data_definitions
+      in
+      { acc with refs }, arg_data_definition
+    with
+    | acc, Error () ->
+        acc                                                   (* skip arg def *)
+    | acc, Ok arg_data_definition ->
+        register_linkage_record ~arg_data_definition acc
+    | exception Not_found ->
+        error acc @@ Procedure_arg_record_not_found { arg_name }
+  in
+
+  Cobol_ptree.Visitor.fold_procedure_using_phrase object
+    inherit [procedure_args_accumulator] Cobol_ptree.Visitor.folder
+    method! fold_procedure_calling_style _ = Visitor.skip
+    method! fold_procedure_by_value_arg a acc =
+      Visitor.skip_children @@
+      resolve_arg_name_ref acc
+        ~arg_name:a.by_value_arg_name
+        ~arg_passing_style:Arg_by_value
+    method! fold_procedure_by_reference_arg a acc =
+      let optional = a.by_reference_arg_optional in
+      Visitor.skip_children @@
+      resolve_arg_name_ref acc
+        ~arg_name:a.by_reference_arg_name
+        ~arg_passing_style:(Arg_by_reference { optional })
+  end ~&pa { rev_args = []; refs } |>
+  fun acc -> Some (List.rev acc.rev_args &@<- pa), acc.refs
+
+
+let procedure_of_compilation_unit ~data_definitions ~refs cu' =
 
   let open struct
     type acc =
@@ -32,6 +97,7 @@ let procedure_of_compilation_unit cu' =
         blocks: procedure_block Qualmap.t;
         block_list: procedure_block list;
         current_section: section_under_construction with_loc option;
+        args: Cobol_ptree.procedure_using_phrase with_loc option;
       }
     and section_under_construction =
       {
@@ -44,13 +110,29 @@ let procedure_of_compilation_unit cu' =
         blocks = Qualmap.empty;
         block_list = [];
         current_section = None;
+        args = None;
       }
 
-    let procedure acc =
+    let procedure_blocks acc =
       {
         named = acc.blocks;
         list = List.rev acc.block_list;
       }
+
+    let procedure_using acc =
+      match acc.args with
+      | None ->
+          None, refs
+      | Some args ->
+          resolve_procedure_args ~data_definitions ~refs args
+
+    let procedure acc =
+      let procedure_using, references = procedure_using acc in
+      {
+        procedure_blocks = procedure_blocks acc;
+        procedure_using;
+      },
+      references
 
     let name n : Cobol_ptree.qualname = Name n
     let qual n q : Cobol_ptree.qualname = Qual (n, q)
@@ -88,7 +170,8 @@ let procedure_of_compilation_unit cu' =
       match acc.current_section with
       | Some ({ payload = { sec_name = qn; _ }; _ } as section) ->
           let section = section_block section in
-          { blocks = Qualmap.add ~&qn section acc.blocks;
+          { acc with
+            blocks = Qualmap.add ~&qn section acc.blocks;
             block_list = section :: acc.block_list;
             current_section = None }
       | None ->
@@ -116,7 +199,8 @@ let procedure_of_compilation_unit cu' =
             acc.block_list,
             Some ({ ~&s with sec_paragraphs } &@ loc)
       in
-      { blocks = Qualmap.add qn (paragraph_block p) acc.blocks;
+      { acc with
+        blocks = Qualmap.add qn (paragraph_block p) acc.blocks;
         block_list;
         current_section }
 
@@ -137,6 +221,9 @@ let procedure_of_compilation_unit cu' =
       Visitor.do_children_and_then acc
         commit_section                  (* be sure to handle the last section *)
 
+    method! fold_procedure_using_phrase' args acc =
+      Visitor.skip_children { acc with args = Some args }
+
     method! fold_paragraph' p acc =
       Visitor.skip_children @@ match ~&p with
       | { paragraph_is_section = true;
@@ -144,9 +231,7 @@ let procedure_of_compilation_unit cu' =
       | { paragraph_name = Some name; _ } -> named_paragraph name p acc
       | { paragraph_name = None; _ }      -> anonymous_paragraph p acc
 
-    (* TODO: nested programs... *)
-    method! fold_nested_programs _  = Visitor.skip
-
+    method! fold_nested_programs _  = Visitor.skip                    (* TODO *)
   end in
 
   Cobol_ptree.Visitor.fold_compilation_unit' visitor
@@ -154,73 +239,20 @@ let procedure_of_compilation_unit cu' =
 
 (* --- *)
 
-let references
+let collect_references
     ~(data_definitions: Cobol_unit.Types.data_definitions)
-    ~(fold_exec_block': Typeck_outputs.fold_exec_block') procedure =
-
-  let open Typeck_outputs in (* for references_acc *)
-  let init =
-    {
-      current_section = None;
-      refs = Typeck_outputs.no_refs;
-      diags = Typeck_diagnostics.none;
-    } in
-  let references { refs; diags; _ } = refs, diags
-  in
-
-  let baseloc_of_qualname: Cobol_ptree.qualname -> srcloc = function
-    | Name name
-    | Qual (name, _) -> ~@name
-  in
-
-  let error acc err =
-    { acc with diags = Proc_error err :: acc.diags }
-  in
-  let register_name name acc =
-    let qn = Cobol_ptree.Name name in
-    let loc = name.loc in
-    begin try
-        let bnd = Qualmap.find_binding qn data_definitions.data_items.named in
-        { acc with
-          refs = Typeck_outputs.register_data_qualref
-              ~loc bnd.full_qn acc.refs }
-      with
-      | Not_found ->
-        acc  (* ignored for now, as we don't process all the DATA DIV. yet. *)
-      | Qualmap.Ambiguous (lazy matching_qualnames) ->
-        error acc @@ Ambiguous_data_name { given_qualname = qn &@ loc;
-                                           matching_qualnames }
-    end in
+    ~(fold_exec_block': Typeck_outputs.exec_block_folder)
+    ~(refs: references_acc)
+    procedure =
 
   let visitor = object (v)
     inherit [references_acc] Cobol_unit.Visitor.folder
 
     method! fold_qualname qn acc =                (* TODO: data_name' instead *)
-      let loc = baseloc_of_qualname qn in
       Visitor.do_children @@
-      (* match Qualmap.find qn data_definitions.data_items.named with
-         | Data_field { def; _ } ->
-             { acc with
-               refs = Typeck_outputs.register_data_field_ref ~loc def acc.refs }
-         | Data_renaming { def; _ } ->
-             { acc with
-               refs = Typeck_outputs.register_data_renaming_ref ~loc def acc.refs }
-         | Data_condition { def; _ } ->
-             { acc with
-               refs = Typeck_outputs.register_condition_name_ref ~loc def acc.refs }
-         | Table_index { qualname = qn; _ } ->
-             { acc with
-               refs = Typeck_outputs.register_data_qualref ~loc ~&qn acc.refs } *)
-      try
-        let bnd = Qualmap.find_binding qn data_definitions.data_items.named in
-        { acc with
-          refs = Typeck_outputs.register_data_qualref ~loc bnd.full_qn acc.refs }
-      with
-      | Not_found ->
-        acc  (* ignored for now, as we don't process all the DATA DIV. yet. *)
-      | Qualmap.Ambiguous (lazy matching_qualnames) ->
-        error acc @@ Ambiguous_data_name { given_qualname = qn &@ loc;
-                                           matching_qualnames }
+      Typeck_references.register_data_qualname
+        ~data_definitions
+        (qn &@ baseloc_of_qualname qn) acc
 
     method! fold_procedure_section ({ section_paragraphs; _ } as s)
         ({ current_section; _ } as acc) =
@@ -235,46 +267,44 @@ let references
       Visitor.skip @@
       Cobol_ptree.Proc_division_visitor.fold_paragraph' v paragraph acc
 
-
     method! fold_procedure_name' qn
         ({ current_section = in_section; _ } as acc) =
       let register ?in_section qn acc =
         let loc = baseloc_of_qualname ~&qn in
         match Cobol_unit.Procedure.find ~&qn ?in_section procedure with
         | block ->
-          { acc with
-            refs = Typeck_outputs.register_procedure_ref ~loc block acc.refs }
+            { acc with
+              refs = Typeck_outputs.register_procedure_ref ~loc block acc.refs }
         | exception Not_found ->
-          error acc @@ Unknown_proc_name qn
+            error acc @@ Unknown_proc_name qn
         | exception Qualmap.Ambiguous (lazy matching_qualnames) ->
-          error acc @@ Ambiguous_proc_name { given_qualname = qn;
-                                             matching_qualnames }
+            error acc @@ Ambiguous_proc_name { given_qualname = qn;
+                                               matching_qualnames }
       in
       let acc = register ?in_section qn acc in
       let acc = match ~&qn with
         | Name _ -> acc
         | Qual (_, section_qn) ->
-          let loc = baseloc_of_qualname section_qn in
-          register (section_qn &@ loc) acc
+            register (section_qn &@ baseloc_of_qualname section_qn) acc
       in
       Visitor.skip_children acc
 
     method! fold_exec_block' exec_block acc =
-      let acc = fold_exec_block' ~register_name exec_block acc
-      in
-      Visitor.skip_children acc
+      Visitor.skip_children @@
+      fold_exec_block' ~data_definitions exec_block acc
 
   end in
 
-  Cobol_unit.Visitor.fold_procedure visitor procedure init |> references
+  Cobol_unit.Visitor.fold_procedure visitor procedure refs
 
 (* --- *)
 
 let of_compilation_unit ~data_definitions ~fold_exec_block' cu' =
-  let procedure = procedure_of_compilation_unit cu' in
-  let references, diags = references ~data_definitions ~fold_exec_block' procedure in
-  {
-    procedure;
-    references;
-  },
-  diags
+  let procedure, refs =
+    procedure_of_compilation_unit ~data_definitions cu'
+      ~refs:Typeck_references.empty_accumulator
+  in
+  let { refs = references; diags; _ } =
+    collect_references ~data_definitions ~fold_exec_block' ~refs procedure
+  in
+  { procedure; references }, diags

--- a/src/lsp/cobol_typeck/typeck_procedure.mli
+++ b/src/lsp/cobol_typeck/typeck_procedure.mli
@@ -21,6 +21,6 @@ type output =
 
 val of_compilation_unit
   : data_definitions: Cobol_unit.Types.data_definitions
-  -> fold_exec_block': Typeck_outputs.fold_exec_block'
+  -> fold_exec_block': Typeck_outputs.exec_block_folder
   -> Cobol_ptree.compilation_unit with_loc
   -> output * Typeck_diagnostics.t

--- a/src/lsp/cobol_typeck/typeck_procedure_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure_diagnostics.ml
@@ -14,7 +14,6 @@
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-module DIAGS = Cobol_common.Diagnostics
 module QUAL = Cobol_unit.Qual
 module NEL = Cobol_common.Basics.NEL
 
@@ -28,12 +27,22 @@ type error =
   | Unknown_proc_name of Cobol_ptree.qualname with_loc
   | Ambiguous_data_name of qualname_ambiguity
   | Ambiguous_proc_name of qualname_ambiguity
-
+  | Invalid_proc_arg_storage of
+      {
+        arg_name: Cobol_ptree.name with_loc;
+        actual_storage: Cobol_data.Types.data_storage;
+      }
+  | Procedure_arg_record_not_found of
+      {
+        arg_name: Cobol_ptree.name with_loc;
+      }
 
 let error_loc = function
   | Unknown_proc_name { loc; _ }
   | Ambiguous_data_name { given_qualname = { loc; _ }; _ }
-  | Ambiguous_proc_name { given_qualname = { loc; _ }; _ } ->
+  | Ambiguous_proc_name { given_qualname = { loc; _ }; _ }
+  | Invalid_proc_arg_storage { arg_name = { loc; _ }; _ }
+  | Procedure_arg_record_not_found { arg_name = { loc; _ } } ->
       Some loc
 
 let pp_qualname_ambiguity ~kind ppf { given_qualname; matching_qualnames } =
@@ -50,3 +59,14 @@ let pp_error ppf = function
       pp_qualname_ambiguity ~kind:"data-name" ppf ambiguity
   | Ambiguous_proc_name ambiguity ->
       pp_qualname_ambiguity ~kind:"procedure-name" ppf ambiguity
+  | Invalid_proc_arg_storage { arg_name; actual_storage } ->
+      Pretty.print ppf
+        "Invalid@ storage@ %a@ for@ PROCEDURE@ DIVISION@ argument@ %a@ (LINKAGE@ \
+         expected)"
+        Cobol_data.Printer.pp_data_storage actual_storage
+        Cobol_ptree.pp_name' arg_name
+  | Procedure_arg_record_not_found { arg_name } ->
+      Pretty.print ppf
+        "PROCEDURE@ DIVISION@ argument@ %a@ not@ found@ (expected@ in@ the@ \
+         LINKAGE@ section)"
+        Cobol_ptree.pp_name' arg_name

--- a/src/lsp/cobol_typeck/typeck_references.ml
+++ b/src/lsp/cobol_typeck/typeck_references.ml
@@ -1,0 +1,67 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                        SuperBOL OSS Studio                             *)
+(*                                                                        *)
+(*  Copyright (c) 2022-2026 OCamlPro SAS                                  *)
+(*                                                                        *)
+(* All rights reserved.                                                   *)
+(* This source code is licensed under the GNU Affero General Public       *)
+(* License version 3 found in the LICENSE.md file in the root directory   *)
+(* of this source tree.                                                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Typeck_outputs                                     (* for references_acc *)
+open Typeck_procedure_diagnostics
+open Cobol_unit.Types
+open Cobol_common.Srcloc.TYPES
+open Cobol_common.Srcloc.INFIX
+
+module Qualmap = Cobol_unit.Qualmap
+
+let empty_accumulator =
+  {
+    current_section = None;
+    refs = Typeck_outputs.no_refs;
+    diags = Typeck_diagnostics.none;
+  }
+
+let error acc err =
+  { acc with diags = Proc_error err :: acc.diags }
+
+(** May raise {!Not_found} when [strict = true] (the default) *)
+let resolve_data_qualname ~data_definitions ?(strict = true)
+    ({ loc; payload = qn } as qn') acc =
+  try
+    let bnd = Qualmap.find_binding qn data_definitions.data_items.named in
+    Ok { resolved_name = qn'; resolved = bnd.value },
+    { acc with
+      refs = Typeck_outputs.register_data_qualref ~loc bnd.full_qn acc.refs }
+  with
+  | Not_found when not strict ->
+      (* TODO: error acc @@ Undefined_data_item { qualname = qn' } *)
+      Error (),
+      acc
+  | Qualmap.Ambiguous (lazy matching_qualnames) ->
+      Error (),
+      error acc @@ Ambiguous_data_name { given_qualname = qn &@ loc;
+                                         matching_qualnames }
+
+(** May raise {!Not_found} *)
+let resolve_record_name ~data_definitions name acc =
+  let res, acc =
+    resolve_data_qualname (Cobol_ptree.Name name &@<- name) acc
+      ~data_definitions
+  in
+  Result.map (fun { resolved; _ } -> { resolved; resolved_name = name }) res,
+  acc
+
+let register_data_qualname ~data_definitions qn' acc =
+  snd @@
+  resolve_data_qualname ~data_definitions qn' acc
+    ~strict:false  (* ignore missing defs unfil we process all the DATA
+                      DIVISION. *)
+
+let register_name ~data_definitions name acc =
+  register_data_qualname (Cobol_ptree.Name name &@<- name) acc
+    ~data_definitions

--- a/src/lsp/cobol_typeck/typeck_units.ml
+++ b/src/lsp/cobol_typeck/typeck_units.ml
@@ -16,7 +16,6 @@ open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
 module Visitor = Cobol_common.Visitor
-module DIAGS = Cobol_common.Diagnostics
 module CUs = Cobol_unit.Collections.SET
 module CUMap = Cobol_unit.Collections.MAP
 
@@ -124,7 +123,7 @@ end
     groups. *)
 let of_compilation_group
   : Cobol_config.t ->
-    fold_exec_block':Typeck_outputs.fold_exec_block' ->
+    fold_exec_block':Typeck_outputs.exec_block_folder ->
     Cobol_ptree.compilation_group ->
     Typeck_outputs.t Typeck_results.with_diags =
   fun config ~fold_exec_block' compilation_group_ptree ->

--- a/src/lsp/cobol_typeck/typeck_units.mli
+++ b/src/lsp/cobol_typeck/typeck_units.mli
@@ -13,6 +13,6 @@
 
 val of_compilation_group
   : Cobol_config.t
-  -> fold_exec_block':Typeck_outputs.fold_exec_block'
+  -> fold_exec_block':Typeck_outputs.exec_block_folder
   -> Cobol_ptree.compilation_group
   -> Typeck_outputs.t Typeck_results.with_diags

--- a/src/lsp/cobol_unit/unit_collections.ml
+++ b/src/lsp/cobol_unit/unit_collections.ml
@@ -19,6 +19,7 @@ open Cobol_common.Srcloc.INFIX
 
 let compare_with_name u name =
   String.compare ~&(~&u.unit_name) name
+
 let compare_by_name u1 u2 =
   String.compare ~&(~&u1.unit_name) ~&(~&u2.unit_name)
 
@@ -56,6 +57,7 @@ module MAP: sig
                  and type +'a t = 'a Map.Make (M).t
   val units: 'a t -> SET.t
   val find_by_name: string -> 'a t -> cobol_unit with_loc * 'a
+  val tabulate: (key -> 'a) -> SET.t -> 'a t
 end = struct
   include Map.Make (M)
   let units map =
@@ -63,4 +65,6 @@ end = struct
   let find_by_name name map =
     let u, v = find_first (fun u -> compare_with_name u name >= 0) map in
     if ~&(~&u.unit_name) = name then u, v else raise Not_found
+  let tabulate f set =
+    SET.fold (fun u map -> add u (f u) map) set empty
 end

--- a/src/lsp/cobol_unit/unit_printer.ml
+++ b/src/lsp/cobol_unit/unit_printer.ml
@@ -15,6 +15,34 @@ open Unit_types
 
 open Cobol_common.Srcloc.INFIX
 
+let pp_resolved_name pp_resolved : _ resolved_name Fmt.t =
+  Pretty.record [
+    Fmt.(field "resolved-name" (fun x -> x.resolved_name) Cobol_ptree.pp_name');
+    Fmt.(field "resolved" (fun x -> x.resolved) pp_resolved);
+  ]
+
+let pp_resolved_qualname pp_resolved : _ resolved_qualname Fmt.t =
+  Pretty.record [
+    Fmt.(field "resolved-name" (fun x -> x.resolved_name) Cobol_ptree.pp_qualname');
+    Fmt.(field "resolved" (fun x -> x.resolved) pp_resolved);
+  ]
+
+let pp_arg_passing_style ppf = function
+  | Arg_by_value ->
+      Pretty.print ppf "by@ value"
+  | Arg_by_reference { optional = false } ->
+      Pretty.print ppf "by@ reference"
+  | Arg_by_reference { optional = true } ->
+      Pretty.print ppf "by@ reference,@ optional"
+
+let pp_procedure_arg =
+  Pretty.record [
+    Fmt.(field "arg-definition" (fun x -> x.arg_data_definition)
+           (pp_resolved_name Cobol_data.Printer.pp_data_definition));
+    Fmt.(field "passing-style" (fun x -> x.arg_passing_style)
+           pp_arg_passing_style);
+  ]
+
 let pp_cobol_unit ?(show_items = false) =
   Pretty.record_with_conditional_fields [
     T Fmt.(field "name" (fun x -> ~&(x.unit_name)) string);

--- a/src/lsp/cobol_unit/unit_procedure.ml
+++ b/src/lsp/cobol_unit/unit_procedure.ml
@@ -22,7 +22,7 @@ let rec find
   : procedure_block =
   match in_section with
   | None ->
-      Unit_qualmap.find procedure_name procedure.named
+      Unit_qualmap.find procedure_name procedure.procedure_blocks.named
   | Some { section_paragraphs; _ } ->
       try
         Paragraph (Unit_qualmap.find procedure_name section_paragraphs.named)
@@ -35,7 +35,8 @@ let rec full_qn
   =
   match in_section with
   | None ->
-      (Unit_qualmap.find_binding procedure_name procedure.named).full_qn
+      (Unit_qualmap.find_binding procedure_name
+         procedure.procedure_blocks.named).full_qn
   | Some { section_paragraphs; _ } ->
       try
         (Unit_qualmap.find_binding procedure_name section_paragraphs.named).full_qn

--- a/src/lsp/cobol_unit/unit_types.ml
+++ b/src/lsp/cobol_unit/unit_types.ml
@@ -25,6 +25,18 @@ type 'a named_n_ordered =
     list: 'a list;
   }
 
+type ('a, 'ref_name) resolved_reference =
+  {
+    resolved_name: 'ref_name;
+    resolved: 'a;                                  (* note: skipped in visitor *)
+  }
+
+type 'a resolved_name =
+  ('a, Cobol_ptree.name with_loc) resolved_reference
+
+type 'a resolved_qualname =
+  ('a, Cobol_ptree.qualname with_loc) resolved_reference
+
 (* config *)
 
 (** Corresponds to the contents of the CONFIGURATION SECTION. *)
@@ -64,7 +76,23 @@ type procedure_block =
   | Paragraph of procedure_paragraph with_loc
   | Section of procedure_section with_loc
 
-type procedure = procedure_block named_n_ordered
+type procedure_using = procedure_arg with_loc list
+
+and procedure_arg =
+  {
+    arg_data_definition: Cobol_data.Types.data_definition resolved_name;
+    arg_passing_style: arg_passing_style;
+  }
+
+and arg_passing_style =
+  | Arg_by_reference of { optional: bool }
+  | Arg_by_value
+
+type procedure =
+  {
+    procedure_blocks: procedure_block named_n_ordered;
+    procedure_using: procedure_using with_loc option;
+  }
 
 (* main *)
 

--- a/src/lsp/cobol_unit/unit_visitor.ml
+++ b/src/lsp/cobol_unit/unit_visitor.ml
@@ -32,6 +32,11 @@ class ['a] folder = object
   method fold_procedure_paragraph: (procedure_paragraph, 'a) fold = default
   method fold_procedure_paragraph': (procedure_paragraph with_loc, 'a) fold = default
   method fold_procedure_block: (procedure_block, 'a) fold = default
+  method fold_resolved_name: 'x. ('x resolved_name, 'a) fold = default
+  (* method fold_resolved_qualname: 'x. ('x resolved_qualname, 'a) fold = default *)
+  method fold_procedure_arg: (procedure_arg, 'a) fold = default
+  method fold_procedure_using: (procedure_using, 'a) fold = default
+  method fold_procedure_using': (procedure_using with_loc, 'a) fold = default
   method fold_procedure: (procedure, 'a) fold = default
 end
 
@@ -73,9 +78,34 @@ let fold_procedure_block (v: _ #folder) =
       | Section s -> fold_procedure_section' v s
     end
 
+let fold_resolved_name ~fold (v: _ #folder) =
+  handle v#fold_resolved_name
+    ~continue:begin fun { resolved_name; resolved } x -> x
+      >> fold_string' v resolved_name
+      >> fold v resolved
+    end
+
+let fold_procedure_arg (v: _ #folder) =
+  handle v#fold_procedure_arg
+    ~continue:begin fun { arg_data_definition; arg_passing_style } x ->
+      ignore arg_passing_style;
+      x
+      >> fold_resolved_name v ~fold:(fun _ _ -> Fun.id) arg_data_definition
+    end
+
+let fold_procedure_using (v: _ #folder) =
+  handle v#fold_procedure_using
+    ~continue:(fold_with_loc_list v ~fold:fold_procedure_arg)
+
+let fold_procedure_using' (v: _ #folder) =
+  handle' v#fold_procedure_using' ~fold:fold_procedure_using v
+
 let fold_procedure (v: _ #folder) =
   handle v#fold_procedure                                     (* skip `named` *)
-    ~continue:(fun s -> fold_list v ~fold:fold_procedure_block s.list)
+    ~continue:begin fun { procedure_blocks; procedure_using } x -> x
+      >> fold_option ~fold:fold_procedure_using' v procedure_using
+      >> fold_list v ~fold:fold_procedure_block procedure_blocks.list
+    end
 
 let fold_cobol_unit (v: _ #folder) =
   handle v#fold_cobol_unit

--- a/src/lsp/superbol_preprocs/esql.ml
+++ b/src/lsp/superbol_preprocs/esql.ml
@@ -35,8 +35,8 @@ let scanner =
     Esql_exec_block (Sql_parser.parse text) , []
   )
 
-let fold_exec_block': Cobol_typeck.Outputs.fold_exec_block'
-  = fun ~register_name exec_block acc ->
+let fold_exec_block': Cobol_typeck.Outputs.exec_block_folder
+  = fun ~data_definitions exec_block acc ->
     match exec_block.payload with
     | Esql_exec_block esql ->
       let cob_var_extractor_folder = object
@@ -49,8 +49,7 @@ let fold_exec_block': Cobol_typeck.Outputs.fold_exec_block'
           esql []
       in
       List.fold_left begin fun acc cobol_var_id ->
-        register_name cobol_var_id acc
+        Cobol_typeck.References.register_name cobol_var_id acc
+          ~data_definitions
       end acc cobol_vars
     | _ -> acc
-
-

--- a/test/lsp/lsp_definition.ml
+++ b/test/lsp/lsp_definition.ml
@@ -690,3 +690,29 @@ let%expect_test "definition-index" =
        9              SET I IN V-TAB TO 0
     6-missing (line 11, character 15):
     No definition found |}];;
+
+
+let%expect_test "definition-procedure-using" =
+  let { end_with_postproc; projdir }, server = make_lsp_project () in
+  print_definitions ~projdir server @@ extract_position_markers {cobol|
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 ARG PIC X.
+       PROCEDURE DIVISION USING AR_|1-arg|_G.
+          DISPLAY ARG.
+          STOP RUN.
+    |cobol};
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    1-arg (line 6, character 34):
+    __rootdir__/prog.cob:6.10-6.13:
+       3          PROGRAM-ID. prog.
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6 >        01 ARG PIC X.
+    ----             ^^^
+       7          PROCEDURE DIVISION USING ARG.
+       8             DISPLAY ARG. |}]

--- a/test/lsp/lsp_hover.ml
+++ b/test/lsp/lsp_hover.ml
@@ -1389,3 +1389,37 @@ let%expect_test "hover-data-division-ref-count-only" =
        7          PROCEDURE DIVISION.
        8             DISPLAY VAR.
     References: 3 |}]
+
+let%expect_test "hover-procedure-using" =
+  let { projdir; end_with_postproc }, server = make_lsp_project () in
+  print_hovered server ~projdir @@ extract_position_markers {cobol|
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 ARG PIC X.
+       PROCEDURE DIVISION USING AR_|_G.
+          DISPLAY ARG.
+          STOP RUN.
+    |cobol};
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    (line 6, character 34):
+    __rootdir__/prog.cob:7.32-7.35:
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6          01 ARG PIC X.
+       7 >        PROCEDURE DIVISION USING ARG.
+    ----                                   ^^^
+       8             DISPLAY ARG.
+       9             STOP RUN.
+    ```cobol
+    ARG
+    ```
+    ```cobol
+    PIC X USAGE DISPLAY
+    ```
+    ALPHANUMERIC(1)
+    ---
+    References: 3 |}]

--- a/test/lsp/lsp_references.ml
+++ b/test/lsp/lsp_references.ml
@@ -472,3 +472,69 @@ let%expect_test "references-requests-group-var" =
     ----                          ^
       12             MOVE 1 TO X.
       13             STOP RUN. |}]
+
+let%expect_test "references-requests-procedure-using" =
+  let { end_with_postproc; projdir }, server = make_lsp_project () in
+  print_references ~projdir server @@ extract_position_markers {cobol|
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 _|1-arg|_ARG PIC X.
+       PROCEDURE DIVISION USING AR_|2-arg|_G.
+          DISPLAY ARG.
+          STOP RUN.
+    |cobol};
+  end_with_postproc [%expect.output];
+  [%expect {|
+    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    1-arg (line 5, character 10):
+    __rootdir__/prog.cob:6.10-6.13:
+       3          PROGRAM-ID. prog.
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6 >        01 ARG PIC X.
+    ----             ^^^
+       7          PROCEDURE DIVISION USING ARG.
+       8             DISPLAY ARG.
+    __rootdir__/prog.cob:7.32-7.35:
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6          01 ARG PIC X.
+       7 >        PROCEDURE DIVISION USING ARG.
+    ----                                   ^^^
+       8             DISPLAY ARG.
+       9             STOP RUN.
+    __rootdir__/prog.cob:8.18-8.21:
+       5          LINKAGE SECTION.
+       6          01 ARG PIC X.
+       7          PROCEDURE DIVISION USING ARG.
+       8 >           DISPLAY ARG.
+    ----                     ^^^
+       9             STOP RUN.
+      10
+    2-arg (line 6, character 34):
+    __rootdir__/prog.cob:6.10-6.13:
+       3          PROGRAM-ID. prog.
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6 >        01 ARG PIC X.
+    ----             ^^^
+       7          PROCEDURE DIVISION USING ARG.
+       8             DISPLAY ARG.
+    __rootdir__/prog.cob:7.32-7.35:
+       4          DATA DIVISION.
+       5          LINKAGE SECTION.
+       6          01 ARG PIC X.
+       7 >        PROCEDURE DIVISION USING ARG.
+    ----                                   ^^^
+       8             DISPLAY ARG.
+       9             STOP RUN.
+    __rootdir__/prog.cob:8.18-8.21:
+       5          LINKAGE SECTION.
+       6          01 ARG PIC X.
+       7          PROCEDURE DIVISION USING ARG.
+       8 >           DISPLAY ARG.
+    ----                     ^^^
+       9             STOP RUN.
+      10 |}]

--- a/test/testing_utils/prog_typeck.ml
+++ b/test/testing_utils/prog_typeck.ml
@@ -12,7 +12,7 @@
 (**************************************************************************)
 
 let typeck ?parser_options ?source_format ?filename contents =
-  let fold_exec_block' ~register_name:_ _exec_block acc =
+  let fold_exec_block' ~data_definitions:_ _exec_block acc =
     (* We could use Superbol_preprocs.Esql.fold_exec_block' to test
        SQL statements*)
     acc


### PR DESCRIPTION
- Improve parse-tree types for `USING` phrases, notably with cleaner source locations;
- Perform basic checks w.r.t formal arguments;
- Handle references, definitions, and hover for such arguments.

Additionally embarks some code cleanup and new functions for accessing various bits of information on defined data items.