### PR TITLE
Fix size shown for data items with yet-unsupported usage or erroneous definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Warnings on unsupported usage, where the reported data item size may be be wrong [#570](https://github.com/OCamlPro/superbol-studio-oss/pull/570)
 
 ### Fixed
-- Size shown on hover of data items with usages that are not (yet) supported [#575](https://github.com/OCamlPro/superbol-studio-oss/pull/575)
+- Details shown on hover of data items with definition issues [#575](https://github.com/OCamlPro/superbol-studio-oss/pull/575)
 - Handling of alphanumeric literals with UTF-8 characters in fixed-format COBOL code [#564](https://github.com/OCamlPro/superbol-studio-oss/pull/564)
 - Handling of queries about `LINKAGE` items given in `USING` phrases [#561](https://github.com/OCamlPro/superbol-studio-oss/pull/561)
 - Parsing of LSP CLI arguments, that notably prevented caching in global storage [#549](https://github.com/OCamlPro/superbol-studio-oss/pull/549) (fix for [Issue #547](https://github.com/OCamlPro/superbol-studio-oss/issues/547))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Warnings on unsupported usage, where the reported data item size may be be wrong [#570](https://github.com/OCamlPro/superbol-studio-oss/pull/570)
 
 ### Fixed
+- Size shown on hover of data items with usages that are not (yet) supported [#575](https://github.com/OCamlPro/superbol-studio-oss/pull/575)
 - Handling of alphanumeric literals with UTF-8 characters in fixed-format COBOL code [#564](https://github.com/OCamlPro/superbol-studio-oss/pull/564)
 - Handling of queries about `LINKAGE` items given in `USING` phrases [#561](https://github.com/OCamlPro/superbol-studio-oss/pull/561)
 - Parsing of LSP CLI arguments, that notably prevented caching in global storage [#549](https://github.com/OCamlPro/superbol-studio-oss/pull/549) (fix for [Issue #547](https://github.com/OCamlPro/superbol-studio-oss/issues/547))

--- a/src/lsp/cobol_common/basics.ml
+++ b/src/lsp/cobol_common/basics.ml
@@ -77,6 +77,9 @@ module LIST = struct
     List.rev l
   let hd = List.hd
   let tl = List.tl
+  let exists ?loc f l =
+    check_10 "exists" ~loc l;
+    List.exists f l
   let split ?loc l =
     check_10 "split" ~loc l;
     List.split l

--- a/src/lsp/cobol_data/data_item.ml
+++ b/src/lsp/cobol_data/data_item.ml
@@ -93,3 +93,9 @@ let def_offset: data_definition -> Data_memory.offset = function
   | Data_renaming { def; _} -> ~&def.renaming_offset
   | Data_condition { field; _} -> ~&field.field_offset
   | Table_index { table; _ } -> ~&table.table_offset
+
+let def_has_issues: data_definition -> bool = function
+  | Data_field { def; _ } -> ~&def.field_has_definition_issues
+  | Data_renaming _ -> false
+  | Data_condition { field; _ } -> ~&field.field_has_definition_issues
+  | Table_index { table; _ } -> ~&table.table_has_definition_issues

--- a/src/lsp/cobol_data/data_printer.ml
+++ b/src/lsp/cobol_data/data_printer.ml
@@ -163,6 +163,8 @@ and pp_field_definition: field_definition Pretty.printer = fun ppf x ->
     I ((fun x -> x.field_qualname <> None),
        Fmt.field "qualname" (fun x -> x.field_qualname) pp_qualname'_opt,
        Fmt.(styled `Yellow @@ any "filler"));
+    C ((fun x -> x.field_has_definition_issues),
+       Fmt.any "/!\\ with_errors /!\\");
     C ((fun x -> x.field_redefines <> None),
        Fmt.field "redefines" (fun x -> x.field_redefines) pp_qualname'_opt);
     C ((fun x -> x.field_leading_ranges <> []),
@@ -204,6 +206,8 @@ and pp_field_layout: field_layout Pretty.printer = fun ppf -> function
 and pp_table_definition: table_definition Pretty.printer = fun ppf x ->
   Pretty.record_with_conditional_fields [
     T Fmt.(styled `Yellow @@ any "table");
+    C ((fun x -> x.table_has_definition_issues),
+       Fmt.any "/!\\ with_errors /!\\");
     C ((fun x -> x.table_redefines <> None),
        Fmt.field "redefines" (fun x -> x.table_redefines) pp_qualname'_opt);
     T (Fmt.field "offset" (fun x -> x.table_offset) pp_offset);

--- a/src/lsp/cobol_data/data_printer.ml
+++ b/src/lsp/cobol_data/data_printer.ml
@@ -255,6 +255,8 @@ let pp_renamed_item_layout: renamed_item_layout Pretty.printer = fun ppf -> func
 let pp_record_renaming: record_renaming Pretty.printer =
   Pretty.record_with_conditional_fields [
     T (Fmt.field "qualname" (fun r -> r.renaming_name) Cobol_ptree.pp_qualname');
+    C ((fun r -> r.renaming_has_definition_issues),
+       Fmt.any "/!\\ with_errors /!\\");
     T (Fmt.field "from" (fun r -> r.renaming_from) Cobol_ptree.pp_qualname');
     C ((fun r -> r.renaming_thru <> None),
        Fmt.field "thru" (fun r -> r.renaming_thru) pp_qualname'_opt);

--- a/src/lsp/cobol_data/data_types.ml
+++ b/src/lsp/cobol_data/data_types.ml
@@ -91,6 +91,7 @@ and field_definition =
     field_length_variability: length_variability;
     field_conditions: condition_names;
     field_redefinitions: item_redefinitions;
+    field_has_definition_issues: bool; (* TODO: generic warning/error flags? data_diags? *)
   }
 
 and field_layout =
@@ -113,6 +114,7 @@ and table_definition =
     table_init_values: Cobol_ptree.literal with_loc list;     (* list for now *)
     table_redefines: Cobol_ptree.qualname with_loc option;    (* redef only *)
     table_redefinitions: item_redefinitions;
+    table_has_definition_issues: bool; (* TODO: generic warning/error flags? data_diags? *)
   }
 and table_range =
   {

--- a/src/lsp/cobol_data/data_types.ml
+++ b/src/lsp/cobol_data/data_types.ml
@@ -91,7 +91,7 @@ and field_definition =
     field_length_variability: length_variability;
     field_conditions: condition_names;
     field_redefinitions: item_redefinitions;
-    field_has_definition_issues: bool; (* TODO: generic warning/error flags? data_diags? *)
+    field_has_definition_issues: bool;
   }
 
 and field_layout =
@@ -114,7 +114,7 @@ and table_definition =
     table_init_values: Cobol_ptree.literal with_loc list;     (* list for now *)
     table_redefines: Cobol_ptree.qualname with_loc option;    (* redef only *)
     table_redefinitions: item_redefinitions;
-    table_has_definition_issues: bool; (* TODO: generic warning/error flags? data_diags? *)
+    table_has_definition_issues: bool;
   }
 and table_range =
   {
@@ -171,6 +171,7 @@ and record_renaming =
     renaming_size: Data_memory.size;
     renaming_from: Cobol_ptree.qualname with_loc;
     renaming_thru: Cobol_ptree.qualname with_loc option;
+    renaming_has_definition_issues: bool;
   }
 and renamed_item_layout =
   | Renamed_elementary of

--- a/src/lsp/cobol_data/data_visitor.ml
+++ b/src/lsp/cobol_data/data_visitor.ml
@@ -251,7 +251,8 @@ let fold_record_renaming (v: _ #folder) =
   handle v#fold_record_renaming
     ~continue:begin fun { renaming_name; renaming_layout;
                           renaming_offset; renaming_size;
-                          renaming_from; renaming_thru } x -> x
+                          renaming_from; renaming_thru;
+                          renaming_has_definition_issues = _ } x -> x
       >> Cobol_ptree.Terms_visitor.fold_qualname' v renaming_name
       >> fold_renamed_item_layout v renaming_layout
       >> fold_memory_offset v renaming_offset

--- a/src/lsp/cobol_data/data_visitor.ml
+++ b/src/lsp/cobol_data/data_visitor.ml
@@ -171,7 +171,8 @@ and fold_field_definition (v: _ #folder) =
                           field_leading_ranges;
                           field_offset; field_size; field_layout;
                           field_conditions; field_redefinitions;
-                          field_length_variability = _ } x -> x
+                          field_length_variability = _;
+                          field_has_definition_issues = _ } x -> x
       >> Cobol_ptree.Terms_visitor.fold_qualname'_opt v field_qualname
       >> Cobol_ptree.Terms_visitor.fold_qualname'_opt v field_redefines
       >> fold_list ~fold:fold_table_range v field_leading_ranges
@@ -199,7 +200,8 @@ and fold_table_definition (v: _ #folder) =
   handle v#fold_table_definition
     ~continue:begin fun { table_field; table_offset; table_size;
                           table_range; table_init_values;
-                          table_redefines; table_redefinitions } x -> x
+                          table_redefines; table_redefinitions;
+                          table_has_definition_issues = _ } x -> x
       >> fold_field_definition' v table_field
       >> fold_memory_offset v table_offset
       >> fold_memory_size v table_size

--- a/src/lsp/cobol_lsp/lsp_data_info_printer.ml
+++ b/src/lsp/cobol_lsp/lsp_data_info_printer.ml
@@ -16,7 +16,19 @@ open Cobol_data.Types
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-let pp_size = Fmt.(any "Size: " ++ Cobol_data.Memory.pp_size ++ any " bits")
+let pp_readable_size ppf size =
+  try
+    let bits = Cobol_data.Memory.as_bits size in
+    if Int.rem bits 8 = 0 then
+      let bytes = bits / 8 in
+      Fmt.pf ppf "%u byte%s" bytes (if bytes > 1 then "s" else "")
+    else
+      Fmt.pf ppf "%u bit%s" bits (if bits > 1 then "s" else "")
+  with Cobol_data.Memory.NOT_SCALAR _ ->
+    Fmt.pf ppf "*variable*"
+
+let pp_size =
+  Fmt.(any "Size: " ++ pp_readable_size)
 
 let pp_int' = Cobol_ptree.pp_with_loc Fmt.int
 
@@ -176,8 +188,10 @@ and pp_field_definition: field_definition Pretty.printer = fun ppf x ->
     ++ any "\n\n"
     ++ const pp_field_layout x.field_layout
     ++ (match x.field_layout with
-    | Struct_field _ -> any "  \n" ++ const pp_size x.field_size
-    | _ -> nop)
+        | Struct_field _ when not x.field_has_definition_issues ->
+            any "  \n" ++ const pp_size x.field_size
+        | _ ->
+            nop)
     ++ any "  \n"
     ++ const (option (any "Redefines:\n" ++ pp_cobol_block Cobol_ptree.pp_qualname')) x.field_redefines)
   ppf x

--- a/src/lsp/cobol_lsp/lsp_data_info_printer.ml
+++ b/src/lsp/cobol_lsp/lsp_data_info_printer.ml
@@ -250,16 +250,18 @@ let pp_renamed_item_layout: renamed_item_layout Pretty.printer = fun ppf x ->
 let pp_record_renaming: record_renaming Pretty.printer = fun ppf r ->
   let open Fmt in begin
     pp_cobol_block begin
-      const Cobol_ptree.pp_qualname' r.renaming_name
-      ++ any "\nRENAMES "
-      ++ const Cobol_ptree.pp_qualname' r.renaming_from
-      ++ const (option (any "\nTHRU " ++ Cobol_ptree.pp_qualname')) r.renaming_thru
-    end
-    ++ any "\n\n"
-    ++ const pp_renamed_item_layout r.renaming_layout
-    ++ (match r.renaming_layout with
-        | Renamed_struct _ -> any "  \n" ++ const pp_size r.renaming_size
-        | _ -> nop)
+      const Cobol_ptree.pp_qualname' r.renaming_name ++ any "\n" ++
+      if r.renaming_has_definition_issues then nop else
+        any "RENAMES " ++
+        const Cobol_ptree.pp_qualname' r.renaming_from ++
+        const (option (any "\nTHRU " ++ Cobol_ptree.pp_qualname'))
+          r.renaming_thru
+    end ++ any "\n\n" ++
+    if r.renaming_has_definition_issues then nop else
+      const pp_renamed_item_layout r.renaming_layout ++
+      match r.renaming_layout with
+      | Renamed_struct _ -> any "  \n" ++ const pp_size r.renaming_size
+      | _ -> nop
   end ppf r
 
 let pp_record_renaming': record_renaming with_loc Pretty.printer = fun ppf ->

--- a/src/lsp/cobol_lsp/lsp_data_info_printer.ml
+++ b/src/lsp/cobol_lsp/lsp_data_info_printer.ml
@@ -182,19 +182,32 @@ and pp_field_layout: field_layout Pretty.printer = fun ppf x ->
       Fmt.const pp_struct subfields ppf x
 
 and pp_field_definition: field_definition Pretty.printer = fun ppf x ->
-  let pp_qualname_opt_in_block' = pp_cobol_block Fmt.(option ~none:(any "FILLER") Cobol_ptree.pp_qualname')  in
-  Fmt.(
-    const pp_qualname_opt_in_block' x.field_qualname
-    ++ any "\n\n"
-    ++ const pp_field_layout x.field_layout
-    ++ (match x.field_layout with
-        | Struct_field _ when not x.field_has_definition_issues ->
-            any "  \n" ++ const pp_size x.field_size
-        | _ ->
-            nop)
-    ++ any "  \n"
-    ++ const (option (any "Redefines:\n" ++ pp_cobol_block Cobol_ptree.pp_qualname')) x.field_redefines)
-  ppf x
+  let definition_has_issues = x.field_has_definition_issues in
+  let pp_qualname_opt_in_block' =
+    pp_cobol_block Fmt.(option ~none:(any "FILLER") Cobol_ptree.pp_qualname')
+  and pp_size ppf x =
+    match x.field_layout with
+    | Struct_field _ when not x.field_has_definition_issues ->
+        Fmt.fmt "  \n%a" ppf pp_size x.field_size
+    | _ ->
+        ()
+  in
+  match x.field_layout with
+  | Elementary_field _ when definition_has_issues ->
+      Fmt.(const pp_qualname_opt_in_block' x.field_qualname ++ any "\n\n" ++
+           any "*(layout omitted due to issues in item definition)*  \n" ++
+           const (option @@
+                  any "Redefines:\n" ++ pp_cobol_block Cobol_ptree.pp_qualname')
+             x.field_redefines)
+        ppf x
+  | _ ->
+      Fmt.(const pp_qualname_opt_in_block' x.field_qualname ++ any "\n\n" ++
+           const pp_field_layout x.field_layout ++
+           const pp_size x ++ any "  \n" ++
+           const (option @@
+                  any "Redefines:\n" ++ pp_cobol_block Cobol_ptree.pp_qualname')
+             x.field_redefines)
+        ppf x
 
 and pp_field_definition': field_definition with_loc Pretty.printer = fun ppf ->
   Cobol_ptree.pp_with_loc pp_field_definition ppf
@@ -235,18 +248,19 @@ let pp_renamed_item_layout: renamed_item_layout Pretty.printer = fun ppf x ->
       Fmt.const pp_struct subfields ppf x
 
 let pp_record_renaming: record_renaming Pretty.printer = fun ppf r ->
-  Fmt.(
-    pp_cobol_block (
+  let open Fmt in begin
+    pp_cobol_block begin
       const Cobol_ptree.pp_qualname' r.renaming_name
       ++ any "\nRENAMES "
       ++ const Cobol_ptree.pp_qualname' r.renaming_from
-      ++ const (option (any "\nTHRU " ++ Cobol_ptree.pp_qualname')) r.renaming_thru)
+      ++ const (option (any "\nTHRU " ++ Cobol_ptree.pp_qualname')) r.renaming_thru
+    end
     ++ any "\n\n"
     ++ const pp_renamed_item_layout r.renaming_layout
     ++ (match r.renaming_layout with
-    | Renamed_struct _ -> any "  \n" ++ const pp_size r.renaming_size
-    | _ -> nop) )
-  ppf r
+        | Renamed_struct _ -> any "  \n" ++ const pp_size r.renaming_size
+        | _ -> nop)
+  end ppf r
 
 let pp_record_renaming': record_renaming with_loc Pretty.printer = fun ppf ->
   Cobol_ptree.pp_with_loc pp_record_renaming ppf

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -553,44 +553,46 @@ let handle_semtoks_full,
 (** {3 Hover} *)
 
 let doc_of_datadef ~rev_comments ~filename data_def =
-  let open Cobol_preproc.Text in
-  let loc = Cobol_data.Item.def_loc data_def in
-  let def_filename = (fst @@ Cobol_common.Srcloc.as_lexloc loc).pos_fname in
-  if not (String.equal filename def_filename) (** def is in copybook *)
+  let definition_loc = Cobol_data.Item.def_loc data_def in
+  let definition_lexloc = Cobol_common.Srcloc.as_lexloc definition_loc in
+  let definition_filename = (fst definition_lexloc).pos_fname in
+  if not (String.equal filename definition_filename)      (* def is in copybook *)
   then ""
   else
-    let def_range = Lsp_position.range_of_srcloc_in ~filename loc in
-    let (inline, full_line) =
-      List.fold_left begin fun acc { comment_loc; comment_kind; comment_contents } ->
-        let com_range = Lsp_position.range_of_lexloc comment_loc in
-        if def_range.start.line = com_range.start.line
-        then (Some comment_contents, snd acc)
-        else if def_range.start.line = com_range.start.line + 1
-             && comment_kind == `Line
-        then (fst acc, Some comment_contents)
-        else acc
-      end (None, None) rev_comments
+    let definition_range =
+      Lsp_position.range_of_srcloc_in ~filename definition_loc
     in
-    match inline, full_line with
-    | Some comment, _ -> "\n---\n" ^ String.sub comment 2 (String.length comment - 2)
-    | None, Some comment -> "\n---\n" ^ String.sub comment 1 (String.length comment - 1)
-    | _ -> ""
+    let definition_line = definition_range.start.line in
+    List.find_map begin fun Cobol_preproc.Text.{ comment_loc; comment_kind;
+                                                 comment_contents = c } ->
+      let comment_range = Lsp_position.range_of_lexloc comment_loc in
+      let comment_line = comment_range.start.line in
+      if definition_line = comment_line
+      then Some (String.sub c 2 (String.length c - 2))
+      else if definition_line = comment_line + 1 && comment_kind == `Line
+      then Some (String.sub c 1 (String.length c - 1))
+      else None
+    end rev_comments |> function
+    | Some c -> c
+    | None -> ""
 
-let lookup_data_definition_for_hover cu_name element_at_pos group =
+let lookup_data_definition cu_name element_at_pos group =
   let { payload = cu; _ } = CUs.find_by_name cu_name group in
   let named_data_defs = cu.unit_data.data_items.named in
   try match element_at_pos with
     | Data_item { full_qn = Some qn; def_loc } ->
-        Cobol_unit.Qualmap.find qn named_data_defs, def_loc
+        Cobol_unit.Qualmap.find qn named_data_defs,
+        def_loc
     | Data_full_name qn | Data_name qn ->
-        Cobol_unit.Qualmap.find qn named_data_defs, Lsp_lookup.baseloc_of_qualname qn
+        Cobol_unit.Qualmap.find qn named_data_defs,
+        Lsp_lookup.baseloc_of_qualname qn
     | Data_item _ | Proc_name _ ->
         raise Not_found
   with Cobol_unit.Qualmap.Ambiguous _ -> raise Not_found
 
-let data_definition_on_hover
-    ?(always_show_hover_definition_text_in_data_div = false) ~rev_comments
-    ~uri position (checked_doc : Cobol_typeck.Outputs.t) =
+let describe_data_definition_at_pos
+    ?(always_show_hover_definition_text_in_data_div = false)
+    ~rev_comments ~uri position (checked_doc : Cobol_typeck.Outputs.t) =
   let Cobol_typeck.Outputs.{ group; _ } = checked_doc in
   let filename = Lsp.Uri.to_path uri in
   match Lsp_lookup.element_at_position ~uri position group with
@@ -601,25 +603,30 @@ let data_definition_on_hover
       enclosing_compilation_unit_name = Some cu_name } ->
       try
         let data_def, hover_loc
-          = lookup_data_definition_for_hover cu_name ele_at_pos group in
+          = lookup_data_definition cu_name ele_at_pos group in
+        let data_def_loc = Cobol_data.Item.def_loc data_def in
         let doc_comments = doc_of_datadef ~rev_comments ~filename data_def in
+        let pp_documentation ppf =
+          if doc_comments <> ""
+          then Pretty.print ppf "\n---\n%s" doc_comments
+        in
         let text =
           if always_show_hover_definition_text_in_data_div ||
-             not (Lsp_position.is_in_srcloc ~filename position @@
-                  Cobol_data.Item.def_loc data_def)
-          then Some (Pretty.to_string "%a%s"
-                       Lsp_data_info_printer.pp_data_definition data_def doc_comments)
+             not (Lsp_position.is_in_srcloc ~filename position data_def_loc)
+          then Some (Pretty.to_string "%a%t"
+                       Lsp_data_info_printer.pp_data_definition data_def
+                       pp_documentation)
           else None
         in
         Some (text, hover_loc)
       with Not_found ->
         None
 
-let data_references_on_hover ~rootdir ~textDocument position checked_doc =
+let data_references ~rootdir ~textDocument position checked_doc =
   let context = ReferenceContext.create ~includeDeclaration:true in
   let params = ReferenceParams.create ~context ~position ~textDocument () in
+  Option.map List.length @@
   lookup_references_in_doc ~rootdir params checked_doc
-  |> Option.map List.length
 
 
 let hover_markdown ~filename ~loc value =
@@ -671,11 +678,13 @@ let handle_hover ?always_show_hover_definition_text_in_data_div
     ~f:begin fun ~doc:{ project; artifacts = { pplog; rev_comments; _ }; _ } checked_doc ->
       let rootdir = Lsp_project.(string_of_rootdir @@ rootdir project) in
       let ref_count () =
-        data_references_on_hover ~rootdir ~textDocument:doc position checked_doc
+        data_references ~rootdir ~textDocument:doc position checked_doc
       in
-      match data_definition_on_hover ~uri:doc.uri position checked_doc
-              ?always_show_hover_definition_text_in_data_div ~rev_comments,
-            preproc_info_on_hover ~filename position pplog with
+      match
+        describe_data_definition_at_pos ~uri:doc.uri position checked_doc
+          ?always_show_hover_definition_text_in_data_div ~rev_comments,
+        preproc_info_on_hover ~filename position pplog
+      with
       | None, None ->
           None
       | Some (None, loc), None ->
@@ -778,7 +787,8 @@ let codelens_positions ~uri group =
                                       field_leading_ranges;
                                       field_offset; field_size; field_layout;
                                       field_conditions; field_redefinitions;
-                                      field_length_variability = _ } acc =
+                                      field_length_variability = _;
+                                      field_has_definition_issues = _ } acc =
         ignore(field_redefines, field_leading_ranges, field_offset, field_size);
         skip @@ begin acc
           |> Cobol_ptree.Terms_visitor.fold_qualname'_opt v field_qualname
@@ -788,8 +798,10 @@ let codelens_positions ~uri group =
         end
       method! fold_table_definition { table_field; table_offset; table_size;
                                       table_range; table_init_values;
-                                      table_redefines; table_redefinitions } acc =
-        ignore(table_offset, table_size, table_init_values, table_redefines);
+                                      table_redefines; table_redefinitions;
+                                      table_has_definition_issues } acc =
+        ignore(table_offset, table_size, table_init_values, table_redefines,
+               table_has_definition_issues);
         skip @@ begin acc
           |> fold_field_definition' v table_field
           |> fold_table_range v table_range

--- a/src/lsp/cobol_typeck/typeck_clauses.ml
+++ b/src/lsp/cobol_typeck/typeck_clauses.ml
@@ -238,25 +238,25 @@ let auto_usage diags ~usage_clause picture =
   | Binary ->
       let diags, picture
         = ensure_picture diags ~only:`Numeric_category ~usage_clause picture in
-      diags, Some (Binary picture)
+      diags, Ok (Binary picture)
   | Bit ->
       let diags, picture
         = ensure_picture diags ~only:`Boolean_class ~usage_clause picture in
-      diags, Some (Bit picture)
+      diags, Ok (Bit picture)
   | Display ->
       let diags, picture
         = ensure_picture diags ~only:`Any_class ~usage_clause picture in
-      diags, Some (Display picture)
+      diags, Ok (Display picture)
   | National ->
       let diags, picture
         = ensure_picture diags ~only:`Nonalpha_class ~usage_clause picture in
-      diags, Some (National picture)
+      diags, Ok (National picture)
   | PackedDecimal ->
       let diags, picture
         = ensure_picture diags ~only:`Numeric_category ~usage_clause picture in
-      diags, Some (Packed_decimal { picture; with_sign_nibble = true })
+      diags, Ok (Packed_decimal { picture; with_sign_nibble = true })
   | _ ->
-      diags, None
+      diags, Error None
 
 
 
@@ -293,7 +293,7 @@ let to_usage_n_value ~item_name ~item_loc ~picture_config item_clauses =
   in
   let usage_clause, usage_clause_loc = match item_clauses.usage with
     | Some usage ->
-        ~&usage, Some  ~@usage
+        ~&usage, Some ~@usage
     | None ->                      (* fallback to DISPLAY *)
         Display, None             (* TODO: NATIONAL in case value is a natlit *)
   in
@@ -310,16 +310,16 @@ let to_usage_n_value ~item_name ~item_loc ~picture_config item_clauses =
         auto_usage diags ~usage_clause picture
 
     | BinaryChar s ->
-        diags, Some (Binary_char (signedness s))
+        diags, Ok (Binary_char (signedness s))
 
     | BinaryDouble s ->
-        diags, Some (Binary_double (signedness s))
+        diags, Ok (Binary_double (signedness s))
 
     | BinaryLong s ->
-        diags, Some (Binary_long (signedness s))
+        diags, Ok (Binary_long (signedness s))
 
     | BinaryShort s ->
-        diags, Some (Binary_short (signedness s))
+        diags, Ok (Binary_short (signedness s))
 
     | Bit ->
         auto_usage diags ~usage_clause picture
@@ -327,77 +327,77 @@ let to_usage_n_value ~item_name ~item_loc ~picture_config item_clauses =
     | Display ->
         begin match picture, value with
           | None, None ->
-              diags, None
+              diags, Error None
           | None, Some value ->
-              diags, Some (display_usage_from_literal ~&value)
+              diags, Ok (display_usage_from_literal ~&value)
           | Some _, _ ->
               auto_usage diags ~usage_clause picture
         end
 
     | FloatBinary32 e ->
-        diags, Some (Float_binary { width = `W32;
+        diags, Ok (Float_binary { width = `W32;
                                     endian = endian e })
 
     | FloatBinary64 e ->
-        diags, Some (Float_binary { width = `W64;
+        diags, Ok (Float_binary { width = `W64;
                                     endian = endian e })
 
     | FloatBinary128 e ->
-        diags, Some (Float_binary { width = `W128;
+        diags, Ok (Float_binary { width = `W128;
                                     endian = endian e })
 
     | FloatDecimal16 { endianness_mode = e;
                        encoding_mode = c } ->
-        diags, Some (Float_decimal { width = `W16;
+        diags, Ok (Float_decimal { width = `W16;
                                      endian = endian e;
                                      encoding = encoding c })
 
     | FloatDecimal34 { endianness_mode = e;
                        encoding_mode = c } ->
-        diags, Some (Float_decimal { width = `W34;
+        diags, Ok (Float_decimal { width = `W34;
                                      endian = endian e;
                                      encoding = encoding c })
 
     | FloatExtended ->
-        diags, Some Float_extended
+        diags, Ok Float_extended
 
     | FloatLong ->
-        diags, Some Float_long
+        diags, Ok Float_long
 
     | FloatShort ->
-        diags, Some Float_short
+        diags, Ok Float_short
 
     | FunctionPointer f ->
-        diags, Some (Function_pointer f)
+        diags, Ok (Function_pointer f)
 
     | ProcedurePointer ->
-        diags, Some Procedure_pointer
+        diags, Ok Procedure_pointer
 
     | Index ->                                 (* TODO: check value \in Z (N?) *)
-        diags, Some Index
+        diags, Ok Index
 
     | National -> (* <- TODO: better handling of NATIONAL (partial in GnuCOBOL) *)
         auto_usage diags ~usage_clause picture
 
     | ObjectReference r ->
-        diags, Some (Object_reference r)
+        diags, Ok (Object_reference r)
 
     | PackedDecimal ->
         auto_usage diags ~usage_clause picture
 
     | Pointer p ->
-        diags, Some (Pointer p)
+        diags, Ok (Pointer p)
 
     | ProgramPointer p ->
-        diags, Some (Program_pointer p)
+        diags, Ok (Program_pointer p)
 
     (* TODO: customizable USAGE mapping *)
     | UsagePending `BinaryCLong s ->
-        diags, Some (Binary_C_long (signedness s))
+        diags, Ok (Binary_C_long (signedness s))
     | UsagePending `Comp1 ->
-        diags, Some Float_short
+        diags, Ok Float_short
     | UsagePending `Comp2 ->
-        diags, Some Float_long
+        diags, Ok Float_long
     | UsagePending `Comp3 ->                  (* == Packed_decimal in GnuCOBOL *)
         auto_usage diags ~usage_clause:PackedDecimal picture
 
@@ -405,40 +405,41 @@ let to_usage_n_value ~item_name ~item_loc ~picture_config item_clauses =
         let diags, picture
           = ensure_picture diags ~only:`Numeric_category
             ~usage_clause:PackedDecimal picture in
-        diags, Some (Packed_decimal { picture; with_sign_nibble = false })
+        diags, Ok (Packed_decimal { picture; with_sign_nibble = false })
 
     | Type _
     | UsagePending (`Comp10|`CompN|`Comp5|`Comp0|`Comp15|`CompX|`Comp9) ->
         (* Note: `usage_clause_loc = None` implies `usage_clause = Display`,
            unreachable here. *)
         let usage_clause = usage_clause &@ Option.get usage_clause_loc in
-        data_warning diags @@ Unsupported_usage { usage_clause }, None
+        let warn = Typeck_data_diagnostics.Unsupported_usage { usage_clause } in
+        diags, Error (Some warn)
   in
   let diags = match usage, item_clauses.picture with
     | _, None
-    | None, Some _
-    | Some (Binary _ |
-            Bit _ |
-            Display _ |
-            National _ |
-            Packed_decimal _), Some _ ->
+    | Error _, Some _
+    | Ok (Binary _ |
+          Bit _ |
+          Display _ |
+          National _ |
+          Packed_decimal _), Some _ ->
         diags
-    | Some (Binary_C_long _ |
-            Binary_char _ |
-            Binary_double _ |
-            Binary_long _ |
-            Binary_short _ |
-            Float_binary _ |
-            Float_decimal _ |
-            Float_extended |
-            Float_long |
-            Float_short |
-            Function_pointer _ |
-            Procedure_pointer |
-            Index |
-            Object_reference _ |
-            Pointer _ |
-            Program_pointer _), Some picture ->
+    | Ok (Binary_C_long _ |
+          Binary_char _ |
+          Binary_double _ |
+          Binary_long _ |
+          Binary_short _ |
+          Float_binary _ |
+          Float_decimal _ |
+          Float_extended |
+          Float_long |
+          Float_short |
+          Function_pointer _ |
+          Procedure_pointer |
+          Index |
+          Object_reference _ |
+          Pointer _ |
+          Program_pointer _), Some picture ->
         data_error diags @@
         Unexpected_picture_clause { picture; item_name; item_loc;
                                     reason = `Item_with_usage usage_clause }

--- a/src/lsp/cobol_typeck/typeck_data_items.ml
+++ b/src/lsp/cobol_typeck/typeck_data_items.ml
@@ -20,6 +20,7 @@ open Cobol_common.Srcloc.INFIX
 
 module Visitor = Cobol_common.Visitor
 module Qualmap = Cobol_unit.Qualmap
+module LIST = Cobol_common.Basics.LIST
 module NEL = Cobol_common.Basics.NEL
 module PIC = Cobol_data.Picture
 
@@ -63,6 +64,7 @@ and item_under_construction =               (* item currently being assembled *)
     item_rev_fields: Cobol_data.Types.item_definition with_loc list;
     item_rev_renames: Cobol_data.Types.record_renaming with_loc list;
     item_rev_conditions: Cobol_data.Types.condition_names;
+    item_diagnostics: Typeck_diagnostics.t;
   }
 
 and condition_name_under_construction =
@@ -104,11 +106,14 @@ let init (config: unit_config) =
 let error acc error = { acc with diags = Data_error error :: acc.diags }
 let warn acc d = { acc with diags = Data_warning d :: acc.diags }
 
+let data_error e = Typeck_diagnostics.Data_error e
+let data_warning w = Typeck_diagnostics.Data_warning w
+
 let result { definitions = { data_items; data_records };
              references; diags; _ } : output * Typeck_diagnostics.t =
   { definitions =
-      { data_items = { data_items with list = List.rev data_items.list };
-        data_records = List.rev data_records };
+      { data_items = { data_items with list = LIST.rev data_items.list };
+        data_records = LIST.rev data_records };
     references },
   diags
 
@@ -211,19 +216,19 @@ let commit_record acc ~renamings (record_item: item_definition with_loc) =
             add_anonymous_def (Data_field { record; def })
       end
       ~table:begin fun table acc ->                             (* table indexes *)
-        List.fold_left begin fun acc qualname ->
+        LIST.fold_left begin fun acc qualname ->
           add_named_def qualname (Table_index { record; table; qualname }) acc
         end acc ~&table.table_range.range_indexes
       end
   in
   let data_items =                                      (* add renaming items *)
-    List.fold_left begin fun data_items def ->
+    LIST.fold_left begin fun data_items def ->
       add_named_def ~&def.renaming_name
         (Data_renaming { record; def }) data_items
     end data_items renamings
   in
   let data_items =                                     (* add condition names *)
-    List.fold_left begin fun data_items (def, field) ->
+    LIST.fold_left begin fun data_items (def, field) ->
       (* TODO: [validation] entries have no name.  (The current parse-tree does
          not allow those). *)
       add_named_def ~&def.condition_name_qualname
@@ -252,7 +257,7 @@ let commit_item_definition ~renamings def acc =
 
 
 
-let check_inherited_usage acc ~item_name item_clauses item_stack =
+let check_inherited_usage ~item_name item_clauses item_stack =
   let top_item_usage =
     match item_stack with
     | [] -> None
@@ -272,21 +277,22 @@ let check_inherited_usage acc ~item_name item_clauses item_stack =
   in
   match item_clauses.Typeck_clauses.usage, top_item_usage with
   | _, None ->
-      acc, item_clauses
+      [], item_clauses
   | None, (Some _ as usage) ->
-      acc, { item_clauses with usage }
+      [], { item_clauses with usage }
   | Some u, Some p ->
-      let acc =         (* check matching usage (according to the standard) *)
+      let diags =         (* check matching usage (according to the standard) *)
         if Cobol_ptree.compare_usage_clause ~&u ~&p <> 0 then
-          warn acc @@ Mismatching_usage_in_group { item_name;
-                                                   item_usage = u;
-                                                   group_usage = p }
-        else acc
+          [data_warning @@ Mismatching_usage_in_group { item_name;
+                                                        item_usage = u;
+                                                        group_usage = p }]
+        else
+          []
       in
-      acc, item_clauses
+      diags, item_clauses
 
 
-let item_range acc ~item_qualifier
+let item_range ~item_qualifier
     (item_clauses: Typeck_clauses.data_clauses) (item_stack: item_stack) =
   let qualify_as_subordinate n = qual n item_qualifier &@<- n in
   let qualify n = qualify n item_stack in                         (* CHECKME! *)
@@ -297,13 +303,13 @@ let item_range acc ~item_qualifier
         None
     | Some OccursFixed { times; indexed_by; _ } ->
         Some { range_span = Fixed_span { occurs_times = int times };
-               range_indexes = List.map qualify_as_subordinate indexed_by }
+               range_indexes = LIST.map qualify_as_subordinate indexed_by }
     | Some OccursDepending { from; to_; depending; indexed_by; _ } ->
         let min = match from with Some f -> int f | None -> 1 &@<- to_ in
         Some { range_span = Depending_span { occurs_depending_min = min;
                                              occurs_depending_max = int to_;
                                              occurs_depending = depending };
-               range_indexes = List.map qualify_as_subordinate indexed_by }
+               range_indexes = LIST.map qualify_as_subordinate indexed_by }
     | Some OccursDynamic { capacity_in; from; to_;
                            initialized; indexed_by; _ } ->
         let range_span
@@ -312,7 +318,7 @@ let item_range acc ~item_qualifier
                            occurs_dynamic_capacity_max = opt int to_;
                            occurs_dynamic_initialized = initialized } in
         Some { range_span;
-               range_indexes = List.map qualify_as_subordinate indexed_by }
+               range_indexes = LIST.map qualify_as_subordinate indexed_by }
   in
   let leading_ranges = match range, item_stack with
     | Some r, { item_rev_leading_ranges = l; _ } :: _ -> r :: l
@@ -320,7 +326,7 @@ let item_range acc ~item_qualifier
     | None, { item_rev_leading_ranges = l; _ } :: _ -> l
     | None, [] -> []
   in
-  acc, range, leading_ranges
+  range, leading_ranges
 
 
 let register_field_def acc (def: field_definition with_loc) =
@@ -331,66 +337,85 @@ let register_field_def acc (def: field_definition with_loc) =
   | None -> acc
 
 
-let error_if_picture ~item_name ~item_loc ~reason acc = function
+let error_if_picture ~item_name ~item_loc ~reason = function
   | None ->
-      acc
+      []
   | Some picture ->
-      error acc @@ Unexpected_picture_clause { picture; reason;
-                                               item_name; item_loc }
+      [data_error @@ Unexpected_picture_clause { picture; reason;
+                                                 item_name; item_loc }]
 
 
-let field_usage_n_value acc { item_name; item_loc; item_clauses; _ } =
-  let diags, usage, value =
-    Typeck_clauses.to_usage_n_value item_clauses ~item_name ~item_loc
-      ~picture_config:acc.picture_config
-  in
-  let acc = { acc with diags = Typeck_diagnostics.union acc.diags diags } in
-  acc, usage, value
-
-
-let field_layout_n_size acc ~usage ~init_value { item_name;
-                                                 item_loc;
-                                                 item_size;
-                                                 item_clauses;
-                                                 item_rev_fields; _ } =
+let field_layout_n_size ~usage ~init_value { item_name;
+                                             item_loc;
+                                             item_size;
+                                             item_clauses;
+                                             item_rev_fields; _ } =
   match item_rev_fields, usage with
-  | [], Some usage ->
-      acc,
+  | [], Ok usage ->
+      [],
       Elementary_field { usage; init_value },
       Typeck_utils.size_of ~usage
-  | [], None ->          (* missing usage (reported as missing pic string) *)
-      error acc @@
-      Missing_picture_clause_for_elementary_item { item_name; item_loc },
+  | [], Error Some diag ->                                    (* missing usage *)
+      [data_warning diag],
+      Elementary_field { usage = Display (PIC.alphanumeric ~size:1);
+                         init_value = None },
+      Cobol_data.Memory.byte_size
+  | [], Error None ->        (* missing usage (reported as missing pic string) *)
+      [data_error @@
+       Missing_picture_clause_for_elementary_item { item_name; item_loc }],
       Elementary_field { usage = Display (PIC.alphanumeric ~size:1);
                          init_value = None },
       Cobol_data.Memory.byte_size
   | flds, _ ->
-      error_if_picture ~item_name ~item_loc ~reason:`Group_item acc
+      error_if_picture ~item_name ~item_loc ~reason:`Group_item
         item_clauses.picture,
       Struct_field { subfields = NEL.of_rev_list flds },
       item_size                (* accumulated during commits of subfields *)
 
 
-let item_definition acc ({ item_loc;
+let subitem_fields_have_issues { item_rev_fields; _ } =
+  LIST.exists begin fun f -> match ~&f with
+    | Field { field_has_definition_issues; _ } -> field_has_definition_issues
+    | Table _ -> false
+  end item_rev_fields
+
+
+let item_definition acc ({ item_name;
+                           item_loc;
+                           item_clauses;
                            item_qualname;
                            item_redefines;
                            item_offset;
                            item_range;
                            item_rev_leading_ranges;
-                           item_rev_conditions; _ } as item) =
-  let acc, usage, init_value = field_usage_n_value acc item in
-  let acc, field_layout, field_size =
-    field_layout_n_size acc item ~usage ~init_value in
+                           item_rev_conditions;
+                           item_diagnostics; _ } as item) =
+  let diags, usage, init_value =
+    Typeck_clauses.to_usage_n_value item_clauses ~item_name ~item_loc
+      ~picture_config:acc.picture_config
+  in
+  let diags', field_layout, field_size =
+    field_layout_n_size item ~usage ~init_value
+  in
+  let item_diagnostics =
+    LIST.append ~loc:__LOC__ diags @@
+    LIST.append ~loc:__LOC__ diags' item_diagnostics in
+  let definition_issues =
+    item_diagnostics <> [] || subitem_fields_have_issues item
+  in
   let field =
     { field_qualname = item_qualname;
       field_redefines = None;
-      field_leading_ranges = List.rev item_rev_leading_ranges;
+      field_leading_ranges = LIST.rev item_rev_leading_ranges;
       field_layout;
       field_offset = item_offset;
       field_size;
       field_length_variability = Fixed_length;
-      field_conditions = List.rev item_rev_conditions;
-      field_redefinitions = [] } &@ item_loc
+      field_conditions = LIST.rev item_rev_conditions;
+      field_redefinitions = [];
+      field_has_definition_issues = definition_issues } &@ item_loc
+  and acc =
+    { acc with diags = Typeck_diagnostics.union acc.diags item_diagnostics }
   in
   match item_range with
   | None ->
@@ -408,7 +433,8 @@ let item_definition acc ({ item_loc;
               table_range = range;
               table_init_values = [];
               table_redefines = item_redefines;
-              table_redefinitions = [] } &@<- field
+              table_redefinitions = [];
+              table_has_definition_issues = definition_issues } &@<- field
   | Some ({ range_span = Depending_span { occurs_depending; _ }; _ } as range) ->
       let dep_size = Cobol_data.Memory.valof ~&occurs_depending in
       let table_size
@@ -420,7 +446,8 @@ let item_definition acc ({ item_loc;
               table_range = range;
               table_init_values = [];
               table_redefines = item_redefines;
-              table_redefinitions = [] } &@<- field
+              table_redefinitions = [];
+              table_has_definition_issues = definition_issues } &@<- field
   | Some ({ range_span = Dynamic_span _; _ } as range) ->
       register_field_def acc field,
       Table { table_field = field;
@@ -429,14 +456,15 @@ let item_definition acc ({ item_loc;
               table_range = range;
               table_init_values = [];
               table_redefines = item_redefines;
-              table_redefinitions = [] } &@<- field
+              table_redefinitions = [];
+              table_has_definition_issues = definition_issues } &@<- field
 
 
 let commit_conditions acc def { item_rev_conditions; _ } =
   match ~&def with
   | Field field ->
       let pending_conditions =
-        List.fold_left begin fun pcs cond_name ->
+        LIST.fold_left begin fun pcs cond_name ->
           (cond_name, field &@<- def) :: pcs
         end acc.pending_conditions item_rev_conditions
       in
@@ -446,11 +474,11 @@ let commit_conditions acc def { item_rev_conditions; _ } =
 
 
 let item_definitions acc items =
-  List.fold_left begin fun (acc, rev_defs, renamings) item ->
+  LIST.fold_left begin fun (acc, rev_defs, renamings) item ->
     let acc, def = item_definition acc item in
     commit_conditions acc def item,
     def :: rev_defs,
-    List.rev_append item.item_rev_renames renamings
+    LIST.rev_append item.item_rev_renames renamings
   end (acc, [], []) items
 
 
@@ -562,7 +590,7 @@ let on_redefinition_item acc item_clauses
                                          table_item_name = redefined_qualname }
       in
       let acc =
-        List.fold_left begin fun acc field_def ->
+        LIST.fold_left begin fun acc field_def ->
           match ~&field_def with
           | Field { field_length_variability = Variable_length; _ }
           | Table { table_range = { range_span = Depending_span _; _ }; _ }
@@ -579,13 +607,13 @@ let on_redefinition_item acc item_clauses
               acc                                                       (* ok *)
         end acc redefined_item.item_rev_fields
       in
-      let acc, item_clauses =
-        check_inherited_usage acc ~item_name item_clauses base_stack
+      let item_diagnostics, item_clauses =
+        check_inherited_usage ~item_name item_clauses base_stack
       and item_qualname = qualname item_name base_stack
       and item_qualifier = qualifier item_name base_stack
       and item_redefines = Some (qualify redefined_name base_stack) in
-      let acc, item_range, item_rev_leading_ranges =
-        item_range acc ~item_qualifier item_clauses base_stack in
+      let item_range, item_rev_leading_ranges =
+        item_range ~item_qualifier item_clauses base_stack in
       { acc with                            (* push on stack, with same level *)
         item_stack = { item_level = expected_level;
                        item_name;
@@ -600,7 +628,8 @@ let on_redefinition_item acc item_clauses
                        item_rev_leading_ranges;
                        item_rev_fields = [];
                        item_rev_renames = [];
-                       item_rev_conditions = [] } :: acc.item_stack }
+                       item_rev_conditions = [];
+                       item_diagnostics } :: acc.item_stack }
 
 
 let on_item acc ~at_level
@@ -609,9 +638,7 @@ let on_item acc ~at_level
                               data_clauses }; loc }
   =
   let item_clauses = Typeck_clauses.of_data_item data_clauses in
-  let acc =
-    { acc with
-      diags = Typeck_diagnostics.union acc.diags item_clauses.clause_diags } in
+  let item_diagnostics = item_clauses.clause_diags in
   match item_clauses.redefines with
   | Some redefined_name ->
       on_redefinition_item acc item_clauses
@@ -628,12 +655,15 @@ let on_item acc ~at_level
         | _ ->
             acc
       in
-      let acc, item_clauses =
-        check_inherited_usage ~item_name acc item_clauses base_stack
+      let item_diagnostics', item_clauses =
+        check_inherited_usage ~item_name item_clauses base_stack
       and item_qualname = qualname item_name base_stack
       and item_qualifier = qualifier item_name base_stack in
-      let acc, item_range, item_rev_leading_ranges =
-        item_range acc ~item_qualifier item_clauses base_stack in
+      let item_range, item_rev_leading_ranges =
+        item_range ~item_qualifier item_clauses base_stack in
+      let item_diagnostics =
+        LIST.append ~loc:__LOC__ item_diagnostics item_diagnostics'
+      in
       { acc with
         item_stack = { item_level = ~&data_level;
                        item_name;
@@ -648,7 +678,8 @@ let on_item acc ~at_level
                        item_rev_leading_ranges;
                        item_rev_fields = [];
                        item_rev_renames = [];
-                       item_rev_conditions = [] } :: base_stack }
+                       item_rev_conditions = [];
+                       item_diagnostics } :: base_stack }
 
 
 let dummy_renamed_elementary =

--- a/src/lsp/cobol_typeck/typeck_data_items.ml
+++ b/src/lsp/cobol_typeck/typeck_data_items.ml
@@ -106,6 +106,8 @@ let init (config: unit_config) =
 let error acc error = { acc with diags = Data_error error :: acc.diags }
 let warn acc d = { acc with diags = Data_warning d :: acc.diags }
 
+let data_errors acc l = List.fold_left error acc l
+
 let data_error e = Typeck_diagnostics.Data_error e
 let data_warning w = Typeck_diagnostics.Data_warning w
 
@@ -538,7 +540,7 @@ let find_in_current_record qualname acc =
     let res = Qualmap.find ~&qualname acc.current_qualmap in
     Ok (register_ref ~from:qualname ~to_:~&res.field_qualname acc, res)
   with Not_found ->
-    Error (error acc @@ Item_not_found { qualname })
+    Error (Typeck_data_diagnostics.Item_not_found { qualname })
 
 
 (* --- *)
@@ -700,13 +702,14 @@ let renaming acc
                               rename_from = from;
                               rename_thru = thru; _ };
       loc } =
+  let open Typeck_data_diagnostics in
   let renaming_name = qual name renaming_qualifier &@<- name in
   let from = requal ~&from renaming_qualifier &@<- from in
   let acc, from_item = match find_in_current_record from acc with
     | Ok (acc, def) ->
         report_occurs acc from def, Some def
-    | Error acc ->
-        acc, None
+    | Error diag ->
+        error acc diag, None
   in
   let acc, thru_item_n_name = match thru with
     | None ->
@@ -715,56 +718,58 @@ let renaming acc
         let thru = requal ~&thru renaming_qualifier &@<- thru in
         match find_in_current_record thru acc with
         | Ok (acc, def) ->
-            report_occurs acc thru def, Some (def, thru)
-        | Error acc ->
-            acc, None
+            report_occurs acc thru def, Some (Ok (def, thru))
+        | Error diag ->
+            error acc diag, Some (Error ())
   in
   match from_item, thru_item_n_name with
   | None, _ ->
       Error acc
-  | Some from_field, None ->
+  | Some from_field, (None | Some Error ()) ->
       let renaming_layout = match ~&from_field.field_layout with
         | Elementary_field { usage; _ } -> Renamed_elementary { usage }
         | Struct_field { subfields } -> Renamed_struct { subfields }
       in
+      let ko = thru_item_n_name = Some (Error ()) in
       Ok (acc, { renaming_name;
                  renaming_layout;
                  renaming_offset = ~&from_field.field_offset;
                  renaming_size = ~&from_field.field_size;
                  renaming_from = from;
-                 renaming_thru = None } &@ loc)
-  | Some from_field, Some (thru_field, thru_name) ->
+                 renaming_thru = None;
+                 renaming_has_definition_issues = ko } &@ loc)
+  | Some from_field, Some Ok (thru_field, thru_name) ->
       let from_offset = ~&from_field.field_offset
       and thru_offset = ~&thru_field.field_offset
       and thru_size = ~&thru_field.field_size in
       let end_ = Cobol_data.Memory.shift thru_offset ~by:thru_size in
       let size_ = Cobol_data.Memory.size ~from:from_offset ~to_:end_ in
-      let acc, renaming_layout =
+      let diags, renaming_layout =
         try
           let bits = Cobol_data.Memory.as_bits size_ in
           let size = bits / 8 in
           if size > 0 && bits mod 8 = 0 then
-            acc, Renamed_elementary { usage = Display (PIC.alphanumeric ~size) }
+            [], Renamed_elementary { usage = Display (PIC.alphanumeric ~size) }
           else if size > 0 then
-            error acc @@ Invalid_renaming_size { loc; from_field; thru_field;
-                                                 bits },
+            [Invalid_renaming_size { loc; from_field; thru_field; bits }],
             Renamed_elementary { usage = Display (PIC.alphanumeric ~size) }
           else
-            error acc @@ Invalid_renaming_range { loc; from_field; thru_field },
+            [Invalid_renaming_range { loc; from_field; thru_field }],
             dummy_renamed_elementary
         with Cobol_data.Memory.NOT_SCALAR (`Vars vars) ->
           let depending_vars =
             NEL.map vars ~f:(fun (Cobol_data.Memory.Valof qn) -> qn) in
-          error acc @@
-          Invalid_renaming_of_variable_length_range { loc; depending_vars },
+          [Invalid_renaming_of_variable_length_range { loc; depending_vars }],
           dummy_renamed_elementary
       in
-      Ok (acc, { renaming_name;
-                 renaming_layout;
-                 renaming_offset = from_offset;
-                 renaming_size = size_;
-                 renaming_from = from;
-                 renaming_thru = Some thru_name } &@ loc)
+      Ok (data_errors acc diags,
+          { renaming_name;
+            renaming_layout;
+            renaming_offset = from_offset;
+            renaming_size = size_;
+            renaming_from = from;
+            renaming_thru = Some thru_name;
+            renaming_has_definition_issues = diags <> [] } &@ loc)
 
 
 let on_rename ({ loc; _ } as rename_item) acc =

--- a/test/cobol_typeck/ko_renames.ml
+++ b/test/cobol_typeck/ko_renames.ml
@@ -13,7 +13,7 @@
 
 open Prog_printer
 
-let dotest = Typeck_testing.show_diagnostics
+let dotest = Typeck_testing.show_data
 
 let%expect_test "renames-errors-1" =
   dotest @@ prog "renames-error-1"
@@ -73,6 +73,193 @@ let%expect_test "renames-errors-1" =
       15
     >> Error: Invalid pair of RENAMES operands: first field B-3 IN B should
               precede second field B-2 IN B
+
+    prog.cob:4.7-9.27:
+       1          PROGRAM-ID. renames-error-1.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        01 B.
+    ----          ^^^^^
+       5 >          02 B-1 PIC 9 OCCURS 5 TIMES.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       6 >          02 B-2 PIC 9.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^
+       7 >          02 B-3 PIC 9.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^
+       8 >          02 B-4 OCCURS 5 TIMES.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       9 >            03 FILLER PIC X.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      10          66 B-R1 RENAMES B-1. *> should error
+      11          66 B-R2 RENAMES B-1 THRU B-2. *> should error
+    Item definition: {
+      qualname: B
+      offset: 0
+      size: 96
+      layout: {
+        structure
+        fields: {
+          table
+          offset: 0
+          size: 40
+          range: {
+            span: fixed-length: 5
+          }
+          field: {
+            qualname: B-1 IN B
+            leading ranges: 1
+            offset: 0
+            size: 8
+            layout: {
+              elementary
+              usage: {
+                display
+                category: NUMERIC(digits = 1, scale = 0, sign = unsigned)
+              }
+            }
+          }
+        }{
+          qualname: B-2 IN B
+          offset: 40
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: NUMERIC(digits = 1, scale = 0, sign = unsigned)
+            }
+          }
+        }{
+          qualname: B-3 IN B
+          offset: 48
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: NUMERIC(digits = 1, scale = 0, sign = unsigned)
+            }
+          }
+        }{
+          table
+          offset: 56
+          size: 40
+          range: {
+            span: fixed-length: 5
+          }
+          field: {
+            qualname: B-4 IN B
+            leading ranges: 1
+            offset: 56
+            size: 8
+            layout: {
+              structure
+              fields: {
+                filler
+                leading ranges: 1
+                offset: 56
+                size: 8
+                layout: {
+                  elementary
+                  usage: {
+                    display
+                    category: ALPHANUMERIC(1)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    prog.cob:10.7-10.27:
+       7            02 B-3 PIC 9.
+       8            02 B-4 OCCURS 5 TIMES.
+       9              03 FILLER PIC X.
+      10 >        66 B-R1 RENAMES B-1. *> should error
+    ----          ^^^^^^^^^^^^^^^^^^^^
+      11          66 B-R2 RENAMES B-1 THRU B-2. *> should error
+      12          66 B-R3 RENAMES B-3 THRU B-4. *> should error
+    Record renaming: {
+      qualname: B-R1 IN B
+      from: B-1 IN B
+      offset: 0
+      size: 8
+      layout: {
+        elementary
+        usage: {
+          display
+          category: NUMERIC(digits = 1, scale = 0, sign = unsigned)
+        }
+      }
+    }
+    prog.cob:11.7-11.36:
+       8            02 B-4 OCCURS 5 TIMES.
+       9              03 FILLER PIC X.
+      10          66 B-R1 RENAMES B-1. *> should error
+      11 >        66 B-R2 RENAMES B-1 THRU B-2. *> should error
+    ----          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      12          66 B-R3 RENAMES B-3 THRU B-4. *> should error
+      13          66 B-R4 RENAMES B-3 THRU B-2. *> should error
+    Record renaming: {
+      qualname: B-R2 IN B
+      from: B-1 IN B
+      thru: B-2 IN B
+      offset: 0
+      size: 48
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(6)
+        }
+      }
+    }
+    prog.cob:12.7-12.36:
+       9              03 FILLER PIC X.
+      10          66 B-R1 RENAMES B-1. *> should error
+      11          66 B-R2 RENAMES B-1 THRU B-2. *> should error
+      12 >        66 B-R3 RENAMES B-3 THRU B-4. *> should error
+    ----          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      13          66 B-R4 RENAMES B-3 THRU B-2. *> should error
+      14          PROCEDURE DIVISION.
+    Record renaming: {
+      qualname: B-R3 IN B
+      from: B-3 IN B
+      thru: B-4 IN B
+      offset: 48
+      size: 16
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(2)
+        }
+      }
+    }
+    prog.cob:13.7-13.36:
+      10          66 B-R1 RENAMES B-1. *> should error
+      11          66 B-R2 RENAMES B-1 THRU B-2. *> should error
+      12          66 B-R3 RENAMES B-3 THRU B-4. *> should error
+      13 >        66 B-R4 RENAMES B-3 THRU B-2. *> should error
+    ----          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      14          PROCEDURE DIVISION.
+      15
+    Record renaming: {
+      qualname: B-R4 IN B
+      /!\ with_errors /!\
+      from: B-3 IN B
+      thru: B-2 IN B
+      offset: 48
+      size: 0
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(0)
+        }
+      }
+    }
   |}];;
 
 
@@ -106,6 +293,101 @@ let%expect_test "renames-missing-target" =
       10          PROCEDURE DIVISION.
       11
     >> Error: Item 'B3 IN B' not found
+
+    prog.cob:4.7-4.33:
+       1          PROGRAM-ID. renames-missing-target.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        01 A PIC X OCCURS 5 TIMES.
+    ----          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       5          66 A-R1 RENAMES A.
+       6          01 B.
+    Item definition: {
+      table
+      offset: 0
+      size: 40
+      range: {
+        span: fixed-length: 5
+      }
+      field: {
+        qualname: A
+        leading ranges: 1
+        offset: 0
+        size: 8
+        layout: {
+          elementary
+          usage: {
+            display
+            category: ALPHANUMERIC(1)
+          }
+        }
+      }
+    }
+    prog.cob:6.7-8.21:
+       3          WORKING-STORAGE SECTION.
+       4          01 A PIC X OCCURS 5 TIMES.
+       5          66 A-R1 RENAMES A.
+       6 >        01 B.
+    ----          ^^^^^
+       7 >          02 B1 PIC X.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^
+       8 >          02 B2 PIC X.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^
+       9            66 BR RENAMES B1 THRU B3.
+      10          PROCEDURE DIVISION.
+    Item definition: {
+      qualname: B
+      offset: 0
+      size: 16
+      layout: {
+        structure
+        fields: {
+          qualname: B1 IN B
+          offset: 0
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: ALPHANUMERIC(1)
+            }
+          }
+        }{
+          qualname: B2 IN B
+          offset: 8
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: ALPHANUMERIC(1)
+            }
+          }
+        }
+      }
+    }
+    prog.cob:9.9-9.34:
+       6          01 B.
+       7            02 B1 PIC X.
+       8            02 B2 PIC X.
+       9 >          66 BR RENAMES B1 THRU B3.
+    ----            ^^^^^^^^^^^^^^^^^^^^^^^^^
+      10          PROCEDURE DIVISION.
+      11
+    Record renaming: {
+      qualname: BR IN B
+      /!\ with_errors /!\
+      from: B1 IN B
+      offset: 0
+      size: 8
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(1)
+        }
+      }
+    }
   |}];;
 
 let%expect_test "renames-errors-invalid-sizes" =
@@ -125,4 +407,71 @@ let%expect_test "renames-errors-invalid-sizes" =
     ----            ^^^^^^^^^^^^^^^^^^^^^^
        8          PROCEDURE DIVISION.
        9
-    >> Error: Invalid range of 9 bits between RENAMES operands |}];;
+    >> Error: Invalid range of 9 bits between RENAMES operands
+
+    prog.cob:4.7-6.30:
+       1          PROGRAM-ID. renames-errors-invalid-sizes.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        01 FILLER.
+    ----          ^^^^^^^^^^
+       5 >          02 A PIC X.
+    ----  ^^^^^^^^^^^^^^^^^^^^^
+       6 >          02 B PIC 1 USAGE BIT.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       7            66 C RENAMES A THRU B. *> should error
+       8          PROCEDURE DIVISION.
+    Item definition: {
+      filler
+      offset: 0
+      size: 9
+      layout: {
+        structure
+        fields: {
+          qualname: A
+          offset: 0
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: ALPHANUMERIC(1)
+            }
+          }
+        }{
+          qualname: B
+          offset: 8
+          size: 1
+          layout: {
+            elementary
+            usage: {
+              bit
+              category: BOOLEAN(1)
+            }
+          }
+        }
+      }
+    }
+    prog.cob:7.9-7.31:
+       4          01 FILLER.
+       5            02 A PIC X.
+       6            02 B PIC 1 USAGE BIT.
+       7 >          66 C RENAMES A THRU B. *> should error
+    ----            ^^^^^^^^^^^^^^^^^^^^^^
+       8          PROCEDURE DIVISION.
+       9
+    Record renaming: {
+      qualname: C
+      /!\ with_errors /!\
+      from: A
+      thru: B
+      offset: 0
+      size: 9
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(1)
+        }
+      }
+    } |}];;

--- a/test/cobol_typeck/ko_usage.ml
+++ b/test/cobol_typeck/ko_usage.ml
@@ -13,7 +13,7 @@
 
 open Prog_printer
 
-let dotest = Typeck_testing.show_diagnostics
+let dotest = Typeck_testing.show_data
 
 let%expect_test "mismatching-subordinate-usage" =
   dotest @@ prog "mismatching-subordinate-usage"
@@ -41,7 +41,40 @@ let%expect_test "mismatching-subordinate-usage" =
     ----            ^^^^^^^^^^^^^^^^^^^
        6          PROCEDURE DIVISION.
        7
-    >> Error: Missing PICTURE clause for item 'X' |}];;
+    >> Error: Missing PICTURE clause for item 'X'
+
+    prog.cob:4.7-5.28:
+       1          PROGRAM-ID. mismatching-subordinate-usage.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        01 FILLER BINARY.
+    ----          ^^^^^^^^^^^^^^^^^
+       5 >          02 X USAGE DISPLAY.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       6          PROCEDURE DIVISION.
+       7
+    Item definition: {
+      filler
+      /!\ with_errors /!\
+      offset: 0
+      size: 8
+      layout: {
+        structure
+        fields: {
+          qualname: X
+          /!\ with_errors /!\
+          offset: 0
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: ALPHANUMERIC(1)
+            }
+          }
+        }
+      }
+    } |}];;
 
 
 let%expect_test "pic-on-wrong-usage" =
@@ -70,4 +103,237 @@ let%expect_test "pic-on-wrong-usage" =
     ----                 ^^^^^^^^
        7          PROCEDURE DIVISION.
        8
-    >> Error: Unexpected PICTURE clause for item 'B' with USAGE INDEX |}];;
+    >> Error: Unexpected PICTURE clause for item 'B' with USAGE INDEX
+
+    prog.cob:4.7-4.25:
+       1          PROGRAM-ID. pic-on-wrong-usage.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        77 A PIC 99 INDEX.
+    ----          ^^^^^^^^^^^^^^^^^^
+       5          01 FILLER INDEX.
+       6            02 B PIC X(4).
+    Item definition: {
+      qualname: A
+      /!\ with_errors /!\
+      offset: 0
+      size: size-of-index
+      layout: {
+        elementary
+        usage: index
+      }
+    }
+    prog.cob:5.7-6.23:
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4          77 A PIC 99 INDEX.
+       5 >        01 FILLER INDEX.
+    ----          ^^^^^^^^^^^^^^^^
+       6 >          02 B PIC X(4).
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^
+       7          PROCEDURE DIVISION.
+       8
+    Item definition: {
+      filler
+      /!\ with_errors /!\
+      offset: 0
+      size: size-of-index
+      layout: {
+        structure
+        fields: {
+          qualname: B
+          /!\ with_errors /!\
+          offset: 0
+          size: size-of-index
+          layout: {
+            elementary
+            usage: index
+          }
+        }
+      }
+    } |}];;
+
+
+let%expect_test "unsupported-usage" =
+  dotest @@ prog "unsupported-usage"
+    ~working_storage:{|
+       77 A COMP-X.
+       01 B.
+         02 FILLER COMP-X.
+       01 C.
+         02 D COMP-0 OCCURS 10.
+      *> CHECKME: Here it's unclear whether F's error flag should propagate to E.
+       01 E PIC X.
+       01 F COMP-X REDEFINES E.
+    |};
+  [%expect {|
+    prog.cob:4.12-4.18:
+       1          PROGRAM-ID. unsupported-usage.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        77 A COMP-X.
+    ----               ^^^^^^
+       5          01 B.
+       6            02 FILLER COMP-X.
+    >> Warning: Unsupported USAGE COMP-X
+
+    prog.cob:6.19-6.25:
+       3          WORKING-STORAGE SECTION.
+       4          77 A COMP-X.
+       5          01 B.
+       6 >          02 FILLER COMP-X.
+    ----                      ^^^^^^
+       7          01 C.
+       8            02 D COMP-0 OCCURS 10.
+    >> Warning: Unsupported USAGE COMP-X
+
+    prog.cob:8.14-8.20:
+       5          01 B.
+       6            02 FILLER COMP-X.
+       7          01 C.
+       8 >          02 D COMP-0 OCCURS 10.
+    ----                 ^^^^^^
+       9         *> CHECKME: Here it's unclear whether F's error flag should propagate to E.
+      10          01 E PIC X.
+    >> Warning: Unsupported USAGE COMP-0
+
+    prog.cob:11.12-11.18:
+       8            02 D COMP-0 OCCURS 10.
+       9         *> CHECKME: Here it's unclear whether F's error flag should propagate to E.
+      10          01 E PIC X.
+      11 >        01 F COMP-X REDEFINES E.
+    ----               ^^^^^^
+      12          PROCEDURE DIVISION.
+      13
+    >> Warning: Unsupported USAGE COMP-X
+
+    prog.cob:4.7-4.19:
+       1          PROGRAM-ID. unsupported-usage.
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4 >        77 A COMP-X.
+    ----          ^^^^^^^^^^^^
+       5          01 B.
+       6            02 FILLER COMP-X.
+    Item definition: {
+      qualname: A
+      /!\ with_errors /!\
+      offset: 0
+      size: 8
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(1)
+        }
+      }
+    }
+    prog.cob:5.7-6.26:
+       2          DATA DIVISION.
+       3          WORKING-STORAGE SECTION.
+       4          77 A COMP-X.
+       5 >        01 B.
+    ----          ^^^^^
+       6 >          02 FILLER COMP-X.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       7          01 C.
+       8            02 D COMP-0 OCCURS 10.
+    Item definition: {
+      qualname: B
+      /!\ with_errors /!\
+      offset: 0
+      size: 8
+      layout: {
+        structure
+        fields: {
+          filler
+          /!\ with_errors /!\
+          offset: 0
+          size: 8
+          layout: {
+            elementary
+            usage: {
+              display
+              category: ALPHANUMERIC(1)
+            }
+          }
+        }
+      }
+    }
+    prog.cob:7.7-8.31:
+       4          77 A COMP-X.
+       5          01 B.
+       6            02 FILLER COMP-X.
+       7 >        01 C.
+    ----          ^^^^^
+       8 >          02 D COMP-0 OCCURS 10.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       9         *> CHECKME: Here it's unclear whether F's error flag should propagate to E.
+      10          01 E PIC X.
+    Item definition: {
+      qualname: C
+      offset: 0
+      size: 80
+      layout: {
+        structure
+        fields: {
+          table
+          /!\ with_errors /!\
+          offset: 0
+          size: 80
+          range: {
+            span: fixed-length: 10
+          }
+          field: {
+            qualname: D IN C
+            /!\ with_errors /!\
+            leading ranges: 1
+            offset: 0
+            size: 8
+            layout: {
+              elementary
+              usage: {
+                display
+                category: ALPHANUMERIC(1)
+              }
+            }
+          }
+        }
+      }
+    }
+    prog.cob:10.7-11.31:
+       7          01 C.
+       8            02 D COMP-0 OCCURS 10.
+       9         *> CHECKME: Here it's unclear whether F's error flag should propagate to E.
+      10 >        01 E PIC X.
+    ----          ^^^^^^^^^^^
+      11 >        01 F COMP-X REDEFINES E.
+    ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      12          PROCEDURE DIVISION.
+      13
+    Item definition: {
+      qualname: E
+      offset: 0
+      size: 8
+      layout: {
+        elementary
+        usage: {
+          display
+          category: ALPHANUMERIC(1)
+        }
+      }
+      redefs: {
+        qualname: F
+        /!\ with_errors /!\
+        redefines: E
+        offset: 0
+        size: 8
+        layout: {
+          elementary
+          usage: {
+            display
+            category: ALPHANUMERIC(1)
+          }
+        }
+      }
+    } |}];;

--- a/test/lsp/lsp_hover.ml
+++ b/test/lsp/lsp_hover.ml
@@ -908,13 +908,14 @@ let%expect_test "hover-datadef-renames" =
           05 YY PIC XX.
           66 Z_|_ R_|_ENAMES _|_Y.
           66 Y-THRU-YY_|_ RENAMES Y THRU YY.
+          66 Y-THRU-_|_MISSING RENAMES Y THRU MISSING.
         PROCEDURE DIVISION.
             DISPLAY _|_Z.
             STOP RUN.
     |cobol};
   end_with_postproc [%expect.output];
   [%expect {|
-    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    {"params":{"diagnostics":[{"message":"Item 'MISSING IN X' not found","range":{"end":{"character":50,"line":10},"start":{"character":43,"line":10}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     (line 8, character 14):
     __rootdir__/prog.cob:9.13-9.14:
        6           01 X.
@@ -923,7 +924,7 @@ let%expect_test "hover-datadef-renames" =
        9 >           66 Z RENAMES Y.
     ----                ^
       10             66 Y-THRU-YY RENAMES Y THRU YY.
-      11           PROCEDURE DIVISION.
+      11             66 Y-THRU-MISSING RENAMES Y THRU MISSING.
     ```cobol
     Z IN X
     RENAMES Y IN X
@@ -943,7 +944,7 @@ let%expect_test "hover-datadef-renames" =
        9 >           66 Z RENAMES Y.
     ----             ^^^^^^^^^^^^^^^
       10             66 Y-THRU-YY RENAMES Y THRU YY.
-      11           PROCEDURE DIVISION.
+      11             66 Y-THRU-MISSING RENAMES Y THRU MISSING.
     ```cobol
     Z IN X
     RENAMES Y IN X
@@ -963,7 +964,7 @@ let%expect_test "hover-datadef-renames" =
        9 >           66 Z RENAMES Y.
     ----                          ^
       10             66 Y-THRU-YY RENAMES Y THRU YY.
-      11           PROCEDURE DIVISION.
+      11             66 Y-THRU-MISSING RENAMES Y THRU MISSING.
     ```cobol
     Y IN X
     ```
@@ -973,7 +974,7 @@ let%expect_test "hover-datadef-renames" =
     NUMERIC(digits = 1, scale = 0, sign = unsigned)
     *e.g,* [`0`] (0), [`1`] (1)
     ---
-    References: 3
+    References: 4
     (line 9, character 22):
     __rootdir__/prog.cob:10.13-10.22:
        7             05 Y PIC 9.
@@ -981,8 +982,8 @@ let%expect_test "hover-datadef-renames" =
        9             66 Z RENAMES Y.
       10 >           66 Y-THRU-YY RENAMES Y THRU YY.
     ----                ^^^^^^^^^
-      11           PROCEDURE DIVISION.
-      12               DISPLAY Z.
+      11             66 Y-THRU-MISSING RENAMES Y THRU MISSING.
+      12           PROCEDURE DIVISION.
     ```cobol
     Y-THRU-YY IN X
     RENAMES Y IN X
@@ -994,15 +995,29 @@ let%expect_test "hover-datadef-renames" =
     ALPHANUMERIC(3)
     ---
     References: 1
-    (line 11, character 20):
-    __rootdir__/prog.cob:12.20-12.21:
+    (line 10, character 20):
+    __rootdir__/prog.cob:11.13-11.27:
+       8             05 YY PIC XX.
        9             66 Z RENAMES Y.
       10             66 Y-THRU-YY RENAMES Y THRU YY.
-      11           PROCEDURE DIVISION.
-      12 >             DISPLAY Z.
+      11 >           66 Y-THRU-MISSING RENAMES Y THRU MISSING.
+    ----                ^^^^^^^^^^^^^^
+      12           PROCEDURE DIVISION.
+      13               DISPLAY Z.
+    ```cobol
+    Y-THRU-MISSING IN X
+    ```
+    ---
+    References: 1
+    (line 12, character 20):
+    __rootdir__/prog.cob:13.20-13.21:
+      10             66 Y-THRU-YY RENAMES Y THRU YY.
+      11             66 Y-THRU-MISSING RENAMES Y THRU MISSING.
+      12           PROCEDURE DIVISION.
+      13 >             DISPLAY Z.
     ----                       ^
-      13               STOP RUN.
-      14
+      14               STOP RUN.
+      15
     ```cobol
     Z IN X
     RENAMES Y IN X

--- a/test/lsp/lsp_hover.ml
+++ b/test/lsp/lsp_hover.ml
@@ -483,12 +483,13 @@ let%expect_test "hover-datadef-vars-usage" =
         01 _|_VAR9 PIC $++/+.+B+.
         01 _|_VARL PIC L9 DEPENDING ON VAR1.
         01 _|_VAR10 PIC 99 USAGE COMP-0.
+        01 _|_VAR11.
         PROCEDURE DIVISION.
           STOP RUN.
     |cobol};
   end_with_postproc [%expect.output];
   [%expect {|
-    {"params":{"diagnostics":[{"message":"Unsupported USAGE COMP-0","range":{"end":{"character":36,"line":14},"start":{"character":24,"line":14}},"severity":2}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    {"params":{"diagnostics":[{"message":"Missing PICTURE clause for item 'VAR11'","range":{"end":{"character":17,"line":15},"start":{"character":8,"line":15}},"severity":1},{"message":"Unsupported USAGE COMP-0","range":{"end":{"character":36,"line":14},"start":{"character":24,"line":14}},"severity":2}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     (line 5, character 11):
     __rootdir__/prog.cob:6.11-6.14:
        3           PROGRAM-ID. prog.
@@ -640,7 +641,7 @@ let%expect_test "hover-datadef-vars-usage" =
       14 >         01 VARL PIC L9 DEPENDING ON VAR1.
     ----              ^^^^
       15           01 VAR10 PIC 99 USAGE COMP-0.
-      16           PROCEDURE DIVISION.
+      16           01 VAR11.
     ```cobol
     VARL
     ```
@@ -657,15 +658,27 @@ let%expect_test "hover-datadef-vars-usage" =
       14           01 VARL PIC L9 DEPENDING ON VAR1.
       15 >         01 VAR10 PIC 99 USAGE COMP-0.
     ----              ^^^^^
-      16           PROCEDURE DIVISION.
-      17             STOP RUN.
+      16           01 VAR11.
+      17           PROCEDURE DIVISION.
     ```cobol
     VAR10
     ```
+    *(layout omitted due to issues in item definition)*
+    ---
+    References: 1
+    (line 15, character 11):
+    __rootdir__/prog.cob:16.11-16.16:
+      13           01 VAR9 PIC $++/+.+B+.
+      14           01 VARL PIC L9 DEPENDING ON VAR1.
+      15           01 VAR10 PIC 99 USAGE COMP-0.
+      16 >         01 VAR11.
+    ----              ^^^^^
+      17           PROCEDURE DIVISION.
+      18             STOP RUN.
     ```cobol
-    PIC X USAGE DISPLAY
+    VAR11
     ```
-    ALPHANUMERIC(1)
+    *(layout omitted due to issues in item definition)*
     ---
     References: 1 |}];;
 
@@ -1009,27 +1022,30 @@ let%expect_test "hover-datadef-redefines" =
         PROGRAM-ID. prog.
         DATA DIVISION.
         WORKING-STORAGE SECTION.
+        01 S.
+          05 T PIC 9.
+          05 _|_U PIC X REDEFINES _|_T.
         01 X.
           05 Y PIC 9.
-          05 _|_Z REDEFINES Y_|_
+          05 _|_Z REDEFINES Y_|_.
         PROCEDURE DIVISION.
-            DISPLAY _|_Z.
+            DISPLAY _|_S _|_U _|_Z _|_X.
             STOP RUN.
     |cobol};
   end_with_postproc [%expect.output];
   [%expect {|
-    {"params":{"diagnostics":[{"message":"Missing .","range":{"end":{"character":26,"line":7},"start":{"character":26,"line":7}},"severity":4},{"message":"Missing PICTURE clause for item 'Z'","range":{"end":{"character":26,"line":7},"start":{"character":10,"line":7}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    {"params":{"diagnostics":[{"message":"Missing PICTURE clause for item 'Z'","range":{"end":{"character":27,"line":10},"start":{"character":10,"line":10}},"severity":1}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     (line 7, character 13):
     __rootdir__/prog.cob:8.13-8.14:
        5           WORKING-STORAGE SECTION.
-       6           01 X.
-       7             05 Y PIC 9.
-       8 >           05 Z REDEFINES Y
+       6           01 S.
+       7             05 T PIC 9.
+       8 >           05 U PIC X REDEFINES T.
     ----                ^
-       9           PROCEDURE DIVISION.
-      10               DISPLAY Z.
+       9           01 X.
+      10             05 Y PIC 9.
     ```cobol
-    Z IN X
+    U IN S
     ```
     ```cobol
     PIC X USAGE DISPLAY
@@ -1037,19 +1053,57 @@ let%expect_test "hover-datadef-redefines" =
     ALPHANUMERIC(1)
     Redefines:
     ```cobol
+    T IN S
+    ```
+    ---
+    References: 2
+    (line 7, character 31):
+    __rootdir__/prog.cob:8.31-8.32:
+       5           WORKING-STORAGE SECTION.
+       6           01 S.
+       7             05 T PIC 9.
+       8 >           05 U PIC X REDEFINES T.
+    ----                                  ^
+       9           01 X.
+      10             05 Y PIC 9.
+    ```cobol
+    T IN S
+    ```
+    ```cobol
+    PIC 9 USAGE DISPLAY
+    ```
+    NUMERIC(digits = 1, scale = 0, sign = unsigned)
+    *e.g,* [`0`] (0), [`1`] (1)
+    ---
+    References: 2
+    (line 10, character 13):
+    __rootdir__/prog.cob:11.13-11.14:
+       8             05 U PIC X REDEFINES T.
+       9           01 X.
+      10             05 Y PIC 9.
+      11 >           05 Z REDEFINES Y.
+    ----                ^
+      12           PROCEDURE DIVISION.
+      13               DISPLAY S U Z X.
+    ```cobol
+    Z IN X
+    ```
+    *(layout omitted due to issues in item definition)*
+    Redefines:
+    ```cobol
     Y IN X
     ```
     ---
     References: 2
-    (line 7, character 26):
-    __rootdir__/prog.cob:8.25-8.26:
-       5           WORKING-STORAGE SECTION.
-       6           01 X.
-       7             05 Y PIC 9.
-       8 >           05 Z REDEFINES Y
+    (line 10, character 26):
+    __rootdir__/prog.cob:11.25-11.26:
+       8             05 U PIC X REDEFINES T.
+       9           01 X.
+      10             05 Y PIC 9.
+      11 >           05 Z REDEFINES Y.
     ----                            ^
-       9           PROCEDURE DIVISION.
-      10               DISPLAY Z.
+      12           PROCEDURE DIVISION.
+      13               DISPLAY S U Z X.
     ```cobol
     Y IN X
     ```
@@ -1060,17 +1114,33 @@ let%expect_test "hover-datadef-redefines" =
     *e.g,* [`0`] (0), [`1`] (1)
     ---
     References: 2
-    (line 9, character 20):
-    __rootdir__/prog.cob:10.20-10.21:
-       7             05 Y PIC 9.
-       8             05 Z REDEFINES Y
-       9           PROCEDURE DIVISION.
-      10 >             DISPLAY Z.
+    (line 12, character 20):
+    __rootdir__/prog.cob:13.20-13.21:
+      10             05 Y PIC 9.
+      11             05 Z REDEFINES Y.
+      12           PROCEDURE DIVISION.
+      13 >             DISPLAY S U Z X.
     ----                       ^
-      11               STOP RUN.
-      12
+      14               STOP RUN.
+      15
     ```cobol
-    Z IN X
+    S
+    ```
+    Group of 1 subfield
+    Size: 1 byte
+    ---
+    References: 2
+    (line 12, character 22):
+    __rootdir__/prog.cob:13.22-13.23:
+      10             05 Y PIC 9.
+      11             05 Z REDEFINES Y.
+      12           PROCEDURE DIVISION.
+      13 >             DISPLAY S U Z X.
+    ----                         ^
+      14               STOP RUN.
+      15
+    ```cobol
+    U IN S
     ```
     ```cobol
     PIC X USAGE DISPLAY
@@ -1078,8 +1148,43 @@ let%expect_test "hover-datadef-redefines" =
     ALPHANUMERIC(1)
     Redefines:
     ```cobol
+    T IN S
+    ```
+    ---
+    References: 2
+    (line 12, character 24):
+    __rootdir__/prog.cob:13.24-13.25:
+      10             05 Y PIC 9.
+      11             05 Z REDEFINES Y.
+      12           PROCEDURE DIVISION.
+      13 >             DISPLAY S U Z X.
+    ----                           ^
+      14               STOP RUN.
+      15
+    ```cobol
+    Z IN X
+    ```
+    *(layout omitted due to issues in item definition)*
+    Redefines:
+    ```cobol
     Y IN X
     ```
+    ---
+    References: 2
+    (line 12, character 26):
+    __rootdir__/prog.cob:13.26-13.27:
+      10             05 Y PIC 9.
+      11             05 Z REDEFINES Y.
+      12           PROCEDURE DIVISION.
+      13 >             DISPLAY S U Z X.
+    ----                             ^
+      14               STOP RUN.
+      15
+    ```cobol
+    X
+    ```
+    Group of 1 subfield
+    Size: 1 byte
     ---
     References: 2 |}];;
 

--- a/test/lsp/lsp_hover.ml
+++ b/test/lsp/lsp_hover.ml
@@ -222,9 +222,9 @@ let%expect_test "hover-replaced" =
     "B" "C"
     ``` |}];;
 
-(* Hover typedef vars *)
+(* Hover datadef vars *)
 
-let%expect_test "hover-typedef-vars" =
+let%expect_test "hover-datadef-vars" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -293,7 +293,7 @@ let%expect_test "hover-typedef-vars" =
     STRUCT
     ```
     Group of 3 subfields
-    Size: 80 bits
+    Size: 10 bytes
     ---
     References: 2
     (line 7, character 31):
@@ -404,7 +404,7 @@ let%expect_test "hover-typedef-vars" =
     STRUCT
     ```
     Group of 3 subfields
-    Size: 80 bits
+    Size: 10 bytes
     ---
     References: 2
     (line 12, character 36):
@@ -466,7 +466,7 @@ let%expect_test "hover-typedef-vars" =
     ---
     References: 2 |}];;
 
-let%expect_test "hover-typedef-vars-usage" =
+let%expect_test "hover-datadef-vars-usage" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -481,12 +481,14 @@ let%expect_test "hover-typedef-vars-usage" =
         01 _|_VAR7 USAGE POINTER.
         01 _|_VAR8 PIC 9 USAGE PACKED-DECIMAL.
         01 _|_VAR9 PIC $++/+.+B+.
+        01 _|_VARL PIC L9 DEPENDING ON VAR1.
+        01 _|_VAR10 PIC 99 USAGE COMP-0.
         PROCEDURE DIVISION.
           STOP RUN.
     |cobol};
   end_with_postproc [%expect.output];
   [%expect {|
-    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    {"params":{"diagnostics":[{"message":"Unsupported USAGE COMP-0","range":{"end":{"character":36,"line":14},"start":{"character":24,"line":14}},"severity":2}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     (line 5, character 11):
     __rootdir__/prog.cob:6.11-6.14:
        3           PROGRAM-ID. prog.
@@ -600,7 +602,7 @@ let%expect_test "hover-typedef-vars-usage" =
       12 >         01 VAR8 PIC 9 USAGE PACKED-DECIMAL.
     ----              ^^^^
       13           01 VAR9 PIC $++/+.+B+.
-      14           PROCEDURE DIVISION.
+      14           01 VARL PIC L9 DEPENDING ON VAR1.
     ```cobol
     VAR8
     ```
@@ -618,8 +620,8 @@ let%expect_test "hover-typedef-vars-usage" =
       12           01 VAR8 PIC 9 USAGE PACKED-DECIMAL.
       13 >         01 VAR9 PIC $++/+.+B+.
     ----              ^^^^
-      14           PROCEDURE DIVISION.
-      15             STOP RUN.
+      14           01 VARL PIC L9 DEPENDING ON VAR1.
+      15           01 VAR10 PIC 99 USAGE COMP-0.
     ```cobol
     VAR9
     ```
@@ -629,9 +631,45 @@ let%expect_test "hover-typedef-vars-usage" =
     NUMERIC(digits = 4, scale = 2, sign = unsigned)
     *e.g,* [`         `] (0), [`$+1/2.3 4`] (12.34)
     ---
+    References: 1
+    (line 13, character 11):
+    __rootdir__/prog.cob:14.11-14.15:
+      11           01 VAR7 USAGE POINTER.
+      12           01 VAR8 PIC 9 USAGE PACKED-DECIMAL.
+      13           01 VAR9 PIC $++/+.+B+.
+      14 >         01 VARL PIC L9 DEPENDING ON VAR1.
+    ----              ^^^^
+      15           01 VAR10 PIC 99 USAGE COMP-0.
+      16           PROCEDURE DIVISION.
+    ```cobol
+    VARL
+    ```
+    ```cobol
+    PIC L9 USAGE DISPLAY
+    ```
+    ALPHANUMERIC(2)
+    ---
+    References: 1
+    (line 14, character 11):
+    __rootdir__/prog.cob:15.11-15.16:
+      12           01 VAR8 PIC 9 USAGE PACKED-DECIMAL.
+      13           01 VAR9 PIC $++/+.+B+.
+      14           01 VARL PIC L9 DEPENDING ON VAR1.
+      15 >         01 VAR10 PIC 99 USAGE COMP-0.
+    ----              ^^^^^
+      16           PROCEDURE DIVISION.
+      17             STOP RUN.
+    ```cobol
+    VAR10
+    ```
+    ```cobol
+    PIC X USAGE DISPLAY
+    ```
+    ALPHANUMERIC(1)
+    ---
     References: 1 |}];;
 
-let%expect_test "hover-typedef-filler-vars" =
+let%expect_test "hover-datadef-filler-vars" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -667,15 +705,15 @@ let%expect_test "hover-typedef-filler-vars" =
     STRUCT
     ```
     Group of 2 subfields
-    Size: 32 bits
+    Size: 4 bytes
     ---
     References: 1
     (line 9, character 29):
     Hovering nothing worthy |}];;
 
-(* Hover typedef cond *)
+(* Hover datadef cond *)
 
-let%expect_test "hover-typedef-simple-condition" =
+let%expect_test "hover-datadef-simple-condition" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -758,7 +796,7 @@ let%expect_test "hover-typedef-simple-condition" =
     ---
     References: 2 |}];;
 
-let%expect_test "hover-typedef-group-condition" =
+let%expect_test "hover-datadef-group-condition" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -797,7 +835,7 @@ let%expect_test "hover-typedef-group-condition" =
     STRUCT
     ```
     Group of 2 subfields
-    Size: 16 bits
+    Size: 2 bytes
     ---
     References: 1
     (line 9, character 17):
@@ -845,7 +883,7 @@ let%expect_test "hover-typedef-group-condition" =
     ---
     References: 2 |}];;
 
-let%expect_test "hover-typedef-renames" =
+let%expect_test "hover-datadef-renames" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -964,7 +1002,7 @@ let%expect_test "hover-typedef-renames" =
     ---
     References: 2 |}];;
 
-let%expect_test "hover-typedef-redefines" =
+let%expect_test "hover-datadef-redefines" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -1045,7 +1083,7 @@ let%expect_test "hover-typedef-redefines" =
     ---
     References: 2 |}];;
 
-let%expect_test "hover-typedef-table-and-index" =
+let%expect_test "hover-datadef-table-and-index" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -1057,16 +1095,26 @@ let%expect_test "hover-typedef-table-and-index" =
         01 T1_|_ PIC X OCCURS 10 TIMES INDEXED BY INDEX_|_1.
         01 T2 OCCURS 10 TIMES INDEXED BY IND_|_EX2,I_|_3.
           02 SUB-FIELD pic x.
+        01 T3_|_.
+          02 FILLER PIC 99 USAGE DISPLAY.
+        01 T4_|_. *> (no size shown yet, on purpose as COMP-0 is unsupported)
+          02 FILLER PIC 99 USAGE COMP-X.
         01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I_|_4.
           02 SUB-FIELD pic 9.
+        01 VARTAB1.
+          02 VARTAB1-ELT PIC X OCCURS 1 TO 99 DEPENDING ON CNT.
+        01 VARTAB2.
+          02 VARTAB-SIZE PIC 99.
+          02 X PIC X OCCURS 1 TO 99 DEPENDING ON VARTAB-SIZE.
         PROCEDURE DIVISION.
             SET INDEX1 TO IDX.
             MOVE T1 (IND_|_EX1) TO T2(1).
+            DISPLAY VART_|_AB1 VART_|_AB1-ELT VARTAB_|_2.
             STOP RUN.
     |cobol};
   end_with_postproc [%expect.output];
   [%expect {|
-    {"params":{"diagnostics":[],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
+    {"params":{"diagnostics":[{"message":"Unsupported USAGE COMP-X","range":{"end":{"character":39,"line":13},"start":{"character":27,"line":13}},"severity":2}],"uri":"file://__rootdir__/prog.cob"},"method":"textDocument/publishDiagnostics","jsonrpc":"2.0"}
     (line 5, character 18):
     __rootdir__/prog.cob:6.8-6.30:
        3           PROGRAM-ID. prog.
@@ -1132,7 +1180,7 @@ let%expect_test "hover-typedef-table-and-index" =
        9 >         01 T2 OCCURS 10 TIMES INDEXED BY INDEX2,I3.
     ----                                            ^^^^^^
       10             02 SUB-FIELD pic x.
-      11           01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I4.
+      11           01 T3.
     Table
     ```cobol
     OCCURS 10 TIMES
@@ -1143,7 +1191,7 @@ let%expect_test "hover-typedef-table-and-index" =
     T2
     ```
     Group of 1 subfield
-    Size: 8 bits
+    Size: 1 byte
     ---
     References: 1
     (line 8, character 49):
@@ -1154,7 +1202,7 @@ let%expect_test "hover-typedef-table-and-index" =
        9 >         01 T2 OCCURS 10 TIMES INDEXED BY INDEX2,I3.
     ----                                                   ^^
       10             02 SUB-FIELD pic x.
-      11           01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I4.
+      11           01 T3.
     Table
     ```cobol
     OCCURS 10 TIMES
@@ -1165,18 +1213,51 @@ let%expect_test "hover-typedef-table-and-index" =
     T2
     ```
     Group of 1 subfield
-    Size: 8 bits
+    Size: 1 byte
     ---
     References: 1
-    (line 10, character 66):
-    __rootdir__/prog.cob:11.65-11.67:
+    (line 10, character 13):
+    __rootdir__/prog.cob:11.11-11.13:
        8           01 T1 PIC X OCCURS 10 TIMES INDEXED BY INDEX1.
        9           01 T2 OCCURS 10 TIMES INDEXED BY INDEX2,I3.
       10             02 SUB-FIELD pic x.
-      11 >         01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I4.
+      11 >         01 T3.
+    ----              ^^
+      12             02 FILLER PIC 99 USAGE DISPLAY.
+      13           01 T4. *> (no size shown yet, on purpose as COMP-0 is unsupported)
+    ```cobol
+    T3
+    ```
+    Group of 1 subfield
+    Size: 2 bytes
+    ---
+    References: 1
+    (line 12, character 13):
+    __rootdir__/prog.cob:13.11-13.13:
+      10             02 SUB-FIELD pic x.
+      11           01 T3.
+      12             02 FILLER PIC 99 USAGE DISPLAY.
+      13 >         01 T4. *> (no size shown yet, on purpose as COMP-0 is unsupported)
+    ----              ^^
+      14             02 FILLER PIC 99 USAGE COMP-X.
+      15           01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I4.
+    ```cobol
+    T4
+    ```
+    Group of 1 subfield
+    ---
+     (no size shown yet, on purpose as COMP-0 is unsupported)
+    ---
+    References: 1
+    (line 14, character 66):
+    __rootdir__/prog.cob:15.65-15.67:
+      12             02 FILLER PIC 99 USAGE DISPLAY.
+      13           01 T4. *> (no size shown yet, on purpose as COMP-0 is unsupported)
+      14             02 FILLER PIC 99 USAGE COMP-X.
+      15 >         01 FILLER OCCURS 10 TO 20 TIMES DEPENDING CNT INDEXED BY I4.
     ----                                                                    ^^
-      12             02 SUB-FIELD pic 9.
-      13           PROCEDURE DIVISION.
+      16             02 SUB-FIELD pic 9.
+      17           01 VARTAB1.
     Table
     ```cobol
     OCCURS 10 TO 20 TIMES DEPENDING ON CNT
@@ -1187,18 +1268,18 @@ let%expect_test "hover-typedef-table-and-index" =
     FILLER
     ```
     Group of 1 subfield
-    Size: 8 bits
+    Size: 1 byte
     ---
     References: 1
-    (line 14, character 24):
-    __rootdir__/prog.cob:15.21-15.27:
-      12             02 SUB-FIELD pic 9.
-      13           PROCEDURE DIVISION.
-      14               SET INDEX1 TO IDX.
-      15 >             MOVE T1 (INDEX1) TO T2(1).
+    (line 23, character 24):
+    __rootdir__/prog.cob:24.21-24.27:
+      21             02 X PIC X OCCURS 1 TO 99 DEPENDING ON VARTAB-SIZE.
+      22           PROCEDURE DIVISION.
+      23               SET INDEX1 TO IDX.
+      24 >             MOVE T1 (INDEX1) TO T2(1).
     ----                        ^^^^^^
-      16               STOP RUN.
-      17
+      25               DISPLAY VARTAB1 VARTAB1-ELT VARTAB2.
+      26               STOP RUN.
     Table
     ```cobol
     OCCURS 10 TIMES
@@ -1213,9 +1294,59 @@ let%expect_test "hover-typedef-table-and-index" =
     ```
     ALPHANUMERIC(1)
     ---
-    References: 3 |}];;
+    References: 3
+    (line 24, character 24):
+    __rootdir__/prog.cob:25.20-25.27:
+      22           PROCEDURE DIVISION.
+      23               SET INDEX1 TO IDX.
+      24               MOVE T1 (INDEX1) TO T2(1).
+      25 >             DISPLAY VARTAB1 VARTAB1-ELT VARTAB2.
+    ----                       ^^^^^^^
+      26               STOP RUN.
+      27
+    ```cobol
+    VARTAB1
+    ```
+    Group of 1 subfield
+    Size: *variable*
+    ---
+    References: 2
+    (line 24, character 32):
+    __rootdir__/prog.cob:25.28-25.39:
+      22           PROCEDURE DIVISION.
+      23               SET INDEX1 TO IDX.
+      24               MOVE T1 (INDEX1) TO T2(1).
+      25 >             DISPLAY VARTAB1 VARTAB1-ELT VARTAB2.
+    ----                               ^^^^^^^^^^^
+      26               STOP RUN.
+      27
+    ```cobol
+    VARTAB1-ELT IN VARTAB1
+    ```
+    ```cobol
+    PIC X USAGE DISPLAY
+    ```
+    ALPHANUMERIC(1)
+    ---
+    References: 2
+    (line 24, character 46):
+    __rootdir__/prog.cob:25.40-25.47:
+      22           PROCEDURE DIVISION.
+      23               SET INDEX1 TO IDX.
+      24               MOVE T1 (INDEX1) TO T2(1).
+      25 >             DISPLAY VARTAB1 VARTAB1-ELT VARTAB2.
+    ----                                           ^^^^^^^
+      26               STOP RUN.
+      27
+    ```cobol
+    VARTAB2
+    ```
+    Group of 2 subfields
+    Size: *variable*
+    ---
+    References: 2 |}];;
 
-let%expect_test "hover-typedef-communication-section" =
+let%expect_test "hover-datadef-communication-section" =
   let { projdir; end_with_postproc }, server = make_lsp_project () in
   print_hovered server ~projdir @@ extract_position_markers {cobol|
         IDENTIFICATION DIVISION.
@@ -1273,7 +1404,7 @@ let%expect_test "hover-comment" =
     STRUCT
     ```
     Group of 2 subfields
-    Size: 16 bits
+    Size: 2 bytes
     ---
      inline comment
     ---


### PR DESCRIPTION
Additionally:
- show sizes in bytes when relevant;
- indicate when an item is a "variable" ODO.