### PR TITLE
Enable cross-compilation of TramaBOL

### DIFF
--- a/.drom
+++ b/.drom
@@ -5,7 +5,7 @@ version:0.9.0
 
 # hash of toml configuration files
 # used for generation of all files
-cdf7d82543307c1dd3bc3634338ed992:.
+2247a5f7116d8e7bf828b158af1689bb:.
 # end context for .
 
 # begin context for .github/workflows/workflow.yml
@@ -715,7 +715,7 @@ ef52691ec3bef505aa901bf197009fd1:src/lsp/ppx_cobcflags/dune
 
 # begin context for src/lsp/superbol-free/linking_flags.sh
 # file src/lsp/superbol-free/linking_flags.sh
-866dfc5d53965787696d34b52a08536a:src/lsp/superbol-free/linking_flags.sh
+fd264ba43b014605ebefbd7844b08378:src/lsp/superbol-free/linking_flags.sh
 # end context for src/lsp/superbol-free/linking_flags.sh
 
 # begin context for src/lsp/superbol_free_lib/dune
@@ -780,7 +780,7 @@ ee62b3b4e887b6f2350a3964d7bf2bfe:src/tramabol/cobol_ir/dune
 
 # begin context for src/tramabol/ezlibcob/dune
 # file src/tramabol/ezlibcob/dune
-b465af9c4551ced5d0867c56cb2d9cd0:src/tramabol/ezlibcob/dune
+5a9c3442fe9aa40922aad85b67379275:src/tramabol/ezlibcob/dune
 # end context for src/tramabol/ezlibcob/dune
 
 # begin context for src/tramabol/ezlibcob/index.mld
@@ -795,12 +795,12 @@ b465af9c4551ced5d0867c56cb2d9cd0:src/tramabol/ezlibcob/dune
 
 # begin context for src/tramabol/tramabol/dune
 # file src/tramabol/tramabol/dune
-322d9571c2994fc7d64618d74ff883eb:src/tramabol/tramabol/dune
+0fc4a93612979118a9dd5ec1c31cb714:src/tramabol/tramabol/dune
 # end context for src/tramabol/tramabol/dune
 
 # begin context for src/tramabol/tramabol/linking_flags.sh
 # file src/tramabol/tramabol/linking_flags.sh
-51da76b66c24bd63bb7d4a46ce2fc65d:src/tramabol/tramabol/linking_flags.sh
+124d63b9160103d9a0f186b7ffd73ce6:src/tramabol/tramabol/linking_flags.sh
 # end context for src/tramabol/tramabol/linking_flags.sh
 
 # begin context for src/tramabol/tramabol_lib/dune

--- a/Makefile.header
+++ b/Makefile.header
@@ -5,9 +5,16 @@ MAIN_SRCDIR ?= src
 STUDIO = superbol_vscode_oss
 STUDIO_SRCDIR = $(MAIN_SRCDIR)/vscode/superbol-vscode-oss
 GNUCOBOL_SRCDIR = import/gnucobol
-GNUCOBOL4_SRCDIR = import/gnucobol4
 SUPERBOL_LSP_PKG = lsp/superbol-free
 TRAMABOL_PKG = tramabol/tramabol
+
+GNUCOBOL4_COB_CONFIG ?= cob-config
+GNUCOBOL4_COB_CONFIG_HOST ?= $(GNUCOBOL4_COB_CONFIG)
+GNUCOBOL4_LIBDIR ?= $(shell $(GNUCOBOL4_COB_CONFIG_HOST) --libdir)
+
+export GNUCOBOL4_COB_CONFIG
+export GNUCOBOL4_COB_CONFIG_HOST
+export GNUCOBOL4_LIBDIR
 
 JS_OUTDIR = _out
 JS_TARGETS = $(addprefix $(JS_OUTDIR)/,superbol-vscode-oss-bundle.js	\

--- a/Makefile.vsix-rules
+++ b/Makefile.vsix-rules
@@ -31,9 +31,6 @@ DOT_EXE = $(if $(filter win32,$(TARGET_PLAT)),.exe)
 TARGET_PROFILE ?= release
 TARGET_VSIX = $(TARGET_NAME)-$(VERSION)-$(TARGET_SPEC)-$(TARGET_PROFILE).vsix
 
-# For `all-*` targets
-TARGET_PLATFORMS ?= linux # win32 darwin
-
 # ---
 
 STUDIO_JS = $(STUDIO_SRCDIR)/$(STUDIO).bc.js
@@ -154,13 +151,7 @@ bundle-release: $(JS_TARGETS)
 
 # packaging
 
-.PHONY: vsix-dist-setup vsix-package vsix-debug vsix-release	\
-	all-vsix-debug-packages					\
-	all-vsix-debug						\
-	all-vsix-release-packages				\
-	all-vsix-release					\
-	all-vsix-packages					\
-	all-vsix
+.PHONY: vsix-dist-setup vsix-package vsix-debug vsix-release
 
 gnucobol-config: $(GNUCOBOL_SRCDIR)/config
 	@mkdir -p $@
@@ -186,24 +177,12 @@ vsix-release: build-release
 vsix-debug: build-debug
 	$(MAKE) vsix-package TARGET_PROFILE=debug
 
-all-vsix-release all-vsix-release-packages:
-	for plat in $(TARGET_PLATFORMS); do			\
-		$(MAKE) vsix-release TARGET_PLAT=$${plat};	\
-	done
-
-all-vsix-debug all-vsix-debug-packages:
-	for plat in $(TARGET_PLATFORMS); do			\
-		$(MAKE) vsix-debug TARGET_PLAT=$${plat};	\
-	done
-
-all-vsix all-vsix-packages: all-vsix-debug-packages all-vsix-release-packages
-
 vsix-clean: clean
 	rm -rf $(JS_OUTDIR) gnucobol-config _dist *.vsix
 
 # publishing (requires vsce/ovsx login)
 
-.PHONY: ovsx-deploy vsce-deploy deploy-all
+.PHONY: ovsx-deploy vsce-deploy
 
 vsce-deploy:
 	$(NPX) vsce publish $(VSCE_ARGS) $(VSCE_PUBLISH_ARGS)	\
@@ -213,12 +192,6 @@ ovsx-deploy:
 #	Note: should fail in case of duplicate version
 	$(NPX) ovsx publish $(VSCE_ARGS) $(OVSX_PUBLISH_ARGS)	\
 	        --packagePath $(TARGET_VSIX)
-
-deploy-all: # Make sure to run target `all-vsix-release-packages` beforehand
-#	$(MAKE) all-vsix-release-packages;
-	for plat in $(TARGET_PLATFORMS); do				\
-		$(MAKE) ovsx-deploy vsce-deploy TARGET_PROFILE=release;	\
-	done
 
 # vsix-specific cleanup
 

--- a/src/lsp/superbol-free/linking_flags.sh
+++ b/src/lsp/superbol-free/linking_flags.sh
@@ -53,7 +53,10 @@ case "$1" in
                 echo2 ' -cclib -Wl,-Bstatic'
                 echo2 ' -cclib -static-libgcc'
                 for l in $COMMON_LIBS; do
-                    echo2 " -cclib -l$l"
+                    if [ "${l#-}" != "${l}" ]
+                    then echo2 " -cclib $l"
+                    else echo2 " -cclib -l$l"
+                    fi
                 done
                 echo2 ' -cclib -static)'
                 ;;
@@ -64,22 +67,27 @@ case "$1" in
         esac
         ;;
     macosx)
+        shift
         COMMON_LIBS="zarith ${MACPORTS:-/usr/local/osxcross/macports/pkgs/opt/local}/lib/libgmp.a camlstr bigstringaf_stubs cstruct_stubs unix"
-        FLAGS=""
         # `m` and `pthread` are built-in in libSystem
         echo2 '(-noautolink'
-        for l in $COMMON_LIBS; do
-            if [ "${l%.a}" != "${l}" ]; then echo2 " -cclib $l"
+        for l in $COMMON_LIBS $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
             else echo2 " -cclib -l$l"
             fi
         done
-        for l in $FLAGS; do echo2 " -cclib $l"; done
         echo2 ')'
         ;;
     mingw64)
-        FLAGS=""
-        echo2 '(';
-        for l in $FLAGS; do echo2 " -cclib $l"; done
+        shift
+        echo2 '('
+        for l in $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
+            else echo2 " -cclib -l$l"
+            fi
+        done
         echo2 ')'
         ;;
     *)

--- a/src/lsp/superbol-free/linking_flags.sh.drom-tpl
+++ b/src/lsp/superbol-free/linking_flags.sh.drom-tpl
@@ -53,7 +53,10 @@ case "$1" in
                 echo2 ' -cclib -Wl,-Bstatic'
                 echo2 ' -cclib -static-libgcc'
                 for l in $COMMON_LIBS; do
-                    echo2 " -cclib -l$l"
+                    if [ "${l#-}" != "${l}" ]
+                    then echo2 " -cclib $l"
+                    else echo2 " -cclib -l$l"
+                    fi
                 done
                 echo2 ' -cclib -static)'
                 ;;
@@ -64,22 +67,27 @@ case "$1" in
         esac
         ;;
     macosx)
+        shift
         COMMON_LIBS="!(static-macos-clibs) unix"
-        FLAGS="!(static-macos-ldflags)"
         # `m` and `pthread` are built-in in libSystem
         echo2 '(-noautolink'
-        for l in $COMMON_LIBS; do
-            if [ "${l%.a}" != "${l}" ]; then echo2 " -cclib $l"
+        for l in $COMMON_LIBS $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
             else echo2 " -cclib -l$l"
             fi
         done
-        for l in $FLAGS; do echo2 " -cclib $l"; done
         echo2 ')'
         ;;
     mingw64)
-        FLAGS="!(static-mingw64-ldflags)"
-        echo2 '(';
-        for l in $FLAGS; do echo2 " -cclib $l"; done
+        shift
+        echo2 '('
+        for l in $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
+            else echo2 " -cclib -l$l"
+            fi
+        done
         echo2 ')'
         ;;
     *)

--- a/src/tramabol/ezlibcob/dune
+++ b/src/tramabol/ezlibcob/dune
@@ -61,17 +61,30 @@
 
 
 (rule
+ (targets cob_config)
+ (enabled_if (= %{context_name} "default"))
+ (action (with-stdout-to %{targets}
+   (echo %{env:GNUCOBOL4_COB_CONFIG=cob-config}))))
+
+(rule
+ (targets cob_config)
+ (enabled_if (<> %{context_name} "default"))
+ (action (with-stdout-to %{targets}
+   (echo %{env:GNUCOBOL4_COB_CONFIG_HOST=cob-config}))))
+
+
+(rule
  (targets libcob_incdir)
  (enabled_if (<> %{os_type} Win32))
  (action (with-stdout-to %{targets}
-   (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --includedir))))
+   (run %{read:cob_config} --includedir))))
 
 (rule
  (targets libcob_incdir)
  (enabled_if (= %{os_type} Win32))
  (action (with-stdout-to %{targets}
    (pipe-stdout
-     (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --includedir)
+     (run sh %{read:cob_config} --includedir)
      (run sed "s/\\\\/\\\\\\\\/g")))))
 
 
@@ -80,7 +93,7 @@
  (enabled_if (<> %{os_type} Win32))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
-         (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --cflags)
+         (run %{read:cob_config} --cflags)
          (echo ")")))))
 
 (rule
@@ -89,26 +102,43 @@
  (action (with-stdout-to %{targets}
   (progn (echo "(")
          (pipe-stdout
-           (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --cflags)
+           (run sh %{read:cob_config} --cflags)
            (run sed "s/\\\\/\\\\\\\\/g"))
          (echo ")")))))
 
 
+; Note: we require ${GNUCOBOL4_LIBDIR}/libcob-bundle to be available when cross-compiling for OSX:
 (rule
  (targets libcob_libs)
- (enabled_if (<> %{os_type} Win32))
+ (enabled_if (= %{context_name} "default.osx"))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
-         (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --libs)
+         (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib}/libcob-bundle -lcob)
          (echo ")")))))
 
 (rule
  (targets libcob_libs)
- (enabled_if (= %{os_type} Win32))
+ (enabled_if (= %{context_name} "default.windows"))
+ (action (with-stdout-to %{targets}
+  (progn (echo "(")
+         (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob)
+         (echo ")")))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (<> %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+  (progn (echo "(")
+         (run %{read:cob_config} --libs)
+         (echo ")")))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (= %{os_type} Win32)))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
          (pipe-stdout
-           (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --libs)
+           (run sh %{read:cob_config} --libs)
            (run sed "s/\\\\/\\\\\\\\/g"))
          (echo ")")))))
 

--- a/src/tramabol/ezlibcob/package.toml
+++ b/src/tramabol/ezlibcob/package.toml
@@ -114,17 +114,30 @@ dune-trailer = """
 
 
 (rule
+ (targets cob_config)
+ (enabled_if (= %{context_name} "default"))
+ (action (with-stdout-to %{targets}
+   (echo %{env:GNUCOBOL4_COB_CONFIG=cob-config}))))
+
+(rule
+ (targets cob_config)
+ (enabled_if (<> %{context_name} "default"))
+ (action (with-stdout-to %{targets}
+   (echo %{env:GNUCOBOL4_COB_CONFIG_HOST=cob-config}))))
+
+
+(rule
  (targets libcob_incdir)
  (enabled_if (<> %{os_type} Win32))
  (action (with-stdout-to %{targets}
-   (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --includedir))))
+   (run %{read:cob_config} --includedir))))
 
 (rule
  (targets libcob_incdir)
  (enabled_if (= %{os_type} Win32))
  (action (with-stdout-to %{targets}
    (pipe-stdout
-     (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --includedir)
+     (run sh %{read:cob_config} --includedir)
      (run sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g")))))
 
 
@@ -133,7 +146,7 @@ dune-trailer = """
  (enabled_if (<> %{os_type} Win32))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
-         (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --cflags)
+         (run %{read:cob_config} --cflags)
          (echo ")")))))
 
 (rule
@@ -142,26 +155,44 @@ dune-trailer = """
  (action (with-stdout-to %{targets}
   (progn (echo "(")
          (pipe-stdout
-           (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --cflags)
+           (run sh %{read:cob_config} --cflags)
            (run sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"))
          (echo ")")))))
 
 
+; Note: ${GNUCOBOL4_LIBDIR}/libcob-bundle is required when
+; cross-compiling for OSX.
 (rule
  (targets libcob_libs)
- (enabled_if (<> %{os_type} Win32))
+ (enabled_if (= %{context_name} "default.osx"))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
-         (run %{env:GNUCOBOL4_COB_CONFIG=cob-config} --libs)
+         (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib}/libcob-bundle -lcob)
          (echo ")")))))
 
 (rule
  (targets libcob_libs)
- (enabled_if (= %{os_type} Win32))
+ (enabled_if (= %{context_name} "default.windows"))
+ (action (with-stdout-to %{targets}
+  (progn (echo "(")
+         (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob)
+         (echo ")")))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (<> %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+  (progn (echo "(")
+         (run %{read:cob_config} --libs)
+         (echo ")")))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (= %{os_type} Win32)))
  (action (with-stdout-to %{targets}
   (progn (echo "(")
          (pipe-stdout
-           (run sh %{env:GNUCOBOL4_COB_CONFIG=cob-config} --libs)
+           (run sh %{read:cob_config} --libs)
            (run sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g"))
          (echo ")")))))
 

--- a/src/tramabol/tramabol/dune
+++ b/src/tramabol/tramabol/dune
@@ -15,12 +15,12 @@
   )
 
 ; Use `static-clibs` to specify static C libs (without lib prefix)
-; and `static-macos-clibs`, `static-macos-ldflags`, `static-mingw64-ldflags` and `static-alpine-clibs` for system specific deps
+; and `static-macos-clibs` and `static-alpine-clibs` for system specific deps
 (rule
   (targets linking.sexp)
   (deps (file linking_flags.sh) (env_var LINKING_MODE) )
   (action  (with-stdout-to %{targets}
-    (run bash linking_flags.sh linking.sexp %{env:LINKING_MODE=dynamic} %{ocaml-config:system} ))))
+    (run bash linking_flags.sh linking.sexp %{env:LINKING_MODE=dynamic} %{ocaml-config:system} %{read:libcob_libs}))))
 
 
 (documentation
@@ -40,4 +40,34 @@
 ; (name build)
 ; (deps (glob_files *.bc.js))
 ; (enabled_if (= %{profile} "universal")))
+
+
+; Note: ${GNUCOBOL4_LIBDIR}/libcob-bundle is required when cross-compiling.
+(rule
+ (targets libcob_libs)
+ (enabled_if (= %{context_name} "default.osx"))
+  (action (with-stdout-to %{targets}
+    (progn
+      (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib}/libcob-bundle " ")
+      (run %{read:../ezlibcob/cob_config} --libs)))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (= %{context_name} "default.windows"))
+ (action (with-stdout-to %{targets}
+   (echo ""))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (<> %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+   (run %{read:../ezlibcob/cob_config} --libs))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (= %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+   (pipe-stdout
+      (run sh %{read:../ezlibcob/cob_config} --libs)
+      (run sed "s/\\\\/\\\\\\\\/g")))))
 

--- a/src/tramabol/tramabol/dune.drom-tpl
+++ b/src/tramabol/tramabol/dune.drom-tpl
@@ -12,7 +12,7 @@
   )
 
 ; Use `static-clibs` to specify static C libs (without lib prefix)
-; and `static-macos-clibs`, `static-macos-ldflags`, `static-mingw64-ldflags` and `static-alpine-clibs` for system specific deps
+; and `static-macos-clibs` and `static-alpine-clibs` for system specific deps
 (rule
   (targets linking.sexp)
   (deps (file linking_flags.sh) (env_var LINKING_MODE) !(linking-deps))

--- a/src/tramabol/tramabol/linking_flags.sh
+++ b/src/tramabol/tramabol/linking_flags.sh
@@ -53,7 +53,10 @@ case "$1" in
                 echo2 ' -cclib -Wl,-Bstatic'
                 echo2 ' -cclib -static-libgcc'
                 for l in $COMMON_LIBS; do
-                    echo2 " -cclib -l$l"
+                    if [ "${l#-}" != "${l}" ]
+                    then echo2 " -cclib $l"
+                    else echo2 " -cclib -l$l"
+                    fi
                 done
                 echo2 ' -cclib -static)'
                 ;;
@@ -64,22 +67,27 @@ case "$1" in
         esac
         ;;
     macosx)
-        COMMON_LIBS="zarith ${MACPORTS:-/usr/local/osxcross/macports/pkgs/opt/local}/lib/libgmp.a camlstr bigstringaf_stubs cstruct_stubs unix"
-        FLAGS="-L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob"
+        shift
+        COMMON_LIBS="zarith ${MACPORTS:-/usr/local/osxcross/macports/pkgs/opt/local}/lib/libgmp.a camlstr bigstringaf_stubs cstruct_stubs ezlibcob_stubs unix"
         # `m` and `pthread` are built-in in libSystem
         echo2 '(-noautolink'
-        for l in $COMMON_LIBS; do
-            if [ "${l%.a}" != "${l}" ]; then echo2 " -cclib $l"
+        for l in $COMMON_LIBS $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
             else echo2 " -cclib -l$l"
             fi
         done
-        for l in $FLAGS; do echo2 " -cclib $l"; done
         echo2 ')'
         ;;
     mingw64)
-        FLAGS="-L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob"
-        echo2 '(';
-        for l in $FLAGS; do echo2 " -cclib $l"; done
+        shift
+        echo2 '('
+        for l in $@; do
+            if [ "${l%.a}" != "${l}" ] || [ "${l#-}" != "${l}" ]
+            then echo2 " -cclib $l"
+            else echo2 " -cclib -l$l"
+            fi
+        done
         echo2 ')'
         ;;
     *)

--- a/src/tramabol/tramabol/package.toml
+++ b/src/tramabol/tramabol/package.toml
@@ -85,14 +85,44 @@ dune-trailer = """
 (alias
  (name build)
  (deps (glob_files *.exe))
- (enabled_if (<> %{profile} \"universal\")))
+ (enabled_if (<> %{profile} "universal")))
 
 ;(alias
 ; (name build)
 ; (deps (glob_files *.bc.js))
 ; (enabled_if (= %{profile} \"universal\")))
+
+
+; Note: ${GNUCOBOL4_LIBDIR}/libcob-bundle is required when
+; cross-compiling for OSX.
+(rule
+ (targets libcob_libs)
+ (enabled_if (= %{context_name} "default.osx"))
+  (action (with-stdout-to %{targets}
+    (progn
+      (echo -L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib}/libcob-bundle " ")
+      (run %{read:../ezlibcob/cob_config} --libs)))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (= %{context_name} "default.windows"))
+ (action (with-stdout-to %{targets}
+   (echo ""))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (<> %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+   (run %{read:../ezlibcob/cob_config} --libs))))
+
+(rule
+ (targets libcob_libs)
+ (enabled_if (and (= %{context_name} "default") (= %{os_type} Win32)))
+ (action (with-stdout-to %{targets}
+   (pipe-stdout
+      (run sh %{read:../ezlibcob/cob_config} --libs)
+      (run sed "s/\\\\\\\\/\\\\\\\\\\\\\\\\/g")))))
 """
-static-macos-clibs = "zarith ${MACPORTS:-/usr/local/osxcross/macports/pkgs/opt/local}/lib/libgmp.a camlstr bigstringaf_stubs cstruct_stubs"
-static-macos-ldflags = "-L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob"
+static-clibs = "%{read:libcob_libs}"
+static-macos-clibs = "zarith ${MACPORTS:-/usr/local/osxcross/macports/pkgs/opt/local}/lib/libgmp.a camlstr bigstringaf_stubs cstruct_stubs ezlibcob_stubs"
 static-alpine-clibs = "zarith gmp bigstringaf_stubs cstruct_stubs"
-static-mingw64-ldflags = "-L%{env:GNUCOBOL4_LIBDIR=/opt/gnucobol-4.x/lib} -lcob"


### PR DESCRIPTION
Also remove every `all-` targets from `Makefile.vsix-rules`, as using those actually cause more issues than solve problems when cross-compiling.