### PR TITLE
Fix pre-processing of some operators in abbreviated relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Warnings on unsupported usage, where the reported data item size may be be wrong [#570](https://github.com/OCamlPro/superbol-studio-oss/pull/570)
 
 ### Fixed
-- Extension breaks under some circumstances [#596](https://github.com/OCamlPro/superbol-studio-oss/issues/596)
+- Handling of some operators in abbreviated combined relation conditions [#611](https://github.com/OCamlPro/superbol-studio-oss/issues/611)
+- Misbehaviors of CFG visualization due to issues in underlying JS bindings [#596](https://github.com/OCamlPro/superbol-studio-oss/issues/596)
 - Details shown on hover of data items with definition issues [#575](https://github.com/OCamlPro/superbol-studio-oss/pull/575)
 - Handling of alphanumeric literals with UTF-8 characters in fixed-format COBOL code [#564](https://github.com/OCamlPro/superbol-studio-oss/pull/564)
 - Handling of queries about `LINKAGE` items given in `USING` phrases [#561](https://github.com/OCamlPro/superbol-studio-oss/pull/561)

--- a/src/lsp/cobol_preproc/src_lexer.mll
+++ b/src/lsp/cobol_preproc/src_lexer.mll
@@ -233,9 +233,14 @@ let currency_sign_char =                                    (* as per ISO/IEC *)
 let text_char = nonblank # ['\'' '"' '&']
 let neq = text_char # ['=']
 let text_word =
-  (* Note: accepts words that include floating comment markers `*>'; these are
-     processed in `Src_lexing.text_word`. *)
-  (neq* '='? neq+)+ | '=' | ">=" | "<=" | '&'
+  (* A text-word shoud not termninate with an equal sign to explicitly deal with
+     pseudotext markers `==`.  Yet, we allow some punctuation characters before
+     a single equal sign to deal with `(>=` and co, that may appear in
+     abbreviated relational conditions.
+
+     Note: accepts words that include floating comment markers `*>'; these are
+     processed in `Src_lexing.text_word`.  *)
+  (neq* '='? neq+)+ | ((neq # letter # digit # sign)* ['>' '<']? '=' neq*) | '&'
 
 let cdir_char =
   (letter | digit | ':')                            (* colon for pseudo-words *)

--- a/test/cobol_parsing/tokens.ml
+++ b/test/cobol_parsing/tokens.ml
@@ -55,6 +55,25 @@ let%expect_test "tokens-with-attached-ampersand" =
     DISPLAY, WORD[A], &, X"00", ., DISPLAY, X"100", &, X"00", ., EOF
 |}];;
 
+let%expect_test "tokens-operators-after-parenthesis" =
+  (* Just check we extract tokens properly *)
+  Parser_testing.show_parsed_tokens {|
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+           IF A >= 1 THEN DISPLAY "A" END-IF
+           IF A (>= 1 OR 2) THEN DISPLAY "A" END-IF
+           IF A ( >= 1 OR 2) THEN DISPLAY "A" END-IF
+           STOP RUN.
+  |};
+  [%expect {|
+    IDENTIFICATION, DIVISION, ., PROGRAM-ID, ., INFO_WORD[prog], ., PROCEDURE,
+    DIVISION, ., IF, WORD[A], >=, DIGITS[1], THEN, DISPLAY, "A", END-IF, IF,
+    WORD[A], LPAR BEFORE RELOP, >=, DIGITS[1], OR, DIGITS[2], ), THEN, DISPLAY,
+    "A", END-IF, IF, WORD[A], LPAR BEFORE RELOP, >=, DIGITS[1], OR, DIGITS[2], ),
+    THEN, DISPLAY, "A", END-IF, STOP, RUN, ., EOF
+|}];;
+
 (* --- *)
 
 let%expect_test "token-locations" =

--- a/test/cobol_preprocessing/compiler_directives.ml
+++ b/test/cobol_preprocessing/compiler_directives.ml
@@ -73,3 +73,13 @@ $
     prog.cob:7.0-7.4:
     >> Error: Invalid >> compiler directive
 |}];;
+
+let%expect_test "replace" =
+  Preproc_testing.preprocess {|
+       REPLACE ==A== BY ==B==.
+       A
+       B
+  |};
+  [%expect {|
+    B B
+|}];;


### PR DESCRIPTION
Before this fix, text like `A (>= 1 OR 2)` lead to wrong syntax errors on the `=` sign.  Now the pre-processor admits `(>=` and co. as proper text words given to the parser.