### PR TITLE
Documentation and renaming to reduce confusion in the typed COBOL AST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Parsing of LSP CLI arguments, that notably prevented caching in global storage [#549](https://github.com/OCamlPro/superbol-studio-oss/pull/549) (fix for [Issue #547](https://github.com/OCamlPro/superbol-studio-oss/issues/547))
 - Size reported for numeric items with `SIGN SEPARATE` clause [#545](https://github.com/OCamlPro/superbol-studio-oss/pull/545) [#552](https://github.com/OCamlPro/superbol-studio-oss/pull/552) [#553](https://github.com/OCamlPro/superbol-studio-oss/pull/553)
 - Internal logic of the parser to limit the amount of text rescans [#544](https://github.com/OCamlPro/superbol-studio-oss/pull/544)
+- Documentation and renaming to reduce confusion in the typed COBOL AST API [#576](https://github.com/OCamlPro/superbol-studio-oss/pull/576)
 
 ### Removed
 - Remove deprecated Cobol_data.OLD and Cobol_typeck.OLD [#592](https://github.com/OCamlPro/superbol-studio-oss/pull/592)

--- a/src/lsp/cobol_cfg/cfg_jumps.ml
+++ b/src/lsp/cobol_cfg/cfg_jumps.ml
@@ -42,7 +42,7 @@ module Jumps = Set.Make(struct
   end)
 
 let full_qn ~cu qn =
-  (Qualmap.find_binding qn cu.unit_procedure.procedure_blocks.named).full_qn
+  (Resolver_map.find_binding qn cu.unit_procedure.procedure_blocks.named).full_qn
 
 let full_qn' ~cu qn = full_qn ~cu ~&qn
 

--- a/src/lsp/cobol_data/data_types.ml
+++ b/src/lsp/cobol_data/data_types.ml
@@ -77,20 +77,23 @@ and item_definitions = item_definition with_loc nel
 and item_redefinitions = item_definition with_loc list
 
 and item_definition =
-  | Field of field_definition
-  | Table of table_definition
+  | Field of field_definition (** for data items without OCCURS clause *)
+  | Table of table_definition (** for data items with an OCCURS clause *)
 
 and field_definition =
   {
     field_qualname: Cobol_ptree.qualname with_loc option;
-    field_redefines: Cobol_ptree.qualname with_loc option;      (* redef only *)
     field_leading_ranges: table_range list;
     field_offset: Data_memory.offset;         (** offset w.r.t record address *)
     field_size: Data_memory.size;
     field_layout: field_layout;
     field_length_variability: length_variability;
-    field_conditions: condition_names;
-    field_redefinitions: item_redefinitions;
+    field_conditions: condition_names; (** Named conditions on the value of this field. *)
+    field_redefines: Cobol_ptree.qualname with_loc option; (** 
+      Set iff this field is a redefinition. 
+      In that case this field appears inside item_redefinitions of the item it redefines. 
+      Later, we may create instead a item_redefinition type. *)
+    field_redefinitions: item_redefinitions; (** List of alternative definitions for this field *)
     field_has_definition_issues: bool;
   }
 
@@ -112,8 +115,10 @@ and table_definition =
     table_size: Data_memory.size;
     table_range: table_range;
     table_init_values: Cobol_ptree.literal with_loc list;     (* list for now *)
-    table_redefines: Cobol_ptree.qualname with_loc option;    (* redef only *)
-    table_redefinitions: item_redefinitions;
+    table_redefines: Cobol_ptree.qualname with_loc option; (* same as [field_redefines] but for tables *)
+    table_redefinitions: item_redefinitions; (** 
+      List of alternative definitions for the full table. 
+      Note that by default the typechecker generates a warning on table redefinition. *)
     table_has_definition_issues: bool;
   }
 and table_range =
@@ -144,6 +149,7 @@ and dynamic_span =
     occurs_dynamic_initialized: bool with_loc;
   }
 
+(** Named conditions a.k.a. level 88 items *)
 and condition_names = condition_name with_loc list
 and condition_name =
   {
@@ -190,6 +196,8 @@ and renamed_item_layout =
 (*     const_layout: const_layout; *)
 (*   } *)
 
+(** [data_definition] provides a direct access to the pair of each item and associated record items.
+    It is used for instance to retrieve data item information from its name. *)
 type data_definition =
   | Data_field of
       {

--- a/src/lsp/cobol_lsp/lsp_lookup.ml
+++ b/src/lsp/cobol_lsp/lsp_lookup.ml
@@ -538,7 +538,7 @@ let proc_at_pos ~filename (pos: Lsp.Types.Position.t) group : procedure_at_posit
     method! fold_procedure_paragraph { paragraph_name; _ } { cu; _ } =
       let proc_name = match cu, paragraph_name with
         | Some cu, Some qn ->
-          Some (Cobol_unit.Qualmap.find_binding
+          Some (Cobol_unit.Resolver_map.find_binding
                   ~&qn cu.unit_procedure.procedure_blocks.named).full_qn
         | _ -> None
       in

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -229,7 +229,7 @@ let focus_on_name_in_defintions = true
 let find_data_definition Lsp_position.{ location_of; location_of_srcloc }
     ?(allow_notifications = true)
     (qn: Cobol_ptree.qualname) (cu: Cobol_unit.Types.cobol_unit) =
-  match Cobol_unit.Qualmap.find qn cu.unit_data.data_items.named with
+  match Cobol_unit.Resolver_map.find qn cu.unit_data.data_items.named with
   | Data_field { def = { loc; _ }; _ }
   | Data_renaming { def = { loc; _ }; _ }
   | Data_condition { def = { loc; _ }; _ }
@@ -245,7 +245,7 @@ let find_data_definition Lsp_position.{ location_of; location_of_srcloc }
   | Table_index { qualname; _ } ->
       [location_of qualname]
   | exception Not_found
-  | exception Cobol_unit.Qualmap.Ambiguous _
+  | exception Cobol_unit.Resolver_map.Ambiguous _
     when not allow_notifications ->
       []
   | exception Not_found ->
@@ -253,7 +253,7 @@ let find_data_definition Lsp_position.{ location_of; location_of_srcloc }
          analyzed. *)
       (* Lsp_notify.unknown "data-name" qn; *)
       []
-  | exception Cobol_unit.Qualmap.Ambiguous (lazy matching_qualnames) ->
+  | exception Cobol_unit.Resolver_map.Ambiguous (lazy matching_qualnames) ->
       Lsp_notify.ambiguous "data-name" qn ~matching_qualnames;
       []
 
@@ -274,13 +274,13 @@ let find_proc_definition
   | Section p ->
       [location_of p]
   | exception Not_found
-  | exception Cobol_unit.Qualmap.Ambiguous _
+  | exception Cobol_unit.Resolver_map.Ambiguous _
     when not allow_notifications ->
       []
   | exception Not_found ->
       Lsp_notify.unknown "procedure-name" qn;
       []
-  | exception Cobol_unit.Qualmap.Ambiguous (lazy matching_qualnames) ->
+  | exception Cobol_unit.Resolver_map.Ambiguous (lazy matching_qualnames) ->
       Lsp_notify.ambiguous "procedure-name" qn ~matching_qualnames;
       []
 
@@ -325,13 +325,13 @@ let lookup_qn ~kind ~lookup qn =
   | Not_found ->
       Lsp_notify.unknown kind qn;
       None
-  | Cobol_unit.Qualmap.Ambiguous (lazy matching_qualnames) ->
+  | Cobol_unit.Resolver_map.Ambiguous (lazy matching_qualnames) ->
       Lsp_notify.ambiguous kind qn ~matching_qualnames;
       None
 
 let find_full_qn ~kind qn qmap =
   lookup_qn ~kind qn
-    ~lookup:(fun qn -> (Cobol_unit.Qualmap.find_binding qn qmap).full_qn)
+    ~lookup:(fun qn -> (Cobol_unit.Resolver_map.find_binding qn qmap).full_qn)
 
 let find_proc_qn ~kind qn ?in_section cu =
   lookup_qn ~kind qn
@@ -581,14 +581,14 @@ let lookup_data_definition cu_name element_at_pos group =
   let named_data_defs = cu.unit_data.data_items.named in
   try match element_at_pos with
     | Data_item { full_qn = Some qn; def_loc } ->
-        Cobol_unit.Qualmap.find qn named_data_defs,
+        Cobol_unit.Resolver_map.find qn named_data_defs,
         def_loc
     | Data_full_name qn | Data_name qn ->
-        Cobol_unit.Qualmap.find qn named_data_defs,
+        Cobol_unit.Resolver_map.find qn named_data_defs,
         Lsp_lookup.baseloc_of_qualname qn
     | Data_item _ | Proc_name _ ->
         raise Not_found
-  with Cobol_unit.Qualmap.Ambiguous _ -> raise Not_found
+  with Cobol_unit.Resolver_map.Ambiguous _ -> raise Not_found
 
 let describe_data_definition_at_pos
     ?(always_show_hover_definition_text_in_data_div = false)

--- a/src/lsp/cobol_typeck/typeck_data_items.ml
+++ b/src/lsp/cobol_typeck/typeck_data_items.ml
@@ -19,7 +19,7 @@ open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
 module Visitor = Cobol_common.Visitor
-module Qualmap = Cobol_unit.Qualmap
+module Resolver_map = Cobol_unit.Resolver_map
 module LIST = Cobol_common.Basics.LIST
 module NEL = Cobol_common.Basics.NEL
 module PIC = Cobol_data.Picture
@@ -39,7 +39,7 @@ type acc =
     current_storage: Cobol_data.Types.data_storage;
     current_qualification: Cobol_ptree.qualname option;
     item_stack: item_stack;
-    current_qualmap: Cobol_data.Types.field_definition with_loc Qualmap.t;
+    current_resolver_map: Cobol_data.Types.field_definition with_loc Resolver_map.t;
     pending_conditions: condition_name_under_construction list;
     filler_count: int;
     definitions: Cobol_unit.Types.data_definitions;
@@ -83,13 +83,13 @@ let init (config: unit_config) =
   {
     current_storage = Local_storage;                         (* dummy default *)
     current_qualification = None;
-    current_qualmap = Qualmap.empty;
+    current_resolver_map = Resolver_map.empty;
     item_stack = [];
     pending_conditions = [];
     filler_count = 0;
     definitions =
       {
-        data_items = { named = Qualmap.empty; list = [] };
+        data_items = { named = Resolver_map.empty; list = [] };
         data_records = [];
       };
     references = Cobol_unit.Qual.MAP.empty;
@@ -202,7 +202,7 @@ let commit_record acc ~renamings (record_item: item_definition with_loc) =
   let record = { record_name; record_storage = acc.current_storage;
                  record_item; record_renamings = renamings } in
   let add_named_def qn def { named; list } =
-    { named = Qualmap.add ~&qn def named;
+    { named = Resolver_map.add ~&qn def named;
       list = def :: list }
   and add_anonymous_def def { named; list } =
     { named;
@@ -238,7 +238,7 @@ let commit_record acc ~renamings (record_item: item_definition with_loc) =
     end data_items acc.pending_conditions
   in
   { acc with
-    current_qualmap = Qualmap.empty;
+    current_resolver_map = Resolver_map.empty;
     pending_conditions = [];
     definitions = { data_items;
                     data_records = record :: acc.definitions.data_records } }
@@ -335,7 +335,7 @@ let register_field_def acc (def: field_definition with_loc) =
   match ~&def.field_qualname with
   | Some qn ->
       { acc with
-        current_qualmap = Qualmap.add ~&qn def acc.current_qualmap }
+        current_resolver_map = Resolver_map.add ~&qn def acc.current_resolver_map }
   | None -> acc
 
 
@@ -537,7 +537,7 @@ let register_ref ~from:{ loc; _ } ~to_:qualname_opt acc =
 
 let find_in_current_record qualname acc =
   try
-    let res = Qualmap.find ~&qualname acc.current_qualmap in
+    let res = Resolver_map.find ~&qualname acc.current_resolver_map in
     Ok (register_ref ~from:qualname ~to_:~&res.field_qualname acc, res)
   with Not_found ->
     Error (Typeck_data_diagnostics.Item_not_found { qualname })

--- a/src/lsp/cobol_typeck/typeck_outputs.ml
+++ b/src/lsp/cobol_typeck/typeck_outputs.ml
@@ -16,6 +16,7 @@ open Cobol_common.Srcloc.INFIX
 open Cobol_common.Exec_block.TYPES
 module LIST = Cobol_common.Basics.LIST
 
+(** Contains the locations of syntactic occurences for each qualified name *)
 type qualrefmap = srcloc list Cobol_unit.Qual.MAP.t
 type references_in_unit =
   {
@@ -38,9 +39,12 @@ type artifacts =
 
 type outputs =
   {
-    ptree: Cobol_ptree.compilation_group;
-    group: Cobol_unit.Types.group;
-    artifacts: artifacts;
+    ptree: Cobol_ptree.compilation_group; (** 
+      Parse tree (AST without typing information) copied in the typechecker output 
+      to ease its direct use by further passes in the analysis pipeline and queries 
+      in the LSP server. *)
+    group: Cobol_unit.Types.group; (** The typed AST view as an unordered set of cobol_unit *)
+    artifacts: artifacts; (** Other typing artifacts *)
   }
 type t = outputs
 

--- a/src/lsp/cobol_typeck/typeck_procedure.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure.ml
@@ -17,7 +17,7 @@ open Cobol_unit.Types
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-module Qualmap = Cobol_unit.Qualmap
+module Resolver_map = Cobol_unit.Resolver_map
 module Visitor = Cobol_common.Visitor
 
 type output =
@@ -94,7 +94,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
   let open struct
     type acc =
       {
-        blocks: procedure_block Qualmap.t;
+        blocks: procedure_block Resolver_map.t;
         block_list: procedure_block list;
         current_section: section_under_construction with_loc option;
         args: Cobol_ptree.procedure_using_phrase with_loc option;
@@ -107,7 +107,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
 
     let init =
       {
-        blocks = Qualmap.empty;
+        blocks = Resolver_map.empty;
         block_list = [];
         current_section = None;
         args = None;
@@ -145,9 +145,9 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
           | None ->
               { paragraphs with list = paragraph :: list }
           | Some qn ->
-              { named = Qualmap.add ~&qn paragraph named;
+              { named = Resolver_map.add ~&qn paragraph named;
                 list = paragraph :: list }
-        end { named = Qualmap.empty; list = [] } suc.sec_paragraphs
+        end { named = Resolver_map.empty; list = [] } suc.sec_paragraphs
       in
       Section ({ section_name = suc.sec_name; section_paragraphs } &@ loc)
 
@@ -171,7 +171,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
       | Some ({ payload = { sec_name = qn; _ }; _ } as section) ->
           let section = section_block section in
           { acc with
-            blocks = Qualmap.add ~&qn section acc.blocks;
+            blocks = Resolver_map.add ~&qn section acc.blocks;
             block_list = section :: acc.block_list;
             current_section = None }
       | None ->
@@ -200,7 +200,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
             Some ({ ~&s with sec_paragraphs } &@ loc)
       in
       { acc with
-        blocks = Qualmap.add qn (paragraph_block p) acc.blocks;
+        blocks = Resolver_map.add qn (paragraph_block p) acc.blocks;
         block_list;
         current_section }
 
@@ -277,7 +277,7 @@ let collect_references
               refs = Typeck_outputs.register_procedure_ref ~loc block acc.refs }
         | exception Not_found ->
             error acc @@ Unknown_proc_name qn
-        | exception Qualmap.Ambiguous (lazy matching_qualnames) ->
+        | exception Resolver_map.Ambiguous (lazy matching_qualnames) ->
             error acc @@ Ambiguous_proc_name { given_qualname = qn;
                                                matching_qualnames }
       in

--- a/src/lsp/cobol_typeck/typeck_references.ml
+++ b/src/lsp/cobol_typeck/typeck_references.ml
@@ -17,7 +17,7 @@ open Cobol_unit.Types
 open Cobol_common.Srcloc.TYPES
 open Cobol_common.Srcloc.INFIX
 
-module Qualmap = Cobol_unit.Qualmap
+module Resolver_map = Cobol_unit.Resolver_map
 
 let empty_accumulator =
   {
@@ -33,7 +33,7 @@ let error acc err =
 let resolve_data_qualname ~data_definitions ?(strict = true)
     ({ loc; payload = qn } as qn') acc =
   try
-    let bnd = Qualmap.find_binding qn data_definitions.data_items.named in
+    let bnd = Resolver_map.find_binding qn data_definitions.data_items.named in
     Ok { resolved_name = qn'; resolved = bnd.value },
     { acc with
       refs = Typeck_outputs.register_data_qualref ~loc bnd.full_qn acc.refs }
@@ -42,7 +42,7 @@ let resolve_data_qualname ~data_definitions ?(strict = true)
       (* TODO: error acc @@ Undefined_data_item { qualname = qn' } *)
       Error (),
       acc
-  | Qualmap.Ambiguous (lazy matching_qualnames) ->
+  | Resolver_map.Ambiguous (lazy matching_qualnames) ->
       Error (),
       error acc @@ Ambiguous_data_name { given_qualname = qn &@ loc;
                                          matching_qualnames }

--- a/src/lsp/cobol_unit/cobol_unit.ml
+++ b/src/lsp/cobol_unit/cobol_unit.ml
@@ -12,7 +12,7 @@
 (**************************************************************************)
 
 module Qual = Unit_qual
-module Qualmap = Unit_qualmap
+module Resolver_map = Unit_resolver_map
 
 module Types = struct
   include Unit_types

--- a/src/lsp/cobol_unit/unit_printer.ml
+++ b/src/lsp/cobol_unit/unit_printer.ml
@@ -50,7 +50,7 @@ let pp_cobol_unit ?(show_items = false) =
          (Fmt.(list ~sep:nop) Cobol_data.Printer.pp_record));
     C'(show_items,
        Pretty.vfield "items" (fun x -> x.unit_data.data_items.named)
-         (Unit_qualmap.pp_qualmap Cobol_data.Printer.pp_data_definition));
+         (Unit_resolver_map.pp Cobol_data.Printer.pp_data_definition));
   ]
 
 let pp_cobol_unit' ppf u = pp_cobol_unit ppf ~&u

--- a/src/lsp/cobol_unit/unit_procedure.ml
+++ b/src/lsp/cobol_unit/unit_procedure.ml
@@ -22,10 +22,10 @@ let rec find
   : procedure_block =
   match in_section with
   | None ->
-      Unit_qualmap.find procedure_name procedure.procedure_blocks.named
+      Unit_resolver_map.find procedure_name procedure.procedure_blocks.named
   | Some { section_paragraphs; _ } ->
       try
-        Paragraph (Unit_qualmap.find procedure_name section_paragraphs.named)
+        Paragraph (Unit_resolver_map.find procedure_name section_paragraphs.named)
       with Not_found -> find procedure_name procedure
 
 let rec full_qn
@@ -35,9 +35,9 @@ let rec full_qn
   =
   match in_section with
   | None ->
-      (Unit_qualmap.find_binding procedure_name
+      (Unit_resolver_map.find_binding procedure_name
          procedure.procedure_blocks.named).full_qn
   | Some { section_paragraphs; _ } ->
       try
-        (Unit_qualmap.find_binding procedure_name section_paragraphs.named).full_qn
+        (Unit_resolver_map.find_binding procedure_name section_paragraphs.named).full_qn
       with Not_found -> full_qn procedure_name procedure

--- a/src/lsp/cobol_unit/unit_resolver_map.ml
+++ b/src/lsp/cobol_unit/unit_resolver_map.ml
@@ -22,7 +22,7 @@ module NEL = Cobol_common.Basics.NEL
 
 module TYPES = struct
 
-  type 'a qualmap =
+  type 'a resolver_map =
     {
       map: 'a node StrMap.t;
       indirect_quals: StrSet.t;            (* indirect qualifiers used in map *)
@@ -31,7 +31,7 @@ module TYPES = struct
   and 'a node =
     | Exact of {
         binding: 'a binding option;
-        refined: 'a qualmap;
+        refined: 'a resolver_map;
       }
     | Cut of {
         binding: 'a binding;
@@ -49,7 +49,14 @@ module TYPES = struct
 end
 include TYPES
 
-type +'a t = 'a qualmap
+type +'a t = 'a resolver_map
+
+let () =
+  Printexc.register_printer (function
+      | Ambiguous (lazy qns) ->
+          Some (Pretty.to_string "Ambiguous reference found: %a"
+                  (NEL.pp Unit_qual.pp) qns)
+      | _ -> None)
 
 (* --- *)
 
@@ -84,12 +91,12 @@ let pp_binding pp_value ppf { value; full_qn; _ } =
     pp_qualname full_qn
     pp_value value
 
-let pp_qualmap pp_value ppf map =
+let pp pp_value ppf map =
   Pretty.list ~fopen:"{@;<1 2>" ~fsep:"@;<1 2>" ~fclose:"@;}" ~fempty:"{}"
     (pp_binding pp_value) ppf
     (bindings map)
 
-let pp_qualmap_struct pp_value ppf map =
+let pp_struct pp_value ppf map =
   let rec pp_map ppf { map; _ } =
     Pretty.list ~fopen:"{|@;<1 2>" ~fsep:"@;<1 2>" ~fclose:"@;|}" ~fempty:"{/}"
       (fun ppf (key, node) -> Pretty.print ppf "@[<hv 2>%S:@ %a@]" key pp_node node)
@@ -170,13 +177,13 @@ and find_all_bindings qn qmap : _ binding list =
 let find given_qn map =
   (find_binding given_qn map).value
 
-let empty: _ qualmap =
+let empty: _ resolver_map =
   {
     map = StrMap.empty;
     indirect_quals = StrSet.empty;
   }
 
-let add full_qn value (map: 'a qualmap) =
+let add full_qn value (map: 'a resolver_map) =
   let rec insert qn binding { map; indirect_quals } =
     let map =
       StrMap.update (name_of qn) begin fun prev_node ->

--- a/src/lsp/cobol_unit/unit_resolver_map.mli
+++ b/src/lsp/cobol_unit/unit_resolver_map.mli
@@ -13,7 +13,7 @@
 
 module TYPES: sig
 
-  type +'a qualmap
+  type +'a resolver_map
 
   type 'a binding =
     {
@@ -25,18 +25,18 @@ module TYPES: sig
 
 end
 include module type of TYPES
-  with type 'a qualmap = 'a TYPES.qualmap
+  with type 'a resolver_map = 'a TYPES.resolver_map
 
-type +'a t = 'a qualmap
+type +'a t = 'a resolver_map
 
-val pp_qualmap: 'a Pretty.printer -> 'a qualmap Pretty.printer
-val pp_qualmap_struct: 'a Pretty.printer -> 'a qualmap Pretty.printer
+val pp: 'a Pretty.printer -> 'a resolver_map Pretty.printer
+val pp_struct: 'a Pretty.printer -> 'a resolver_map Pretty.printer
 
-val empty: 'a qualmap
-val add: Cobol_ptree.qualname -> 'a -> 'a qualmap -> 'a qualmap
+val empty: 'a resolver_map
+val add: Cobol_ptree.qualname -> 'a -> 'a resolver_map -> 'a resolver_map
 
-val fold: f:('a binding -> 'b -> 'b) -> 'a qualmap -> 'b -> 'b
-val find: Cobol_ptree.qualname -> 'a qualmap -> 'a
+val fold: f:('a binding -> 'b -> 'b) -> 'a resolver_map -> 'b -> 'b
+val find: Cobol_ptree.qualname -> 'a resolver_map -> 'a
 
-val bindings: 'a qualmap -> 'a binding list
-val find_binding: Cobol_ptree.qualname -> 'a qualmap -> 'a binding
+val bindings: 'a resolver_map -> 'a binding list
+val find_binding: Cobol_ptree.qualname -> 'a resolver_map -> 'a binding

--- a/src/lsp/cobol_unit/unit_types.ml
+++ b/src/lsp/cobol_unit/unit_types.ml
@@ -52,9 +52,15 @@ type unit_config =
 
 (* data items *)
 
+(** [data_definitions] exposes two views on the items (fields and tables) in DATA DIVISION: 
+   - [data_items] contains all the items with direct access by name.
+   - [data_records] is a list of record trees where each element represents 
+      a record definition (typically a level 01 or 77 data item) *)
 type data_definitions =
   {
-    data_items: Cobol_data.Types.data_definition named_n_ordered;
+    data_items: Cobol_data.Types.data_definition named_n_ordered; (* 
+      LATER: recheck if the list of ordered data_definition is useful here. 
+      All the structure information should already be accessible trhough [data_records]. *)
     data_records: Cobol_data.Types.record list;
   }
 
@@ -90,8 +96,8 @@ and arg_passing_style =
 
 type procedure =
   {
+    procedure_using: procedure_using with_loc option; (* PROCEDURE DIVISION USING ... *)
     procedure_blocks: procedure_block named_n_ordered;
-    procedure_using: procedure_using with_loc option;
   }
 
 (* main *)

--- a/src/lsp/cobol_unit/unit_types.ml
+++ b/src/lsp/cobol_unit/unit_types.ml
@@ -21,7 +21,7 @@ open Cobol_common.Srcloc.TYPES
     many cases anonymous elements of [list] many not belong to [named]. *)
 type 'a named_n_ordered =
   {
-    named: 'a Unit_qualmap.t;
+    named: 'a Unit_resolver_map.t;
     list: 'a list;
   }
 

--- a/src/lsp/sql_preproc/sql_typeck.ml
+++ b/src/lsp/sql_preproc/sql_typeck.ml
@@ -12,8 +12,8 @@ open Cobol_data.Types
 
 let get_x_info (cu : Cobol_unit.Types.cobol_unit) name_str =
   (* TODO: this needs to include refs from EXEC SQL INCLUDE stmt : TSQL042A *)
-  (* May raise Not_found | Cobol_unit.Qualmap.Ambiguous _ *)
-  Cobol_unit.Qualmap.find
+  (* May raise Not_found | Cobol_unit.Resolver_map.Ambiguous _ *)
+  Cobol_unit.Resolver_map.find
     (Cobol_unit.Qual.name
        (Cobol_common.Srcloc.flagit name_str Cobol_common.Srcloc.dummy) )
     cu.unit_data.data_items.named
@@ -34,7 +34,7 @@ let get_length cu name =
             | _ -> size end
         | _ -> size end
     | _ -> 0
-  with Not_found | Cobol_unit.Qualmap.Ambiguous _ -> 0
+  with Not_found | Cobol_unit.Resolver_map.Ambiguous _ -> 0
 
 type cobol_types =
   | UNKNOWN
@@ -124,7 +124,7 @@ let get_type cu name =
     | Not_found ->
       (*     Pretty.out " \"%s\" not found " name; *)
       UNKNOWN
-    | Cobol_unit.Qualmap.Ambiguous _ ->
+    | Cobol_unit.Resolver_map.Ambiguous _ ->
       (*     Pretty.out " \"%s\" not found. qualname nel lazy_t found" name; *)
       UNKNOWN
   in
@@ -152,7 +152,7 @@ let get_scale cu name =
   | Not_found ->
     (*     Pretty.out " \"%s\" not found " name; *)
     0
-  | Cobol_unit.Qualmap.Ambiguous _ ->
+  | Cobol_unit.Resolver_map.Ambiguous _ ->
     (*     Pretty.out " \"%s\" not found. qualname nel lazy_t found" name; *)
     0
 
@@ -184,7 +184,7 @@ let get_elementary_component cu name =
       aux payload
     | _ -> [name]
   with
-  | Not_found | Cobol_unit.Qualmap.Ambiguous _ -> [name]
+  | Not_found | Cobol_unit.Resolver_map.Ambiguous _ -> [name]
 
 let is_varying_len cu name =
   try
@@ -212,7 +212,7 @@ let is_varying_len cu name =
         | _ -> false)
     | _ -> false
   with
-  | Not_found | Cobol_unit.Qualmap.Ambiguous _ -> false
+  | Not_found | Cobol_unit.Resolver_map.Ambiguous _ -> false
 
 
 (*TODO*)

--- a/src/lsp/superbol_free_lib/command_sql.ml
+++ b/src/lsp/superbol_free_lib/command_sql.ml
@@ -30,8 +30,8 @@ let typeck_file { preproc_options; parser_options; _ } filename =
       let cu = cu'.payload in
       cu
       (* let x_info =
-           (* May raise Not_found | Cobol_unit.Qualmap.Ambiguous _ *)
-           Cobol_unit.Qualmap.find
+           (* May raise Not_found | Cobol_unit.Resolver_map.Ambiguous _ *)
+           Cobol_unit.Resolver_map.find
              (Cobol_unit.Qual.name ( Cobol_common.Srcloc.flagit "VBFLD" Cobol_common.Srcloc.dummy))
              cu.unit_data.data_items.named
          in

--- a/test/cobol_unit/dune
+++ b/test/cobol_unit/dune
@@ -1,6 +1,6 @@
 (library
  (name test_cobol_unit)
- (modules test_qualmap)
+ (modules test_resolver_map)
  (preprocess
   (pps ppx_expect))
  (inline_tests

--- a/test/cobol_unit/test_resolver_map.ml
+++ b/test/cobol_unit/test_resolver_map.ml
@@ -11,7 +11,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Cobol_unit.Qualmap
+open Cobol_unit.Resolver_map
 open Testing_helpers.Make (Cobol_parser.INTERNAL.Dummy.Tags)
 
 module NEL = Cobol_common.Basics.NEL
@@ -20,8 +20,8 @@ let of_list lst =
   List.fold_left (fun map (qn, value) -> add qn value map) empty lst
 
 let show_map map =
-  Pretty.out "@[<v>Map: %a@]@." (pp_qualmap Fmt.text) map;
-  Pretty.out "@[<v>Rep: %a@]@." (pp_qualmap_struct Fmt.text) map
+  Pretty.out "@[<v>Map: %a@]@." (pp Fmt.text) map;
+  Pretty.out "@[<v>Rep: %a@]@." (pp_struct Fmt.text) map
 
 let pp_qualname ppf qn =
   Pretty.print ppf "@[<h>%a@]" Cobol_ptree.pp_qualname qn


### PR DESCRIPTION
This PR tries to add missing documentation on the typed COBOL AST.

Currently this is a draft with open questions where I need some input to produce a useful and missing documentation.

I also suggest some very minor refactorings that I am ready to perform.