### PR TITLE
A set of small fixes

### DIFF
--- a/src/lsp/cobol_config/cobol_config.ml
+++ b/src/lsp/cobol_config/cobol_config.ml
@@ -77,9 +77,9 @@ let default_search_path =
   end
 
 let retrieve_search_path ?search_path () =
-  match search_path with
-  | Some p -> p
-  | None -> Lazy.force default_search_path
+  (match search_path with
+   | Some p -> p
+   | None -> []) @ Lazy.force default_search_path
 
 let find_file ~search_path filename =
   try EzFile.find_in_path search_path filename
@@ -226,6 +226,7 @@ let load_file (module Words: Words.S) ?search_path file =
   let search_path = retrieve_search_path ?search_path () in
   let search_path = EzFile.dirname file :: search_path in
   let rec load acc file =
+    let file = find_file ~search_path file in
     let options = parse_file file in
     List.fold_left begin fun acc option -> match option with
       | Conf_ast.Value _ ->
@@ -240,9 +241,9 @@ let load_file (module Words: Words.S) ?search_path file =
       | ReservedWords words ->
           let basename = String.lowercase_ascii words in
           let filename = EzFile.add_suffix basename ".words" in
-          load acc @@ find_file ~search_path filename
+          load acc filename
       | Include filename ->
-          load acc @@ find_file ~search_path filename
+          load acc filename
     end acc options
   in
   List.rev @@ load [] file

--- a/src/lsp/superbol_free_lib/command_check_syntax.ml
+++ b/src/lsp/superbol_free_lib/command_check_syntax.ml
@@ -15,7 +15,8 @@ open EZCMD.TYPES
 
 open Common_args
 
-let action { platform; preproc_options; parser_options; pretty_verbose } files =
+let action { platform; preproc_options; parser_options; pretty_verbose }
+    ~ppf files =
   let parse input =
     input |>
     Cobol_preproc.preprocessor ~options:preproc_options |>
@@ -24,23 +25,27 @@ let action { platform; preproc_options; parser_options; pretty_verbose } files =
   files |>
   List.iter begin fun filename ->
     pretty_verbose "@[Checking@ `%s'@]@." filename;
-    Cobol_parser.Outputs.sink_result ~platform ~ppf:Fmt.stdout @@
+    Cobol_parser.Outputs.sink_result ~platform ~ppf @@
     Cobol_preproc.Input.from ~filename ~f:parse ~platform;
   end
 
 let cmd =
   let files = ref [] in
+  let ppf = ref Fmt.stderr in
   let common, common_args = Common_args.get () in
 
   EZCMD.sub
     "check syntax"            (* add the corresponding line in Main.subcommands *)
     begin fun () ->
-      action (common ()) !files
+      action (common ()) ~ppf:!ppf !files
     end
     ~args:(common_args @ [
       [],
       Arg.Anons (fun list -> files := list),
       EZCMD.info ~docv:"FILE" "Cobol file to check";
+
+      [ "stdout" ], Arg.Unit (fun () -> ppf := Fmt.stdout),
+      EZCMD.info "Output errors/warnings to stdout";
     ])
     ~doc: "Check the syntax of a Cobol file"
     ~man:[

--- a/src/lsp/superbol_free_lib/command_switch.ml
+++ b/src/lsp/superbol_free_lib/command_switch.ml
@@ -435,6 +435,7 @@ to your $HOME/.profile file.|};
     List.iter (fun (var, v) ->
         Printf.printf "%s='%s'; export %s;\n" var v var)
       [ "GNUCOBOL_DIR", switch_dir;
+        "COB_CONFIG_DIR", switch_dir // "share/gnucobol/config";
         set_path "PATH" "bin";
         set_path "LD_LIBRARY_PATH" "lib" ;
         set_path "MANPATH" "share/man" ;

--- a/src/lsp/superbol_free_lib/common_args.ml
+++ b/src/lsp/superbol_free_lib/common_args.ml
@@ -67,6 +67,7 @@ let get ?(verbose_on = `Stdout) () =
                  "cobolx"; "Cobolx"; "CobolX"; "COBOLX";
                  "auto"; "AUTO"] in
   let libpath = ref ["."] in
+  let search_path = ref [] in
   let libexts = ref Cobol_common.Copybook.copybook_extensions in
   let definitions = ref [] in
   let recovery = ref true in
@@ -114,6 +115,10 @@ let get ?(verbose_on = `Stdout) () =
     ["silence"], Arg.String silence,
     EZCMD.info "Silence specific messages";
 
+    ["config-dir"], Arg.String (fun s ->
+        search_path := !search_path @ [s]),
+    EZCMD.info ~docv:"DIR" "Add DIR to config search path";
+
     ["I"], Arg.String (fun s -> libpath := !libpath @ [s]),
     EZCMD.info ~docv:"DIR" "Add DIR to library search path";
 
@@ -127,15 +132,16 @@ let get ?(verbose_on = `Stdout) () =
 
   let get () =
     let verbose = !Globals.verbosity > 0 in
+    let search_path = !search_path in
     let config =
       DIAGS.show_n_forget ~platform:Superbol_platform.record @@
       match !conf, !dialect with
       | "", None ->
           DIAGS.result Cobol_config.default
       | "", Some d ->
-          Cobol_config.from_dialect ~verbose d
+          Cobol_config.from_dialect ~verbose ~search_path d
       | s, None ->
-          Cobol_config.from_file ~verbose s
+          Cobol_config.from_file ~verbose ~search_path s
       | _ ->
           Pretty.failwith "Flags `--conf` and `--dialect` or `--std` cannot be \
                            used together"

--- a/test/syntax-todo/syntax.at
+++ b/test/syntax-todo/syntax.at
@@ -4,8 +4,9 @@
 
 
 AT_SETUP([MF TYPEDEF])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        PROGRAM-ID      prog.
        WORKING-STORAGE SECTION.
        01  bool-t                  pic x comp-5 typedef.
@@ -13,7 +14,11 @@ AT_DATA([prog.cob],[
        01  ws-show-help            bool-t value 78-true.
        PROCEDURE DIVISION.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.35-5.41:
    2          PROGRAM-ID      prog.
    3          WORKING-STORAGE SECTION.
@@ -24,21 +29,26 @@ prog.cob:5.35-5.41:
    7          PROCEDURE DIVISION.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 AT_SETUP([MF CONSTANT])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        PROGRAM-ID      prog.
        WORKING-STORAGE SECTION.
        01  ws-formatted-book-columns
            value "ID NAME AUTHOR PRICE STOCK SOLD" constant.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf --source-format=xcard prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.51-5.59:
    2          PROGRAM-ID      prog.
    3          WORKING-STORAGE SECTION.
@@ -47,8 +57,8 @@ prog.cob:5.51-5.59:
 ----                                                      ^^^^^^^^
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
@@ -82,14 +92,14 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
 [Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:2.7-2.14:
    1   @&t@
    2 >        display "Hello, COBOL World!"
 ----          ^^^^^^^
 >> Error: Invalid syntax
 
-],
-[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
 
 AT_CLEANUP
@@ -106,14 +116,14 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
 [Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:2.7-2.14:
    1   @&t@
    2 >        display "Hello, COBOL World!"
 ----          ^^^^^^^
 >> Error: Invalid syntax
 
-],
-[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
 
 AT_CLEANUP
@@ -122,8 +132,9 @@ AT_CLEANUP
 
 
 AT_SETUP([MF SHARP in FIELD])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        01  my-bird.
@@ -131,7 +142,11 @@ AT_DATA([prog.cob],[
                10  common-name         name-string.
        procedure division.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.15-5.16:
    2          program-id. toto.
    3          working-storage section.
@@ -142,22 +157,27 @@ prog.cob:5.15-5.16:
    7          procedure division.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 AT_SETUP([MF SHARP DECLARE IN PROCEDURE])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
            declare temp-name as pic X(30) = "European Robin"
            .
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.19-5.28:
    2          program-id. toto.
    3          working-storage section.
@@ -167,15 +187,16 @@ prog.cob:5.19-5.28:
    6              .
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 AT_SETUP([MF FIELD ACCESS])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        01  my-bird.
@@ -185,7 +206,11 @@ AT_DATA([prog.cob],[
        procedure division.
            move 12.0 to my-bird::length-field::min.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:9.33-9.45:
    6                  10  length-field.
    7                      15  min                     pic 9(3)V9.
@@ -194,16 +219,17 @@ prog.cob:9.33-9.45:
 ----                                    ^^^^^^^^^^^^
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF parameterized-section])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
@@ -212,7 +238,11 @@ AT_DATA([prog.cob],[
                              returning return-parameter as binary-long.
            add 1 to value-parameter giving return-parameter.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.51-5.60:
    2          program-id. toto.
    3          working-storage section.
@@ -223,16 +253,17 @@ prog.cob:5.51-5.60:
    7                                returning return-parameter as binary-long.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF parameterized-section with no parameter])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
@@ -241,7 +272,11 @@ AT_DATA([prog.cob],[
                      returning return-parameter as binary-long.
            move 5 to return-parameter.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.33-5.42:
    2          program-id. toto.
    3          working-storage section.
@@ -252,16 +287,17 @@ prog.cob:5.33-5.42:
    7                        returning return-parameter as binary-long.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF parameterized-section with optional argument])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
@@ -270,7 +306,11 @@ AT_DATA([prog.cob],[
                           returning return-parameter as binary-long.
            add 1 to value-parameter giving return-parameter.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.38-5.39:
    2          program-id. toto.
    3          working-storage section.
@@ -281,16 +321,17 @@ prog.cob:5.38-5.39:
    7                             returning return-parameter as binary-long.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF parameterized-section with by-value argument])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
@@ -298,7 +339,11 @@ AT_DATA([prog.cob],[
        by-value section (value value-parameter as binary-long).
            add 1 to value-parameter.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.50-5.51:
    2          program-id. toto.
    3          working-storage section.
@@ -309,16 +354,17 @@ prog.cob:5.50-5.51:
    7              add 1 to value-parameter.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF parameterized-section with by-reference argument])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        procedure division.
@@ -326,7 +372,11 @@ AT_DATA([prog.cob],[
        by-reference section (reference ref-parameter as binary-long).
            add 1 to ref-parameter.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.45-5.46:
    2          program-id. toto.
    3          working-storage section.
@@ -337,16 +387,17 @@ prog.cob:5.45-5.46:
    7              add 1 to ref-parameter.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF LEVEL 78 CONSTANTS])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        78  GRID-SIZE           value 8.
@@ -354,7 +405,11 @@ AT_DATA([prog.cob],[
            05  x-positions     occurs GRID-SIZE.
                10  cell    x-cell-name.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:6.38-6.47:
    3          working-storage section.
    4          78  GRID-SIZE           value 8.
@@ -364,23 +419,28 @@ prog.cob:6.38-6.47:
    7                  10  cell    x-cell-name.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF VALUES with multiple values])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. toto.
        working-storage section.
        01  letters             pic X occurs 8
                                      values "a", "b", "c", "d",
                                             "e", "f", "g", "h".
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:6.62-6.63:
    3          working-storage section.
    4          01  letters             pic X occurs 8
@@ -389,16 +449,17 @@ prog.cob:6.62-6.63:
 ----                                                                 ^
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF COMPUTE with parameterized-section])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. ParameterizedSections.
        procedure division.
            display fibonacci(10)
@@ -411,7 +472,11 @@ AT_DATA([prog.cob],[
            compute result = fibonacci(n - 1) + fibonacci(n - 2).
        end program.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:6.25-6.26:
    3          procedure division.
    4              display fibonacci(10)
@@ -422,8 +487,8 @@ prog.cob:6.25-6.26:
    8                  move n to result
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
@@ -669,6 +734,8 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
 [Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:6.16-6.33:
    3         * Implements a calendar editor column for use in the data grid
    4         *
@@ -679,8 +746,6 @@ prog.cob:6.16-6.33:
    8          working-storage section.
 >> Error: Invalid syntax
 
-],
-[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
 
 AT_CLEANUP
@@ -698,6 +763,8 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 [Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:2.11-2.16:
    1   @&t@
    2 >       $SET ans85
@@ -706,8 +773,6 @@ prog.cob:2.11-2.16:
    4          PROGRAM-ID. customer.
 >> Warning: Ignored compiler directive
 
-],
-[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
 
 AT_CLEANUP
@@ -716,8 +781,9 @@ AT_CLEANUP
 
 
 AT_SETUP([MF LEVEL 78 CONSTANTS])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        IDENTIFICATION DIVISION.
        PROGRAM-ID. customer.
        DATA DIVISION.
@@ -730,7 +796,11 @@ AT_DATA([prog.cob],[
                    07  file-ord-date   PIC 9(8).
        PROCEDURE DIVISION.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:9.45-9.57:
    6          01  customer-record.
    7              03  file-c-order.
@@ -741,16 +811,17 @@ prog.cob:9.45-9.57:
   11                      07  file-ord-date   PIC 9(8).
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF MISSING POINT BEFORE END PROGRAM])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. GetFlyerLevel.
        procedure division.
            evaluate lnk-award-points
@@ -759,7 +830,11 @@ AT_DATA([prog.cob],[
            end-evaluate
        end program.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:8.7-8.10:
    5                   when < 300
    6                      move "Bronze" to lnk-award-level
@@ -768,16 +843,17 @@ prog.cob:8.7-8.10:
 ----          ^^^
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
 
 
 AT_SETUP([MF WHEN COND AND COND])
+
 # promoted on 2024-04-05T13:38
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
        program-id. GetFlyerLevel.
        procedure division.
            evaluate lnk-award-points
@@ -786,7 +862,11 @@ AT_DATA([prog.cob],[
            end-evaluate.
        end program.
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.28-5.31:
    2          program-id. GetFlyerLevel.
    3          procedure division.
@@ -797,8 +877,8 @@ prog.cob:5.28-5.31:
    7              end-evaluate.
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 
@@ -808,14 +888,19 @@ AT_CLEANUP
 
 
 AT_SETUP([LENGTH])
+
 # promoted on 2026-02-09T14:56
-AT_DATA([prog.cob],[
+AT_DATA([prog.cob], [
 identification division.
 program-id.             acas-get-params.
  procedure division.
               MOVE LENGTH(Buffer) TO Buffer-Length
 ])
-AT_CHECK([$SUPERBOL check --recovery=false --free prog.cob], [1], [Checking `prog.cob'
+
+AT_CHECK([$SUPERBOL check --recovery=false --free prog.cob], [1],
+[Checking `prog.cob'
+],
+[SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 prog.cob:5.25-5.26:
    2   identification division.
    3   program-id.             acas-get-params.
@@ -824,8 +909,8 @@ prog.cob:5.25-5.26:
 ----                            ^
 >> Error: Invalid syntax
 
-], [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
 ])
+
 AT_CLEANUP
 
 


### PR DESCRIPTION
* Cobol_config: combine provided search path with default search path
* Superbol_free_lib:
  * Common_args: add an argument '--config-dir DIR' to add DIR to the config search path
  * 'superbol check syntax' outputs diagnostics to stderr by default
  * 'superbol switch env' set COB_CONFIG_DIR