### PR TITLE
Add diagnostic about undefined data-names

### DIFF
--- a/src/lsp/cobol_typeck/typeck_procedure_diagnostics.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure_diagnostics.ml
@@ -25,6 +25,7 @@ type qualname_ambiguity =
 
 type error =
   | Unknown_proc_name of Cobol_ptree.qualname with_loc
+  | Undefined_data_name of Cobol_ptree.qualname with_loc
   | Ambiguous_data_name of qualname_ambiguity
   | Ambiguous_proc_name of qualname_ambiguity
   | Invalid_proc_arg_storage of
@@ -39,6 +40,7 @@ type error =
 
 let error_loc = function
   | Unknown_proc_name { loc; _ }
+  | Undefined_data_name { loc; _ }
   | Ambiguous_data_name { given_qualname = { loc; _ }; _ }
   | Ambiguous_proc_name { given_qualname = { loc; _ }; _ }
   | Invalid_proc_arg_storage { arg_name = { loc; _ }; _ }
@@ -55,6 +57,8 @@ let pp_qualname_ambiguity ~kind ppf { given_qualname; matching_qualnames } =
 let pp_error ppf = function
   | Unknown_proc_name qn ->
       Pretty.print ppf "Unknown@ procedure-name@ '%a'" QUAL.pp ~&qn
+  | Undefined_data_name qn ->
+      Pretty.print ppf "Undefined@ data-name@ '%a'" QUAL.pp ~&qn
   | Ambiguous_data_name ambiguity ->
       pp_qualname_ambiguity ~kind:"data-name" ppf ambiguity
   | Ambiguous_proc_name ambiguity ->

--- a/src/lsp/cobol_typeck/typeck_references.ml
+++ b/src/lsp/cobol_typeck/typeck_references.ml
@@ -29,8 +29,10 @@ let empty_accumulator =
 let error acc err =
   { acc with diags = Proc_error err :: acc.diags }
 
-(** May raise {!Not_found} when [strict = true] (the default) *)
-let resolve_data_qualname ~data_definitions ?(strict = true)
+(** Emits a warning diagnostic on undefined data-name unless
+    [assume_partial_data_definitions] is explictly set to [true]. *)
+let resolve_data_qualname ~data_definitions
+    ?(assume_partial_data_definitions = false)
     ({ loc; payload = qn } as qn') acc =
   try
     let bnd = Resolver_map.find_binding qn data_definitions.data_items.named in
@@ -38,16 +40,16 @@ let resolve_data_qualname ~data_definitions ?(strict = true)
     { acc with
       refs = Typeck_outputs.register_data_qualref ~loc bnd.full_qn acc.refs }
   with
-  | Not_found when not strict ->
-      (* TODO: error acc @@ Undefined_data_item { qualname = qn' } *)
+  | Not_found ->
       Error (),
-      acc
+      if assume_partial_data_definitions
+      then acc                                 (* skip "undefined" diagnostic *)
+      else error acc @@ Undefined_data_name qn'
   | Resolver_map.Ambiguous (lazy matching_qualnames) ->
       Error (),
-      error acc @@ Ambiguous_data_name { given_qualname = qn &@ loc;
+      error acc @@ Ambiguous_data_name { given_qualname = qn';
                                          matching_qualnames }
 
-(** May raise {!Not_found} *)
 let resolve_record_name ~data_definitions name acc =
   let res, acc =
     resolve_data_qualname (Cobol_ptree.Name name &@<- name) acc
@@ -59,8 +61,8 @@ let resolve_record_name ~data_definitions name acc =
 let register_data_qualname ~data_definitions qn' acc =
   snd @@
   resolve_data_qualname ~data_definitions qn' acc
-    ~strict:false  (* ignore missing defs unfil we process all the DATA
-                      DIVISION. *)
+    ~assume_partial_data_definitions:true (* ignore missing defs unfil we
+                                             process all the DATA DIVISION. *)
 
 let register_name ~data_definitions name acc =
   register_data_qualname (Cobol_ptree.Name name &@<- name) acc


### PR DESCRIPTION
Do not actually emit those warnings as not every section of the data division is analyzed.