### PR TITLE
Fix bug in CFG when paragraphs share the same name

### DIFF
--- a/src/lsp/cobol_cfg/cfg_builder.ml
+++ b/src/lsp/cobol_cfg/cfg_builder.ml
@@ -73,14 +73,17 @@ let call_stmt_section_name = "__CALL_STMT__"
 let reset_global_counter () =
   node_idx := 0
 
-let build_node ?(is_section=false) ?(display_name_type=Full) ~cu paragraph =
+let build_node 
+    ?(is_section=false) 
+    ?(display_name_type=Full) 
+    ~in_section ~cu paragraph =
   let { jumps; will_fallthru; terminal; skip_remaining = _ }
     : JumpsCollector.acc = Visitor.fold_procedure_paragraph'
-      (JumpsCollector.folder ~cu) paragraph JumpsCollector.init in
+      (JumpsCollector.folder ~in_section ~cu) paragraph JumpsCollector.init in
   let typ, loc, section_name = match ~&paragraph.paragraph_name with
     | None -> Entry `Paragraph, ~@paragraph, ""
     | Some qn ->
-      let fullqn = full_qn' ~cu qn in
+      let fullqn = full_qn' ~in_section ~cu qn in
       let full_name = qn_to_fullname fullqn in
       let short_name, section_name =
         let name, qualifier = qn_to_strings fullqn in
@@ -185,10 +188,10 @@ let cfg_of ~(cu: cobol_unit) =
   let nodes = List.fold_left begin fun acc block ->
       match block with
       | Paragraph para ->
-        build_node ~cu para :: acc
-      | Section { payload = { section_paragraphs; _ }; _ } ->
+        build_node ~in_section:None ~cu para :: acc
+      | Section { payload = { section_paragraphs; _ } as section; _ } ->
         fst @@ List.fold_left begin fun (acc, is_section) p ->
-          build_node ~is_section ~cu p :: acc,
+          build_node ~is_section ~in_section:(Some section) ~cu p :: acc,
           false
         end (acc, true) section_paragraphs.list
     end [] cu.unit_procedure.procedure_blocks.list
@@ -200,13 +203,15 @@ let cfg_of ~(cu: cobol_unit) =
   end
   |> build_edges
 
-let cfg_of_section ~cu ({ section_paragraphs; _ }: procedure_section) =
+let cfg_of_section ~cu (section: procedure_section) =
   reset_global_counter ();
   let nodes =
-    List.fold_left begin fun (acc, is_section) p ->
-      build_node ~is_section ~display_name_type:Short ~cu p :: acc,
-      false
-    end ([], true) section_paragraphs.list
+    List.fold_left (fun (acc, is_section) p ->
+        build_node ~is_section ~display_name_type:Short 
+          ~in_section:(Some section) ~cu p
+          :: acc,
+        false
+      ) ([], true) section.section_paragraphs.list
     |> fst
     |> List.rev in
   begin match nodes with

--- a/src/lsp/cobol_cfg/cfg_jumps.ml
+++ b/src/lsp/cobol_cfg/cfg_jumps.ml
@@ -41,10 +41,10 @@ module Jumps = Set.Make(struct
       | _ -> to_int j2 - to_int j1
   end)
 
-let full_qn ~cu qn =
-  (Resolver_map.find_binding qn cu.unit_procedure.procedure_blocks.named).full_qn
+let full_qn ~in_section ~cu qn =
+  Procedure.full_qn ?in_section qn cu.unit_procedure
 
-let full_qn' ~cu qn = full_qn ~cu ~&qn
+let full_qn' ~in_section ~cu qn = full_qn ~in_section ~cu ~&qn
 
 
 module JumpsCollector = struct
@@ -61,7 +61,7 @@ module JumpsCollector = struct
                skip_remaining = false;
              }
 
-  let folder ~cu = object (v)
+  let folder ~in_section ~cu = object (v)
     inherit [acc] Visitor.folder
 
     method! fold_goback' _ acc =
@@ -136,21 +136,23 @@ module JumpsCollector = struct
       | GoToSimple { target } ->
         {
           acc with
-          jumps = Jumps.add (Go (full_qn' ~cu target)) acc.jumps;
+          jumps = Jumps.add (Go (full_qn' ~in_section ~cu target)) acc.jumps;
           will_fallthru = false;
           skip_remaining = true;
         }
       | GoToDepending { targets; _ } ->
         Cobol_common.Basics.NEL.(
           targets
-          |> map ~f:(full_qn' ~cu)
+          |> map ~f:(full_qn' ~in_section ~cu)
           |> fold_left ~f:begin fun acc target ->
             Jumps.add (GoDepending target) acc
           end acc.jumps)
         |> begin fun jumps -> { acc with jumps } end
 
     method! fold_perform_target' { payload; _ } acc =
-      let start = full_qn' ~cu payload.perform_target.procedure_start in
+      let start =
+        full_qn' ~in_section ~cu payload.perform_target.procedure_start
+      in
       skip { acc with jumps = Jumps.add (Perform start) acc.jumps }
 
     method! fold_call' { payload = { call_target; _ }; _ } acc =

--- a/src/vscode/superbol-vscode-lib/superbol_cfg_explorer.ml
+++ b/src/vscode/superbol-vscode-lib/superbol_cfg_explorer.ml
@@ -158,14 +158,15 @@ let callGetCFG ?render_options ~uri ~name client =
   Vscode_languageclient.LanguageClient.sendRequest client ()
     ~meth:"superbol/getCFG" ~data |>
   Promise.then_
-    ~rejected:begin fun _ ->
+    ~rejected:(fun err ->
+      let err_js = Promise.error_to_js err in
+      let msg = Ojs.string_of_js (Ojs.get_prop_ascii err_js "message") in
       VS.Window.showErrorMessage
-        ~message:"Impossible to render graph, \
-                  try closing and reopening the webview" ()
-    end
-    ~fulfilled:begin fun jsonoo ->
+        ~message:("Impossible to render graph: " ^ msg) ()
+    )
+    ~fulfilled:(fun jsonoo ->
       Promise.return (Some (decode_graph jsonoo))
-    end
+    )
 
 (* WEBVIEW MANAGEMENT *)
 


### PR DESCRIPTION
In COBOL if a program contains multiple paragraphs with the same name A, then GO TO A, jumps to the paragraph A in the current section without ambiguity.
The CFG was ignoring this rule and therefore crashed signalling an ambiguity when it occurred.
This PR uses the correct procedure name resolution, and fixes the bug.