### PR TITLE
Fix grammar rules for `VALUE OF` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [_] Next release
 
+### Fixed
+- Grammar rules for `VALUE OF` clause [#629](https://github.com/OCamlPro/superbol-studio-oss/pull/629) (fix for [Issue #625](https://github.com/OCamlPro/superbol-studio-oss/issues/625))
+
 
 ## [1.0.0] First stable release (2026-07-23)
 
@@ -23,7 +26,8 @@
 - Documentation and renaming to reduce confusion in the typed COBOL AST API [#576](https://github.com/OCamlPro/superbol-studio-oss/pull/576)
 
 ### Removed
-- Remove deprecated Cobol_data.OLD and Cobol_typeck.OLD [#592](https://github.com/OCamlPro/superbol-studio-oss/pull/592)
+- Remove deprecated `Cobol_data.OLD` and `Cobol_typeck.OLD` [#592](https://github.com/OCamlPro/superbol-studio-oss/pull/592)
+
 
 ## [0.3.0] Third release (2026-02-27)
 

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -1403,10 +1403,13 @@ label_clause:
  | LABEL mr(RECORD IS? | RECORDS ARE? {}) STANDARD { LabelStandard }
  | LABEL mr(RECORD IS? | RECORDS ARE? {}) OMITTED  { LabelOmitted }
 
-valueof_clause:
- | VALUE OF iil = nel(i = name IS? il = qualname_or_literal
-                        { { valueof_valued = i; valueof_value = il; } })
-  { iil }
+let valueof_clause :=
+ | VALUE; OF; ~ = nel(valueof_binding); < >
+
+let valueof_binding :=
+  | s = mr(~ = name; <FileLabelName> | ID; { FileLabelID }); IS?;
+    v = qualname_or_literal;
+    { { valueof_subject = s; valueof_value = v } }
 
 data_clause:
  | DATA_RECORD IS? il = names   { il }
@@ -2820,7 +2823,7 @@ let any_lpar ==
  | LPAR_BEFORE_RELOP; {}
 
 let relation_condition ==
- | neg = ibo(NOT); e = expression; pred = loc(abbrev_relop_operand); 
+ | neg = ibo(NOT); e = expression; pred = loc(abbrev_relop_operand);
     { relation_condition (neg, e, pred) }
 
 nonrel_condition:
@@ -2854,11 +2857,11 @@ abbrev_relation_operand:
 
 extended_condition:
  | e = expression io(IS) n = bo(NOT) c = class_condition
-    { neg_condition ~neg:n (with_loc (ClassCond (e, c)) $sloc) } 
+    { neg_condition ~neg:n (with_loc (ClassCond (e, c)) $sloc) }
  | e = expression io(IS) n = bo(NOT) s = sign_condition
-    { neg_condition ~neg:n (with_loc (SignCond (e, s)) $sloc) } 
+    { neg_condition ~neg:n (with_loc (SignCond (e, s)) $sloc) }
  | e = expression io(IS) n = bo(NOT) OMITTED
-    { neg_condition ~neg:n (with_loc (Omitted e) $sloc) } 
+    { neg_condition ~neg:n (with_loc (Omitted e) $sloc) }
 
 relop [@recovery Eq] [@symbol "<relational arithmetic operator>"]:
  | io(IS) n = ibo(NOT) GREATER THAN?

--- a/src/lsp/cobol_ptree/data_descr.ml
+++ b/src/lsp/cobol_ptree/data_descr.ml
@@ -759,18 +759,24 @@ let pp_source_destination_clause ppf = function
   | Using i -> Fmt.pf ppf "USING %a" pp_ident i
   | Value l -> Fmt.pf ppf "VALUE %a" pp_literal l
 
-type valueof_clause =
+type valueof_clause =                                           (* (obsolete) *)
   {
-    valueof_valued: name with_loc;
+    valueof_subject: file_label;
     valueof_value: qualname_or_literal;
   }
+
+and file_label =
+  | FileLabelID
+  | FileLabelName of name with_loc
 [@@deriving ord]
 
-let pp_valueof_clause ppf { valueof_valued; valueof_value } =
-  Fmt.(
-    pair ~sep:sp pp_name' pp_qualname_or_literal ppf
-      (valueof_valued, valueof_value)
-  )
+let pp_file_label ppf = function
+  | FileLabelID -> Fmt.string ppf "ID"
+  | FileLabelName n -> pp_name' ppf n
+
+let pp_valueof_clause ppf { valueof_subject; valueof_value } =
+  Fmt.(pair ~sep:sp) pp_file_label pp_qualname_or_literal ppf
+    (valueof_subject, valueof_value)
 
 type report_clause =
   | Global

--- a/src/lsp/cobol_ptree/data_descr_visitor.ml
+++ b/src/lsp/cobol_ptree/data_descr_visitor.ml
@@ -81,6 +81,7 @@ class ['a] folder = object
   method fold_table_data_value          : (table_data_value            , 'a) fold = default
   method fold_usage_clause              : (usage_clause                , 'a) fold = default
   method fold_validation_clause         : (validation_clause           , 'a) fold = default
+  method fold_file_label                : (file_label                  , 'a) fold = default
   method fold_valueof_clause            : (valueof_clause              , 'a) fold = default
 
 end
@@ -465,10 +466,17 @@ let fold_validation_clause (v: _ #folder) =
         >> fold_list ~fold:fold_ident v for_
     end
 
+let fold_file_label (v: _ #folder) =
+  handle v#fold_file_label
+    ~continue:begin function
+      | FileLabelID -> Fun.id
+      | FileLabelName n -> fold_name' v n
+    end
+
 let fold_valueof_clause (v: _ #folder) =
   handle v#fold_valueof_clause
-    ~continue:begin fun { valueof_valued; valueof_value } x -> x
-      >> fold_name' v valueof_valued
+    ~continue:begin fun { valueof_subject; valueof_value } x -> x
+      >> fold_file_label v valueof_subject
       >> fold_qualname_or_literal v valueof_value
     end
 


### PR DESCRIPTION
Now accept `VALUE OF ID …` in file sections.

Fix for #625.