### PR TITLE
Refactoring around the AST for PROCEDURE DIVISION

### DIFF
--- a/src/lsp/cobol_cfg/cfg_builder.ml
+++ b/src/lsp/cobol_cfg/cfg_builder.ml
@@ -182,16 +182,12 @@ let build_edges nodes =
 
 let cfg_of ~(cu: cobol_unit) =
   reset_global_counter ();
-  let nodes = List.fold_left begin fun acc block ->
-      match block with
-      | Paragraph para ->
-        build_node ~cu para :: acc
-      | Section { payload = { section_paragraphs; _ }; _ } ->
+  let nodes = List.fold_left begin fun acc { payload = { section_paragraphs; _ }; _ } ->
         fst @@ List.fold_left begin fun (acc, is_section) p ->
           build_node ~is_section ~cu p :: acc,
           false
         end (acc, true) section_paragraphs.list
-    end [] cu.unit_procedure.procedure_blocks.list
+    end [] cu.unit_procedure.procedure_sections
   in
   List.rev nodes
   |> begin function (* adding entry point if not already present *)
@@ -218,14 +214,15 @@ let cfg_of_section ~cu ({ section_paragraphs; _ }: procedure_section) =
 let graph_material_of_doc ({ group; _ }: Cobol_typeck.Outputs.t) =
   Cobol_unit.Collections.SET.fold
     begin fun { payload = cu; _ } acc ->
-      let section_graphs = List.filter_map begin function
-          | Paragraph _ -> None
-          | Section sec ->
+      let section_graphs = List.filter_map begin fun (sec: procedure_section with_loc) ->
+          match ~&sec.section_name with
+          | None -> None
+          | Some section_name ->
             let name = Pretty.to_string "%a (%s)"
-                Cobol_ptree.pp_name' ~&sec.section_name
+                Cobol_ptree.pp_name' section_name
                 ((~&) cu.unit_name) in
             Some (name, `Section (cu, ~&sec))
-        end cu.unit_procedure.procedure_blocks.list in
+        end cu.unit_procedure.procedure_sections in
       let cu_name = (~&)cu.unit_name in
       (cu_name, `Cu cu) :: section_graphs @ acc
     end group []

--- a/src/lsp/cobol_cfg/cfg_builder.ml
+++ b/src/lsp/cobol_cfg/cfg_builder.ml
@@ -222,7 +222,7 @@ let graph_material_of_doc ({ group; _ }: Cobol_typeck.Outputs.t) =
           | Paragraph _ -> None
           | Section sec ->
             let name = Pretty.to_string "%a (%s)"
-                Cobol_ptree.pp_qualname' ~&sec.section_name
+                Cobol_ptree.pp_name' ~&sec.section_name
                 ((~&) cu.unit_name) in
             Some (name, `Section (cu, ~&sec))
         end cu.unit_procedure.procedure_blocks.list in

--- a/src/lsp/cobol_cfg/cfg_jumps.ml
+++ b/src/lsp/cobol_cfg/cfg_jumps.ml
@@ -42,7 +42,7 @@ module Jumps = Set.Make(struct
   end)
 
 let full_qn ~cu qn =
-  (Resolver_map.find_binding qn cu.unit_procedure.procedure_blocks.named).full_qn
+  (Resolver_map.find_binding qn cu.unit_procedure.procedure_blocks).full_qn
 
 let full_qn' ~cu qn = full_qn ~cu ~&qn
 

--- a/src/lsp/cobol_lsp/lsp_completion.ml
+++ b/src/lsp/cobol_lsp/lsp_completion.ml
@@ -159,26 +159,26 @@ let qualnames_proposal ~filename pos group : typed_qualname list =
     |> List.flatten
 
 let procedures_proposal ~filename pos group =
+  let open Cobol_unit.Types in
   match Lsp_lookup.last_cobol_unit_before_pos ~filename pos group with
   | None -> []
   | Some cu ->
-    let to_string_with_type typ paragraph =
-      match ~&paragraph with
-      | Cobol_unit.Types.{ paragraph_name = Some { payload = qn; _ }; _ } ->
-        List.map (fun s -> typ, s) @@ to_string qn
-      | _ -> []
-    in
-    cu.unit_procedure.procedure_blocks.list
-    |> List.rev_map begin function
-      | Cobol_unit.Types.Paragraph p ->
-        to_string_with_type "Paragraph" p
-      | Section section ->
-        List.mapi begin fun i paragraph ->
-          let typ = (if i == 0 then "Section" else "Paragraph") in
-          to_string_with_type typ paragraph end
-          ~&section.section_paragraphs.list
-        |> List.flatten
-    end
+    cu.unit_procedure.procedure_sections
+    |> List.rev_map (fun section ->
+        let paragraph_names = 
+          List.map (fun paragraph ->
+              match ~&paragraph with
+              | { paragraph_name = Some { payload = qn; _ }; 
+                  paragraph = { payload = { paragraph_is_section = false; _ }; _ } } ->
+                  List.map (fun s -> "Paragraph", s) @@ to_string qn
+              | _ -> [])
+            ~&section.section_paragraphs.list |>
+            List.flatten
+        in
+        match ~&section.section_name with
+          | Some sn -> ("Section", ~&sn) :: paragraph_names
+          | None -> paragraph_names
+    )
     |> List.flatten
 
 let all_intrinsic_function_name =

--- a/src/lsp/cobol_lsp/lsp_lookup.ml
+++ b/src/lsp/cobol_lsp/lsp_lookup.ml
@@ -539,7 +539,7 @@ let proc_at_pos ~filename (pos: Lsp.Types.Position.t) group : procedure_at_posit
       let proc_name = match cu, paragraph_name with
         | Some cu, Some qn ->
           Some (Cobol_unit.Resolver_map.find_binding
-                  ~&qn cu.unit_procedure.procedure_blocks.named).full_qn
+                  ~&qn cu.unit_procedure.procedure_blocks).full_qn
         | _ -> None
       in
       skip { cu; proc_name }

--- a/src/lsp/cobol_lsp/lsp_request.ml
+++ b/src/lsp/cobol_lsp/lsp_request.ml
@@ -266,9 +266,9 @@ let find_proc_definition
   | Paragraph { payload = { paragraph_name = Some qn; _ }; _ }
     when focus_on_name_in_defintions ->
       [location_of qn]
-  | Section p
+  | Section { payload = { section_name = Some n; _ } ; _ }
     when focus_on_name_in_defintions ->
-      [location_of ~&p.section_name]
+      [location_of n]
   | Paragraph p ->
       [location_of p]
   | Section p ->

--- a/src/lsp/cobol_ptree/branching_statements.ml
+++ b/src/lsp/cobol_ptree/branching_statements.ml
@@ -101,7 +101,7 @@ and evaluate_branch =
 (* PERFORM *)
 and perform_target_stmt =
   {
-    perform_target: procedure_name with_loc procedure_range;
+    perform_target: procedure_range;
     perform_mode: perform_mode option;
   }
 
@@ -638,7 +638,7 @@ and pp_evaluate_branch ppf { eval_selection; eval_actions } =
 
 and pp_perform_target_stmt ppf { perform_target; perform_mode } =
   Fmt.pf ppf "@[<hv>PERFORM@;<1 2>%a%a@]"
-    (pp_procedure_range pp_procedure_name') perform_target
+    pp_procedure_range perform_target
     Fmt.(option (sp ++ pp_perform_mode)) perform_mode
 
 and pp_perform_inline_stmt ppf { perform_inline_mode; perform_statements } =

--- a/src/lsp/cobol_ptree/operands.ml
+++ b/src/lsp/cobol_ptree/operands.ml
@@ -706,13 +706,13 @@ let pp_unstring_target ppf
 
 (* --- generics --- *)
 
-type 'a procedure_range =
+type procedure_range =
   {
-    procedure_start: 'a;
-    procedure_end: 'a option;
+    procedure_start: procedure_name with_loc;
+    procedure_end: procedure_name with_loc option;
   }
 [@@deriving ord]
 
-let pp_procedure_range pp ppf { procedure_start; procedure_end } =
-  pp ppf procedure_start;
-  Fmt.(option (sp ++ const string "THROUGH" ++ sp ++ pp)) ppf procedure_end
+let pp_procedure_range ppf { procedure_start; procedure_end } =
+  pp_procedure_name' ppf procedure_start;
+  Fmt.(option (sp ++ const string "THROUGH" ++ sp ++ pp_procedure_name')) ppf procedure_end

--- a/src/lsp/cobol_ptree/operands_visitor.ml
+++ b/src/lsp/cobol_ptree/operands_visitor.ml
@@ -47,7 +47,7 @@ class ['a] folder = object
   method fold_stage                    : (stage                     , 'a) fold = default
   method fold_advancing_phrase         : (advancing_phrase          , 'a) fold = default
   method fold_write_target             : (write_target              , 'a) fold = default
-  method fold_procedure_range          : 'x. ('x procedure_range      , 'a) fold = default
+  method fold_procedure_range          : (procedure_range           , 'a) fold = default
   (* SET *)
   method fold_set_attribute_switch     : (set_attribute_switch      , 'a) fold = default
   method fold_screen_attribute         : (screen_attribute          , 'a) fold = default
@@ -251,11 +251,11 @@ let fold_write_target (v: _ #folder) =
 
 (* --- *)
 
-let fold_procedure_range (v: _ #folder) ~fold =
+let fold_procedure_range (v: _ #folder) =
   handle v#fold_procedure_range
     ~continue:begin fun { procedure_start; procedure_end } x -> x
-      >> fold v procedure_start
-      >> fold_option ~fold v procedure_end
+      >> fold_procedure_name' v procedure_start
+      >> fold_procedure_name'_opt v procedure_end
     end
 
 (* SET *)

--- a/src/lsp/cobol_ptree/proc_division.ml
+++ b/src/lsp/cobol_ptree/proc_division.ml
@@ -100,8 +100,14 @@ and use_after_exception =
 
 and paragraph =
   {
-    paragraph_name: name with_loc option;
-    paragraph_is_section: bool;
+    paragraph_name: name with_loc option; (** Contains either:
+      - the paragraph name for a named paragraph
+      - the section name for the anonymous paragraph at the begining of 
+        a named section
+      - [None] for the anonymous paragraph at the begining of 
+        PROCEDURE DIVISION *)
+    paragraph_is_section: bool; (**
+      true when this paragraph is an anonymous paragraph at the begining of a section *)
     paragraph_segment: integer option;
     paragraph_sentences: statements with_loc list;
   }

--- a/src/lsp/cobol_ptree/simple_statements.ml
+++ b/src/lsp/cobol_ptree/simple_statements.ml
@@ -483,14 +483,13 @@ type merge_stmt =
 [@@deriving ord]
 
 and merge_or_sort_target =
-  | OutputProcedure of procedure_name with_loc procedure_range
+  | OutputProcedure of procedure_range
   | Giving of name with_loc list
 [@@deriving ord]
 
 let pp_merge_or_sort_target ppf = function
   | OutputProcedure pr ->
-    Fmt.pf ppf "OUTPUT@ PROCEDURE@ IS@ %a"
-      (pp_procedure_range pp_procedure_name') pr
+    Fmt.pf ppf "OUTPUT@ PROCEDURE@ IS@ %a" pp_procedure_range pr
   | Giving ns ->
     Fmt.pf ppf "GIVING@ %a" Fmt.(list ~sep:sp (pp_with_loc pp_name)) ns
 
@@ -785,14 +784,13 @@ type sort_stmt =
 [@@deriving ord]
 
 and sort_source =                                                (* SORT only *)
-  | SortInputProcedure of procedure_name with_loc procedure_range
+  | SortInputProcedure of procedure_range
   | SortUsing of name with_loc list
 [@@deriving ord]
 
 let pp_sort_source ppf = function
   | SortInputProcedure pr ->
-    Fmt.pf ppf "INPUT@ PROCEDURE@ %a"
-      (pp_procedure_range pp_procedure_name') pr
+    Fmt.pf ppf "INPUT@ PROCEDURE@ %a" pp_procedure_range pr
   | SortUsing ns ->
     Fmt.pf ppf "USING@ %a"
       Fmt.(list ~sep:sp (pp_with_loc pp_name)) ns

--- a/src/lsp/cobol_ptree/statements_visitor.ml
+++ b/src/lsp/cobol_ptree/statements_visitor.ml
@@ -320,7 +320,6 @@ let fold_merge_or_sort_target (v : _ #folder) =
     ~continue:begin function
       | OutputProcedure name_procedure_range ->
           fold_procedure_range v name_procedure_range
-            ~fold:fold_procedure_name'
       | Giving names ->
           fold_list ~fold:fold_name' v names
     end
@@ -428,7 +427,7 @@ let fold_sort_source (v: _ #folder) =
   handle v#fold_sort_source
     ~continue:begin fun s x -> match s with
       | SortInputProcedure pr -> x
-          >> fold_procedure_range ~fold:fold_procedure_name' v pr
+          >> fold_procedure_range v pr
       | SortUsing names -> x
           >> fold_name'_list v names
     end
@@ -1060,7 +1059,7 @@ and fold_perform_inline' (v: _ #folder) : perform_inline_stmt with_loc -> 'a -> 
 and fold_perform_target' (v: _ #folder) : perform_target_stmt with_loc -> 'a -> 'a =
   handle' v#fold_perform_target' v
     ~fold:begin fun v { perform_target = proc_range; perform_mode } x -> x
-      >> fold_procedure_range ~fold:fold_procedure_name' v proc_range
+      >> fold_procedure_range v proc_range
       >> fold_option ~fold:fold_perform_mode v perform_mode
     end
 

--- a/src/lsp/cobol_typeck/typeck_procedure.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure.ml
@@ -101,7 +101,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
       }
     and section_under_construction =
       {
-        sec_name: Cobol_ptree.procedure_name with_loc;
+        sec_name: string with_loc;
         sec_paragraphs: procedure_paragraph with_loc list;
       }
 
@@ -156,8 +156,8 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
       | None, Some n ->
           { paragraph_name = Some (name n &@<- n);
             paragraph = p } &@<- p
-      | Some { payload = { sec_name = qn; _ }; _ }, Some n ->
-          { paragraph_name = Some (qual n ~&qn &@<- n);
+      | Some { payload = { sec_name; _ }; _ }, Some n ->
+          { paragraph_name = Some (qual n (name sec_name) &@<- n);
             paragraph = p } &@<- p
       | _, None ->
           { paragraph_name = None;
@@ -168,10 +168,10 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
 
     let commit_section acc =
       match acc.current_section with
-      | Some ({ payload = { sec_name = qn; _ }; _ } as section) ->
+      | Some ({ payload = { sec_name; _ }; _ } as section) ->
           let section = section_block section in
           { acc with
-            blocks = Resolver_map.add ~&qn section acc.blocks;
+            blocks = Resolver_map.add (name sec_name) section acc.blocks;
             block_list = section :: acc.block_list;
             current_section = None }
       | None ->
@@ -181,7 +181,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
       let acc = commit_section acc in
       let sec_paragraphs = [simple_paragraph s acc] in
       { acc with
-        current_section = Some ({ sec_name = name n &@<- n;
+        current_section = Some ({ sec_name = n;
                                   sec_paragraphs } &@<- s) }
 
     let named_paragraph n p acc =
@@ -195,7 +195,7 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
         | Some s ->
             let loc = Cobol_common.Srcloc.concat ~@s ~@p in
             let sec_paragraphs = p :: ~&s.sec_paragraphs in
-            qual n ~&(~&s.sec_name),
+            qual n (name (~&s.sec_name)),
             acc.block_list,
             Some ({ ~&s with sec_paragraphs } &@ loc)
       in

--- a/src/lsp/cobol_typeck/typeck_procedure.ml
+++ b/src/lsp/cobol_typeck/typeck_procedure.ml
@@ -95,28 +95,22 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
     type acc =
       {
         blocks: procedure_block Resolver_map.t;
-        block_list: procedure_block list;
+        section_list: procedure_section with_loc list;
         current_section: section_under_construction with_loc option;
         args: Cobol_ptree.procedure_using_phrase with_loc option;
       }
     and section_under_construction =
       {
-        sec_name: string with_loc;
+        sec_name: Cobol_ptree.name with_loc option;
         sec_paragraphs: procedure_paragraph with_loc list;
       }
 
     let init =
       {
         blocks = Resolver_map.empty;
-        block_list = [];
+        section_list = [];
         current_section = None;
         args = None;
-      }
-
-    let procedure_blocks acc =
-      {
-        named = acc.blocks;
-        list = List.rev acc.block_list;
       }
 
     let procedure_using acc =
@@ -129,7 +123,8 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
     let procedure acc =
       let procedure_using, references = procedure_using acc in
       {
-        procedure_blocks = procedure_blocks acc;
+        procedure_blocks = acc.blocks;
+        procedure_sections = List.rev acc.section_list;
         procedure_using;
       },
       references
@@ -137,76 +132,80 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
     let name n : Cobol_ptree.qualname = Name n
     let qual n q : Cobol_ptree.qualname = Qual (n, q)
 
-    let section_block
+    let procedure_section
         ({ payload = suc; loc }: section_under_construction with_loc) =
       let section_paragraphs =
-        List.fold_left begin fun ({ named; list } as paragraphs) paragraph ->
-          match ~&paragraph.paragraph_name with
-          | None ->
-              { paragraphs with list = paragraph :: list }
-          | Some qn ->
-              { named = Resolver_map.add ~&qn paragraph named;
-                list = paragraph :: list }
-        end { named = Resolver_map.empty; list = [] } suc.sec_paragraphs
+        (* The section is completely empty: add an empty paragraph to ensure 
+           that each section has at least one paragraph *)
+        if suc.sec_paragraphs = [] then
+          let empty_paragraph = Cobol_ptree.{ 
+            paragraph_name = suc.sec_name;
+            paragraph_is_section = true; 
+            paragraph_segment = None; 
+            paragraph_sentences = [] }
+          in
+          { named = Resolver_map.empty; 
+            list = [{ paragraph_name = None; paragraph = empty_paragraph &@ loc} &@ loc] }
+        else
+          List.fold_left (fun ({ named; list } as paragraphs) paragraph ->
+            match ~&paragraph.paragraph_name with
+            | None ->
+                { paragraphs with list = paragraph :: list }
+            | Some qn ->
+                { named = Resolver_map.add ~&qn paragraph named;
+                  list = paragraph :: list }
+            ) { named = Resolver_map.empty; list = [] } suc.sec_paragraphs
       in
-      Section ({ section_name = suc.sec_name; section_paragraphs } &@ loc)
-
-    let simple_paragraph (p: Cobol_ptree.paragraph with_loc) acc =
-      match acc.current_section, ~&p.paragraph_name with
-      | None, Some n ->
-          { paragraph_name = Some (name n &@<- n);
-            paragraph = p } &@<- p
-      | Some { payload = { sec_name; _ }; _ }, Some n ->
-          { paragraph_name = Some (qual n (name sec_name) &@<- n);
-            paragraph = p } &@<- p
-      | _, None ->
-          { paragraph_name = None;
-            paragraph = p } &@<- p
-
-    let paragraph_block p =
-      Paragraph p
+      { section_name = suc.sec_name; section_paragraphs } &@ loc
 
     let commit_section acc =
       match acc.current_section with
       | Some ({ payload = { sec_name; _ }; _ } as section) ->
-          let section = section_block section in
+          let section = procedure_section section in
+          let blocks = match sec_name with
+            | Some sec_name -> Resolver_map.add (name sec_name) (Section section) acc.blocks
+            | None -> acc.blocks
+          in
           { acc with
-            blocks = Resolver_map.add (name sec_name) section acc.blocks;
-            block_list = section :: acc.block_list;
+            blocks;
+            section_list = section :: acc.section_list;
             current_section = None }
       | None ->
           acc
 
-    let start_new_section n s acc =
+    let start_new_section p acc =
+      let n = Cobol_ptree.(~&p.paragraph_name) in
       let acc = commit_section acc in
-      let sec_paragraphs = [simple_paragraph s acc] in
-      { acc with
-        current_section = Some ({ sec_name = n;
-                                  sec_paragraphs } &@<- s) }
-
-    let named_paragraph n p acc =
-      let p = simple_paragraph p acc in
-      let qn, block_list, current_section =
-        match acc.current_section with
-        | None ->
-            name n,
-            paragraph_block p :: acc.block_list,
-            None
-        | Some s ->
-            let loc = Cobol_common.Srcloc.concat ~@s ~@p in
-            let sec_paragraphs = p :: ~&s.sec_paragraphs in
-            qual n (name (~&s.sec_name)),
-            acc.block_list,
-            Some ({ ~&s with sec_paragraphs } &@ loc)
+      let sec_paragraphs =
+        (* Avoid adding an empty section header paragraph if unneeded, and
+           remove section name from the location of the unnamed paragraph at
+           the begining of section. *)
+        match Cobol_common.Srcloc.concat_locs ~&p.paragraph_sentences with
+        | None -> [] (* when ~&p.paragraph_sentences = [] *)
+        | Some loc -> [{ paragraph_name = None; paragraph = p } &@ loc] 
       in
       { acc with
-        blocks = Resolver_map.add qn (paragraph_block p) acc.blocks;
-        block_list;
-        current_section }
+        current_section = Some ({ sec_name = n;
+                                  sec_paragraphs } &@<- p) }
 
-    let anonymous_paragraph p acc =         (* only at beginning of procedure *)
+    let paragraph_in_current_section (p: Cobol_ptree.paragraph with_loc) acc =
+      let s, loc = match acc.current_section with
+        | None -> { sec_name = None; sec_paragraphs = [] }, ~@p
+        | Some s -> ~&s, Cobol_common.Srcloc.concat ~@s ~@p
+      in
+      let paragraph_name = match ~&p.paragraph_name, s.sec_name with
+        | None, _ -> None (* For first paragraph of PROCEDURE DIVISION *)
+        | Some n, None -> Some (name n &@<- n)
+        | Some n, Some sn -> Some (qual n (name sn) &@<- n)
+      in
+      let p = { paragraph_name; paragraph = p } &@<- p in
+      let blocks = match paragraph_name with
+        | None -> acc.blocks
+        | Some qn -> Resolver_map.add ~&qn (Paragraph p) acc.blocks
+      in
       { acc with
-        block_list = paragraph_block (simple_paragraph p acc) :: acc.block_list }
+        blocks;
+        current_section = Some ({ s with sec_paragraphs = p :: s.sec_paragraphs } &@ loc) }
 
   end in
 
@@ -225,11 +224,11 @@ let procedure_of_compilation_unit ~data_definitions ~refs cu' =
       Visitor.skip_children { acc with args = Some args }
 
     method! fold_paragraph' p acc =
-      Visitor.skip_children @@ match ~&p with
-      | { paragraph_is_section = true;
-          paragraph_name = Some name; _ } -> start_new_section name p acc
-      | { paragraph_name = Some name; _ } -> named_paragraph name p acc
-      | { paragraph_name = None; _ }      -> anonymous_paragraph p acc
+      Visitor.skip_children @@ 
+        if ~&p.paragraph_is_section then
+          start_new_section p acc 
+        else 
+          paragraph_in_current_section p acc
 
     method! fold_nested_programs _  = Visitor.skip                    (* TODO *)
   end in

--- a/src/lsp/cobol_unit/unit_procedure.ml
+++ b/src/lsp/cobol_unit/unit_procedure.ml
@@ -22,7 +22,7 @@ let rec find
   : procedure_block =
   match in_section with
   | None ->
-      Unit_resolver_map.find procedure_name procedure.procedure_blocks.named
+      Unit_resolver_map.find procedure_name procedure.procedure_blocks
   | Some { section_paragraphs; _ } ->
       try
         Paragraph (Unit_resolver_map.find procedure_name section_paragraphs.named)
@@ -36,7 +36,7 @@ let rec full_qn
   match in_section with
   | None ->
       (Unit_resolver_map.find_binding procedure_name
-         procedure.procedure_blocks.named).full_qn
+         procedure.procedure_blocks).full_qn
   | Some { section_paragraphs; _ } ->
       try
         (Unit_resolver_map.find_binding procedure_name section_paragraphs.named).full_qn

--- a/src/lsp/cobol_unit/unit_types.ml
+++ b/src/lsp/cobol_unit/unit_types.ml
@@ -61,7 +61,7 @@ type data_definitions =
   {
     data_items: Cobol_data.Types.data_definition named_n_ordered; (* 
       LATER: recheck if the list of ordered data_definition is useful here. 
-      All the structure information should already be accessible trhough [data_records]. *)
+      All the structure information should already be accessible through [data_records]. *)
     data_records: Cobol_data.Types.record list;
   }
 
@@ -69,14 +69,27 @@ type data_definitions =
 
 type procedure_paragraph =
   {
-    paragraph_name: Cobol_ptree.procedure_name with_loc option;
+    paragraph_name: Cobol_ptree.procedure_name with_loc option; (** 
+      [None] for the unnamed paragraph at the begining of a section.
+      [Some qn] where [qn] is fully qualified otherwise. 
+      Note that [paragraph_name] is different than [~&paragraph.paragraph_name].
+      For an unnamed paragraph at the begining of a section 
+      [~&paragraph.paragraph_name] contains the (optionnal) section name whereas
+      [paragraph_name] contains [None] to indicate that the paragraph is
+      anonymous. *)
     paragraph: Cobol_ptree.paragraph with_loc;
   }
 
 type procedure_section =
   {
-    section_name: Cobol_ptree.name with_loc;
-    section_paragraphs: procedure_paragraph with_loc named_n_ordered;
+    section_name: Cobol_ptree.name with_loc option; (**
+      [None] for the unnamed section at the begining of PROCEDURE DIVISION
+      For convenience when collecting references to all procedure names, 
+      [section_name] is visited as a [procedure_name with_loc option]. *)
+    section_paragraphs: procedure_paragraph with_loc named_n_ordered; (**
+      Includes an anonymous empty paragraph if the section is empty.
+      However, this list does not start with an unnamed paragraph, 
+      when the section immediatley starts with a paragraph name. *)
   }
 
 type procedure_block =
@@ -97,12 +110,9 @@ and arg_passing_style =
 
 type procedure =
   {
-    procedure_using: procedure_using with_loc option; (* PROCEDURE DIVISION USING ... *)
-    procedure_blocks: procedure_block named_n_ordered; 
-    (* FIXME: We should probably replace the ordered part with a regular list of sections 
-       including the implicit anonymous section at begining of the file. 
-       I think we have bugs lurking around linked to this missing section and the 
-       processing irregularity that follows from that. *)
+    procedure_using: procedure_using with_loc option; (** PROCEDURE DIVISION USING ... *)
+    procedure_sections: procedure_section with_loc list;
+    procedure_blocks: procedure_block Unit_resolver_map.t; 
   }
 
 (* main *)
@@ -123,4 +133,4 @@ type t = cobol_unit with_loc
 
 let block_name: _ -> Cobol_ptree.qualname with_loc option = function
   | Paragraph { payload = p; _ } -> p.paragraph_name
-  | Section { payload = s; _ } -> Some (Cobol_ptree.Name s.section_name &@<- s.section_name)
+  | Section { payload = s; _ } -> Option.map (fun s -> Cobol_ptree.Name s &@<- s) s.section_name

--- a/src/lsp/cobol_unit/unit_types.ml
+++ b/src/lsp/cobol_unit/unit_types.ml
@@ -14,6 +14,7 @@
 (** Representation of COBOL compilation units *)
 
 open Cobol_common.Srcloc.TYPES
+open Cobol_common.Srcloc.INFIX
 
 (* utils *)
 
@@ -74,7 +75,7 @@ type procedure_paragraph =
 
 type procedure_section =
   {
-    section_name: Cobol_ptree.procedure_name with_loc;
+    section_name: Cobol_ptree.name with_loc;
     section_paragraphs: procedure_paragraph with_loc named_n_ordered;
   }
 
@@ -97,7 +98,11 @@ and arg_passing_style =
 type procedure =
   {
     procedure_using: procedure_using with_loc option; (* PROCEDURE DIVISION USING ... *)
-    procedure_blocks: procedure_block named_n_ordered;
+    procedure_blocks: procedure_block named_n_ordered; 
+    (* FIXME: We should probably replace the ordered part with a regular list of sections 
+       including the implicit anonymous section at begining of the file. 
+       I think we have bugs lurking around linked to this missing section and the 
+       processing irregularity that follows from that. *)
   }
 
 (* main *)
@@ -118,4 +123,4 @@ type t = cobol_unit with_loc
 
 let block_name: _ -> Cobol_ptree.qualname with_loc option = function
   | Paragraph { payload = p; _ } -> p.paragraph_name
-  | Section { payload = s; _ } -> Some s.section_name
+  | Section { payload = s; _ } -> Some (Cobol_ptree.Name s.section_name &@<- s.section_name)

--- a/src/lsp/cobol_unit/unit_visitor.ml
+++ b/src/lsp/cobol_unit/unit_visitor.ml
@@ -64,7 +64,7 @@ let fold_procedure_paragraph' (v: _ #folder) =
 let fold_procedure_section (v: _ #folder) =
   handle v#fold_procedure_section
     ~continue:begin fun { section_name; section_paragraphs } x -> x
-      >> Cobol_ptree.Terms_visitor.fold_procedure_name' v section_name
+      >> Cobol_ptree.Terms_visitor.fold_name' v section_name
       >> fold_list v section_paragraphs.list ~fold:fold_procedure_paragraph'
     end
 

--- a/src/lsp/cobol_unit/unit_visitor.ml
+++ b/src/lsp/cobol_unit/unit_visitor.ml
@@ -64,7 +64,9 @@ let fold_procedure_paragraph' (v: _ #folder) =
 let fold_procedure_section (v: _ #folder) =
   handle v#fold_procedure_section
     ~continue:begin fun { section_name; section_paragraphs } x -> x
-      >> Cobol_ptree.Terms_visitor.fold_name' v section_name
+      >> Cobol_ptree.Terms_visitor.fold_procedure_name'_opt v 
+          (Option.map (fun sn -> 
+            Cobol_ptree.{ payload = Name sn; loc = sn.loc }) section_name)
       >> fold_list v section_paragraphs.list ~fold:fold_procedure_paragraph'
     end
 
@@ -102,9 +104,9 @@ let fold_procedure_using' (v: _ #folder) =
 
 let fold_procedure (v: _ #folder) =
   handle v#fold_procedure                                     (* skip `named` *)
-    ~continue:begin fun { procedure_blocks; procedure_using } x -> x
+    ~continue:begin fun { procedure_sections; procedure_using; _ } x -> x
       >> fold_option ~fold:fold_procedure_using' v procedure_using
-      >> fold_list v ~fold:fold_procedure_block procedure_blocks.list
+      >> fold_list v ~fold:fold_procedure_section' procedure_sections
     end
 
 let fold_cobol_unit (v: _ #folder) =


### PR DESCRIPTION
- procedure_range does not need to be generic: removing the genericity allows to write visitors that can make action each time a procedure_range is appears in the AST.
- Section names cannot be qualified: replace the qualname with a simple name to reflect that and simplify processing.

I guess we should also simplify the management of the anonymous section at the beginning of a PROCEDURE DIVISION in this PR to remove the annoying difference between paragraphs in this section compared to paragraph in other sections.
This would help fix #599 for real and in general implement more robust analyses.