### PR TITLE
Parse abbreviated conditions in EVALUATE WHEN clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [_] Next release
 
+### Added
+- Parsing of abbreviated conditions in EVALUATE WHEN clauses [#638](https://github.com/OCamlPro/superbol-studio-oss/pull/638)
+
 ### Fixed
 - Grammar rules for `VALUE OF` clause [#629](https://github.com/OCamlPro/superbol-studio-oss/pull/629) (fix for [Issue #625](https://github.com/OCamlPro/superbol-studio-oss/issues/625))
 

--- a/src/lsp/cobol_parser/grammar.mly
+++ b/src/lsp/cobol_parser/grammar.mly
@@ -207,7 +207,7 @@ let dual_handler_none =
 (* Entry points *)
 
 %start <Cobol_ptree.compilation_group> compilation_group
-%start <cond with_loc> standalone_condition
+%start <condition with_loc> standalone_condition
 
 %%
 
@@ -2823,12 +2823,12 @@ let any_lpar ==
  | LPAR_BEFORE_RELOP; {}
 
 let relation_condition ==
- | neg = ibo(NOT); e = expression; pred = loc(abbrev_relop_operand);
-    { relation_condition (neg, e, pred) }
+ | neg = ibo(NOT); e = expression; pred = loc(abbrev_relop_operand); 
+    { Relation (neg, e, pred) }
 
 nonrel_condition:
  | n = ibo(NOT)     e = expression %prec lowest { neg_condition ~neg:n (Expr e &@<- e) }
- | n = ibo(NOT)     c = loc(extended_condition) { neg_condition ~neg:n c }
+ | n = ibo(NOT)     c = loc(extended_condition) { neg_condition ~neg:n (cast_no_rel_cond ~&c &@<- c) }
  | n = ibo(NOT) "(" c  = condition ")"          { neg_condition ~neg:n c }
 
 abbrev_relop_atom:
@@ -2837,7 +2837,7 @@ abbrev_relop_atom:
 
 abbrev_relop_operand:
  | abbrev_relop_atom { $1 }
- | loc(abbrev_relop_operand) logop loc(abbrev_relation_operand)    { AbbrevComb ($1, $2, $3) }
+ | loc(abbrev_relop_operand) logop loc(abbrev_relation_operand)    { AbbrevLogop ($1, $2, $3) }
 
 abbrev_object_atom:
  | n = ibo(NOT)     e = expression          %prec lowest { AbbrevObject (n, e) }
@@ -2845,7 +2845,7 @@ abbrev_object_atom:
 
 abbrev_object_operand:
  | abbrev_object_atom { $1 }
- | loc(abbrev_object_operand) logop loc(abbrev_relation_operand)   { AbbrevComb ($1, $2, $3) }
+ | loc(abbrev_object_operand) logop loc(abbrev_relation_operand)   { AbbrevLogop ($1, $2, $3) }
 
 abbrev_relation_operand:
  | r = relop    e = loc(abbrev_object_atom)                        { AbbrevRelOp (r, e) }
@@ -2853,7 +2853,7 @@ abbrev_relation_operand:
  | n = ibo(NOT) e = expression a = loc(abbrev_relop_atom)          { AbbrevSubject (n, e, a) }
  | n = ibo(NOT) c = loc(extended_condition)                        { AbbrevOther (neg_condition ~neg:n c) }
  | n = ibo(NOT) any_lpar c = loc(abbrev_relation_operand) RPAR     { AbbrevParen (n, c) }
- | loc(abbrev_relation_operand) logop loc(abbrev_relation_operand) { AbbrevComb ($1, $2, $3) }
+ | loc(abbrev_relation_operand) logop loc(abbrev_relation_operand) { AbbrevLogop ($1, $2, $3) }
 
 extended_condition:
  | e = expression io(IS) n = bo(NOT) c = class_condition
@@ -3484,12 +3484,12 @@ let selection_objects :=
  | so = selection_object; ALSO; sol = selection_objects; { so :: sol }
 
 let selection_object :=
- | c = condition;           {SelCond c}                 (* also arith/bool exp*)
- | ~ = range_expression;    < >
- | ~ = partial_expression;  < >                                   (* +COB2002 *)
- | TRUE;                    {SelConst true}
- | FALSE;                   {SelConst false}
- | ANY;                     {SelAny: selection_object}
+ | c = loc(abbrev_relation_operand); {SelCond c}                 (* also arith/bool exp*)
+ | ~ = range_expression;             < >
+ | ~ = partial_expression;           < >                                   (* +COB2002 *)
+ | TRUE;                             {SelConst true}
+ | FALSE;                            {SelConst false}
+ | ANY;                              {SelAny}
 
 let range_expression :=
  | b = ibo(NOT); i1 = expression; THROUGH;
@@ -3497,8 +3497,6 @@ let range_expression :=
    { SelRange { negated = b; start = i1; stop = i2; alphabet = i } }
 
 let partial_expression :=
- | o = relop; e = expression;
-   { SelRelation { relation = o; expr = e } } (* relation (general, bool, pointer) *)
  | IS; n = bo(NOT); c = class_condition;
    { SelClassCond { negated = n; class_specifier = c } } (* class *) (* exp = ident *)
  | n = bo(NOT); c = class_condition_no_ident;

--- a/src/lsp/cobol_parser/grammar_utils.ml
+++ b/src/lsp/cobol_parser/grammar_utils.ml
@@ -24,14 +24,6 @@ module Overlay_manager =
     let name = __MODULE__
   end) ()
 
-let relation_condition (abbrev_rel: abbrev_combined_relation) =
-  match abbrev_rel with
-  | neg, subject, { payload = AbbrevRelOp (op, { payload = AbbrevObject (obj_neg, obj); _ }); loc } ->
-      let neg = if neg then not obj_neg else obj_neg in
-      Cobol_ptree.Terms_helpers.neg_condition ~neg (Relation (subject, op, obj) &@ loc)
-  | _ ->
-      Abbrev abbrev_rel
-
 
 type data_division_sentence =
   | S_DATA_DIVISION_HEADER of srcloc

--- a/src/lsp/cobol_parser/grammar_utils.mli
+++ b/src/lsp/cobol_parser/grammar_utils.mli
@@ -15,8 +15,6 @@ open Cobol_ptree
 
 module Overlay_manager: Cobol_preproc.Src_overlay.MANAGER
 
-val relation_condition: Cobol_ptree.abbrev_combined_relation -> Cobol_ptree.cond
-
 type data_division_sentence =
   | S_DATA_DIVISION_HEADER of srcloc
   | S_FILE_SECTION_HEADER of srcloc

--- a/src/lsp/cobol_ptree/branching_statements.ml
+++ b/src/lsp/cobol_ptree/branching_statements.ml
@@ -116,7 +116,7 @@ and perform_mode =
   | PerformUntil of
       {
         with_test: stage option;
-        until: cond with_loc option; (* None = UNTIL EXIT *)
+        until: condition with_loc option; (* None = UNTIL EXIT *)
       }
   | PerformVarying of
       {
@@ -131,7 +131,7 @@ and varying_phrase =
     varying_ident: ident;
     varying_from: scalar;
     varying_by: scalar option;                  (* XXX: more specialized type *)
-    varying_until: cond with_loc;
+    varying_until: condition with_loc;
   }
 
 
@@ -146,7 +146,7 @@ and search_stmt =
 
 and search_when_clause =
   {
-    search_when_cond: cond with_loc;
+    search_when_cond: condition with_loc;
     search_when_stmts: statements;
   }
 
@@ -163,7 +163,7 @@ and search_all_stmt =
 (* IF *)
 and if_stmt =
   {
-    condition: cond with_loc;
+    condition: condition with_loc;
     then_branch: statements;
     else_branch: statements;
   }
@@ -653,7 +653,7 @@ and pp_perform_mode ppf = function
     Fmt.pf ppf "UNTIL EXIT"
   | PerformUntil { with_test; until = Some until } ->
     Fmt.(option (any " TEST " ++ pp_stage ++ sp)) ppf with_test;
-    Fmt.pf ppf "UNTIL %a" pp_cond' until
+    Fmt.pf ppf "UNTIL %a" pp_condition' until
   | PerformVarying { with_test; varying; after } ->
     Fmt.(option (any " TEST " ++ pp_stage ++ sp)) ppf with_test;
     Fmt.pf ppf "VARYING %a"
@@ -667,7 +667,7 @@ and pp_varying_phrase ppf
     pp_ident vi
     pp_scalar vf
     Fmt.(option (any " BY " ++ pp_scalar)) vb
-    pp_cond' vu
+    pp_condition' vu
 
 (* SEARCH *)
 
@@ -692,7 +692,7 @@ and pp_search_all_stmt ppf { search_all_item = si;
   Fmt.pf ppf "@ END-SEARCH"
 
 and pp_search_when_clause ppf { search_when_cond = c; search_when_stmts = w } =
-  Fmt.pf ppf "WHEN %a@ %a" pp_cond' c pp_statements w
+  Fmt.pf ppf "WHEN %a@ %a" pp_condition' c pp_statements w
 
 (* IF *)
 
@@ -704,7 +704,7 @@ and pp_if_stmt ppf { condition = c; then_branch = t; else_branch = e } =
   in
   let e = match e with [] -> None | _ -> Some e in
   Fmt.pf ppf "@[<v>IF@[<hv>@ %a%t@]@;<1 2>%a%a@ END-IF@]"
-    (Fmt.box pp_cond') c pp_then
+    (Fmt.box pp_condition') c pp_then
     (Fmt.vbox pp_statements) t
     Fmt.(option (any "@ ELSE@;<1 2>" ++ vbox pp_statements)) e
 

--- a/src/lsp/cobol_ptree/data_descr.ml
+++ b/src/lsp/cobol_ptree/data_descr.ml
@@ -493,8 +493,8 @@ type validation_clause =
   | Class of class_clause
   | Default of ident_or_literal option
   | Destination of ident list (* non-empty *)
-  | InvalidWhen of cond with_loc list (* non-empty *)
-  | PresentWhen of cond with_loc
+  | InvalidWhen of condition with_loc list (* non-empty *)
+  | PresentWhen of condition with_loc
   | Varying of data_varying list
   | ValidateStatus of
       {
@@ -546,10 +546,10 @@ let pp_destination_clause =
   Fmt.(any "DESTINATION " ++ list ~sep:sp pp_ident)
 
 let pp_invalid_when_clause =
-  Fmt.(list ~sep:sp (any "INVALID WHEN " ++ pp_cond'))
+  Fmt.(list ~sep:sp (any "INVALID WHEN " ++ pp_condition'))
 
 let pp_present_when_clause =
-  Fmt.(any "PRESENT WHEN " ++ pp_cond')
+  Fmt.(any "PRESENT WHEN " ++ pp_condition')
 
 let pp_validation_clause ppf = function
   | Class cc -> pp_class_clause ppf cc

--- a/src/lsp/cobol_ptree/data_descr_visitor.ml
+++ b/src/lsp/cobol_ptree/data_descr_visitor.ml
@@ -458,8 +458,8 @@ let fold_validation_clause (v: _ #folder) =
       | Class c -> fold_class_clause v c
       | Default i -> fold_option ~fold:fold_ident_or_literal v i
       | Destination i -> fold_list ~fold:fold_ident v i
-      | InvalidWhen c -> fold_list ~fold:fold_cond' v c
-      | PresentWhen c -> fold_cond' v c
+      | InvalidWhen c -> fold_list ~fold:fold_condition' v c
+      | PresentWhen c -> fold_condition' v c
       | Varying l -> fold_list ~fold:fold_data_varying v l
       | ValidateStatus { is_; when_; on; for_ } -> ignore (when_, on); fun x -> x
         >> fold_ident_or_literal v is_

--- a/src/lsp/cobol_ptree/data_sections.ml
+++ b/src/lsp/cobol_ptree/data_sections.ml
@@ -129,7 +129,7 @@ type report_group_clause =
         rounding: rounding;
       }
   | ReportValue of literal
-  | ReportPresentWhen of cond with_loc                              (* +COB2002 *)
+  | ReportPresentWhen of condition with_loc                              (* +COB2002 *)
   | ReportGroupIndicate
   | ReportOccurs of                                             (* +COB2002 *)
       {
@@ -170,7 +170,7 @@ let pp_report_group_clause ppf = function
         ppf reset_on;
       pp_rounding ppf rounding
   | ReportValue v -> Fmt.pf ppf "VALUE %a" pp_literal v
-  | ReportPresentWhen c -> Fmt.pf ppf "PRESENT WHEN %a" pp_cond' c
+  | ReportPresentWhen c -> Fmt.pf ppf "PRESENT WHEN %a" pp_condition' c
   | ReportGroupIndicate -> Fmt.pf ppf "GROUP"
   | ReportOccurs { from; to_; depending; step } ->
       Fmt.pf ppf "OCCURS %a%a%a%a"

--- a/src/lsp/cobol_ptree/operands.ml
+++ b/src/lsp/cobol_ptree/operands.ml
@@ -289,27 +289,28 @@ let pp_divide_operands ppf = function
 
 (* EVALUATE *)
 type selection_subject =
-  | Subject of cond with_loc
+  | Subject of condition with_loc
   | SubjectConst of bool
 [@@deriving ord]
 
 let pp_selection_subject ppf = function
-  | Subject c -> pp_cond' ppf c
+  | Subject c -> pp_condition' ppf c
   | SubjectConst b -> Fmt.pf ppf (if b then "TRUE" else "FALSE")
 
 type selection_object =
-  | SelCond of cond with_loc (* ident / literal / expression *)
+  | SelCond of abbrev_relation_operand with_loc (** Condition with a potentially omitted subject 
+      interpreted as an abbreviated condition prepended by the corresponding subject in EVALUATE.
+      May start with AbbrevSubject to denote an independant condition.
+      Typically used for clauses such as:
+      - WHEN > 5 (matching subject should be an integer)
+      - WHEN A > 3 (matching subject should be either TRUE or FALSE)
+      - WHEN <= 3 OR A > 3 (matching subject should be an integer) *)
   | SelRange of
       {
         negated: bool;
         start: expr with_loc;
         stop: expr with_loc;
         alphabet: name with_loc option;
-      }
-  | SelRelation of
-      {
-        relation: relop;
-        expr: expr with_loc;
       }
   | SelClassCond of
       {
@@ -330,15 +331,13 @@ type selection_object =
 [@@deriving ord]
 
 let pp_selection_object ppf = function
-  | SelCond c -> pp_cond' ppf c
+  | SelCond c -> pp_with_loc pp_abbrev_relation_operand ppf c
   | SelRange { negated; start; stop; alphabet } ->
     if negated then Fmt.pf ppf "NOT@ ";
     Fmt.pf ppf "%a@ THROUGH@ %a%a"
       pp_expr' start
       pp_expr' stop
       Fmt.(option (sp ++ const string "IN" ++ sp ++ pp_with_loc pp_name)) alphabet
-  | SelRelation { relation; expr } ->
-    Fmt.pf ppf "%a@ %a" pp_relop relation pp_expr' expr
   | SelClassCond { negated; class_specifier = cs } ->
     if negated then Fmt.pf ppf "NOT@ ";
     pp_class_ ppf cs

--- a/src/lsp/cobol_ptree/statements_visitor.ml
+++ b/src/lsp/cobol_ptree/statements_visitor.ml
@@ -713,15 +713,12 @@ let fold_selection_object (v: _ #folder) =
     ~continue:begin fun selection_object x ->
       match selection_object with
       | SelCond c -> x
-          >> fold_condition v c
+          >> fold_abbrev_relation_operand' v c
       | SelRange { negated; start; stop; alphabet} -> x
           >> fold_bool v negated
           >> fold_expression v start
           >> fold_expression v stop
           >> fold_option ~fold:fold_name' v alphabet
-      | SelRelation { relation; expr } -> x
-          >> fold_relop v relation
-          >> fold_expression v expr
       | SelClassCond { negated; class_specifier } -> x
           >> fold_bool v negated
           >> fold_class v class_specifier

--- a/src/lsp/cobol_ptree/terms.ml
+++ b/src/lsp/cobol_ptree/terms.ml
@@ -322,15 +322,20 @@ and expr =
   | Binop of expr with_loc * binop * expr with_loc (* split arith/bool ? *)
 
 (** Any form of condition {v c v} *)
-and cond =
+and 'r cond =
   | Expr of expr with_loc (** expression used as a condition *)
-  | Relation of binary_relation (** simple binary relation *)
-  | Abbrev of abbrev_combined_relation (** abbreviated relation *)
+  | Relation of 'r (** potentially abbreviated relation (depending on 'r) *)
   | ClassCond of expr with_loc * class_ (** class condition *)
   | SignCond of expr with_loc * signz (** {v e POSITIVE/NEGATIVE/ZERO v} *)
   | Omitted of expr with_loc (** {v c OMITTED v} *)
-  | Not of cond with_loc (** {v NOT c v} *)
-  | Logop of cond with_loc * logop * cond with_loc (** {v c <AND/OR> c' v} *)
+  | Not of 'r cond with_loc (** {v NOT c v} *)
+  | Logop of 'r cond with_loc * logop * 'r cond with_loc (** {v c <AND/OR> c' v} *)
+  
+and condition = abbrev_combined_relation cond
+
+and expanded_cond = binary_relation cond
+
+and no_rel = | (** empty type used to forbid the Relation constructor in cond *)
 
 and binary_relation =
   expr with_loc * relop * expr with_loc (** {v e <relop> e' v} *)
@@ -349,9 +354,9 @@ and abbrev_relation_operand =
   | AbbrevObject of bool * expr with_loc (** {v NOT? e v} *)
   | AbbrevSubject of abbrev_combined_relation (** {v NOT? e a v} *)
   | AbbrevParen of bool * abbrev_relation_operand with_loc (** {v NOT? (a) v} *)
-  | AbbrevOther of cond (** {v <non-relational condition> v} *)
-  | AbbrevComb (** {v a' <AND/OR> a'' v} *)
-      of (abbrev_relation_operand with_loc as 'x) * logop * 'x
+  | AbbrevLogop (** {v a' <AND/OR> a'' v} *)
+      of (abbrev_relation_operand with_loc as 'x) * logop * 'x  
+  | AbbrevOther of no_rel cond (** {v <non-relational condition> v} *)
 
 
 and logop =
@@ -624,26 +629,23 @@ module COMPARE = struct
         lazy (compare_with_loc compare_abbrev_relation_operand a1 a2)
     | AbbrevParen _, _ -> -1
     | _, AbbrevParen _ -> 1
-    | AbbrevOther c1, AbbrevOther c2 -> compare_cond c1 c2
+    | AbbrevOther c1, AbbrevOther c2 -> compare_cond (fun (never: no_rel) _ -> match never with _ -> .) c1 c2
     | AbbrevOther _, _ -> -1
     | _, AbbrevOther _ -> 1
-    | AbbrevComb (x1, o1, y1), AbbrevComb (x2, o2, y2) ->
+    | AbbrevLogop (x1, o1, y1), AbbrevLogop (x2, o2, y2) ->
         compare_struct (compare_with_loc compare_abbrev_relation_operand x1 x2) @@
         lazy (compare_struct (compare_logop o1 o2) @@
               lazy (compare_with_loc compare_abbrev_relation_operand y1 y2))
 
-  and compare_cond : cond -> cond -> int =
-    fun a b -> match a, b with
+  and compare_cond: 'r. ('r -> 'r -> int) -> 'r cond -> 'r cond -> int =
+    fun compare_rel a b -> match a, b with
       | Expr x, Expr y ->
           compare_expr' x y
       | Expr _, _ -> -1
       | _, Expr _ -> 1
-      | Relation x, Relation y -> compare_binary_relation x y
+      | Relation x, Relation y -> compare_rel x y
       | Relation _, _ -> -1
       | _, Relation _ -> 1
-      | Abbrev x, Abbrev y -> compare_abbrev_combined_relation x y
-      | Abbrev _, _ -> -1
-      | _, Abbrev _ -> 1
       | ClassCond (x1, c1), ClassCond (x2, c2) ->
           compare_struct (compare_expr' x1 x2) @@
           lazy (compare_class_ c1 c2)
@@ -659,14 +661,14 @@ module COMPARE = struct
       | Omitted _, _ -> -1
       | _, Omitted _ -> 1
       | Not x, Not y ->
-          compare_cond' x y
+          compare_cond' compare_rel x y
       | Not _, _ -> -1
       | _, Not _ -> 1
       | Logop (x1, o1, y1), Logop (x2, o2, y2) ->
           compare_struct (compare_logop o1 o2) @@
-          lazy (compare_struct (compare_cond' x1 x2) @@
-                lazy (compare_cond' y1 y2))
-  and compare_cond' a b = compare_with_loc compare_cond a b
+          lazy (compare_struct (compare_cond' compare_rel x1 x2) @@
+                lazy (compare_cond' compare_rel y1 y2))
+  and compare_cond' compare_rel a b = compare_with_loc (compare_cond compare_rel) a b
   and compare_relop =
     Stdlib.compare
   and compare_logop =
@@ -821,6 +823,9 @@ module COMPARE = struct
   let compare_strlit: strlit compare_fun = compare_term
   let compare_strlit_or_intlit: strlit_or_intlit compare_fun = compare_term
   let compare_scalar: scalar compare_fun = compare_term
+  
+  let compare_condition a b = compare_cond compare_abbrev_combined_relation a b
+  let compare_condition' a b = compare_cond' compare_abbrev_combined_relation a b
 end
 include COMPARE
 
@@ -1038,66 +1043,33 @@ module FMT = struct
     | BOr  -> "B-OR"
     | BXor -> "B-XOR"
   and pp_binop ppf o = string ppf (show_binop o)
+  
+  and pp_sign: type k. k sign_cond Pretty.printer = fun ppf -> function
+    | SgnPositive -> string ppf "POSITIVE"
+    | SgnNegative -> string ppf "NEGATIVE"
+    | SgnZero -> string ppf "ZERO"
+  and pp_signz ppf = pp_sign ppf
+  
+  and pp_literal: literal Pretty.printer = fun ppf -> pp_term ppf
+  and pp_literal' = fun ppf -> pp_with_loc pp_literal ppf
+  and pp_ident: ident Pretty.printer = fun ppf -> pp_term ppf
 
-  and pp_binary_relation ppf (a, o, b) =
-    fmt "%a@ %a@ %a" ppf
-      pp_expr' a pp_relop o pp_expr' b
+  let not_ ppf = function false -> fmt "NOT@ " ppf | true -> ()
 
-  and pp_cond ?(pos = true) ppf c =
-    match c with
-    | Expr e ->
-        fmt "%a%a" ppf not_ pos pp_expr' e
-    | Relation rel ->
-        fmt "%a@[<1>(%a)@]" ppf not_ pos pp_binary_relation rel
-    | Abbrev r ->
-        fmt "%a%a" ppf not_ pos pp_abbrev_combined_relation r
-    | ClassCond (e, c) ->
-        fmt "%a@ %a%a" ppf pp_expr' e not_ pos pp_class_ c
-    | SignCond (e, s) ->
-        fmt "%a@ %a%a" ppf pp_expr' e not_ pos pp_sign s
-    | Omitted e ->
-        fmt "%a@ %aOMITTED" ppf pp_expr' e not_ pos
-    | Not c ->
-        pp_with_loc (pp_cond ~pos:(not pos)) ppf c
-    | Logop (a, o, b) ->
-        fmt "@[<1>%a(%a@ %a@ %a)@]" ppf
-          not_ pos pp_cond' a pp_logop o pp_cond' b
-
-  and pp_cond' ppf = pp_with_loc (pp_cond ~pos:true) ppf
-
-  and pp_abbrev_combined_relation ppf (neg, e, a) =
-    fmt "%a%a@ %a" ppf not_ (not neg) pp_expr' e
-      pp_abbrev_relation_operand ~&a
-
-  and pp_abbrev_relation_operand ppf = function
-    | AbbrevRelOp (o, a) ->
-        fmt "%a@ %a" ppf pp_relop o pp_abbrev_relation_operand ~&a
-    | AbbrevObject (neg, e) ->
-        fmt "%a%a" ppf not_ (not neg) pp_expr' e
-    | AbbrevSubject r ->
-        pp_abbrev_combined_relation ppf r
-    | AbbrevParen (neg, a) ->
-        fmt "%a@[<1>(%a)@]" ppf not_ (not neg) pp_abbrev_relation_operand ~&a
-    | AbbrevOther c ->
-        pp_cond ppf c
-    | AbbrevComb (a1, o, a2) ->
-        fmt "%a@ %a@ %a" ppf
-          pp_abbrev_relation_operand ~&a1
-          pp_logop o
-          pp_abbrev_relation_operand ~&a2
-
-  and not_ ppf = function false -> fmt "NOT@ " ppf | true -> ()
-
-  and show_relop = function
+  let show_relop = function
     | Gt -> ">"
     | Lt -> "<"
     | Eq -> "="
     | Ne -> "<>"
     | Ge -> ">="
     | Le -> "<="
-  and pp_relop ppf o = string ppf (show_relop o)
+  let pp_relop ppf o = string ppf (show_relop o)
+  
+  let pp_binary_relation ppf (a, o, b) =
+    fmt "%a@ %a@ %a" ppf
+      pp_expr' a pp_relop o pp_expr' b
 
-  and show_class_ = function
+  let show_class_ = function
     | AlphabetOrClass n -> str "%a" pp_name' n
     | Alphabetic -> "ALPHABETIC"
     | AlphabeticLower -> "ALPHABETIC-LOWER"
@@ -1111,26 +1083,62 @@ module FMT = struct
     | InArithmeticRange -> "IN-ARITHMETIC-RANGE"
     | NearestToZero -> "NEAREST-TO-ZERO"
     | ClassNumeric -> "NUMERIC"
-  and pp_class_ ppf c = string ppf (show_class_ c)
+  let pp_class_ ppf c = string ppf (show_class_ c)
 
-  and pp_sign: type k. k sign_cond Pretty.printer = fun ppf -> function
-    | SgnPositive -> string ppf "POSITIVE"
-    | SgnNegative -> string ppf "NEGATIVE"
-    | SgnZero -> string ppf "ZERO"
-  and pp_signz ppf = pp_sign ppf
-
-  and pp_logop ppf = function
+  let pp_logop ppf = function
     | LAnd -> string ppf "AND"
     | LOr -> string ppf "OR"
 
-  and pp_literal: literal Pretty.printer = fun ppf -> pp_term ppf
-  and pp_literal' = fun ppf -> pp_with_loc pp_literal ppf
-  and pp_ident: ident Pretty.printer = fun ppf -> pp_term ppf
-  and pp_qualname_with_subscripts: qualname_with_subscripts Pretty.printer =
-    fun ppf -> pp_term ppf
-  and pp_qualname_with_subscripts' =
-    fun ppf -> pp_with_loc pp_qualname_with_subscripts ppf
+  let rec pp_cond:
+    'r. 'r Pretty.printer -> ?pos:bool -> 'r cond Pretty.printer = 
+    fun pp_rel ?(pos = true) ppf c -> 
+    match c with
+    | Expr e ->
+        fmt "%a%a" ppf not_ pos pp_expr' e
+    | Relation r ->
+        if pos then
+          pp_rel ppf r
+        else
+          fmt "NOT @[<1>(%a)@]" ppf pp_rel r
+    | ClassCond (e, c) ->
+        fmt "%a@ %a%a" ppf pp_expr' e not_ pos pp_class_ c
+    | SignCond (e, s) ->
+        fmt "%a@ %a%a" ppf pp_expr' e not_ pos pp_sign s
+    | Omitted e ->
+        fmt "%a@ %aOMITTED" ppf pp_expr' e not_ pos
+    | Not c ->
+        pp_with_loc (pp_cond pp_rel ~pos:(not pos)) ppf c
+    | Logop (a, o, b) ->
+        fmt "@[<1>%a(%a@ %a@ %a)@]" ppf
+          not_ pos (pp_cond' pp_rel) a pp_logop o (pp_cond' pp_rel) b
 
+  and pp_cond':
+    'r. 'r Pretty.printer -> 'r cond with_loc Pretty.printer =
+    fun pp_rel ppf c -> pp_with_loc (pp_cond pp_rel ~pos:true) ppf c
+
+  let pp_no_rel _ (never: no_rel) = match never with _ -> .
+
+  let rec pp_abbrev_combined_relation ppf (neg, e, a) =
+    fmt "%a%a@ %a" ppf not_ (not neg) pp_expr' e 
+      pp_abbrev_relation_operand ~&a
+
+  and pp_abbrev_relation_operand ppf = function
+    | AbbrevRelOp (o, a) ->
+        fmt "%a@ %a" ppf pp_relop o pp_abbrev_relation_operand ~&a
+    | AbbrevObject (neg, e) ->
+        fmt "%a%a" ppf not_ (not neg) pp_expr' e
+    | AbbrevSubject r ->
+        pp_abbrev_combined_relation ppf r
+    | AbbrevParen (neg, a) ->
+        fmt "%a@[<1>(%a)@]" ppf not_ (not neg) pp_abbrev_relation_operand ~&a
+    | AbbrevOther c ->
+        pp_cond pp_no_rel ppf c
+    | AbbrevLogop (a1, o, a2) ->
+        fmt "%a@ %a@ %a" ppf
+          pp_abbrev_relation_operand ~&a1
+          pp_logop o
+          pp_abbrev_relation_operand ~&a2
+          
   (** Pretty-printing for named unions of term types (some are yet to be
       renamed) *)
 
@@ -1148,7 +1156,13 @@ module FMT = struct
   let pp_qualname_or_literal: qualname_or_literal Pretty.printer = pp_term
   let pp_qualname_or_intlit: qualname_or_intlit Pretty.printer = pp_term
   let pp_qualname_or_alphanum: qualname_or_alphanum Pretty.printer = pp_term
+  let pp_qualname_with_subscripts: qualname_with_subscripts Pretty.printer =
+    pp_term
+  let pp_qualname_with_subscripts' =
+    pp_with_loc pp_qualname_with_subscripts
 
+  let pp_condition = pp_cond pp_abbrev_combined_relation
+  let pp_condition' = pp_cond' pp_abbrev_combined_relation
 end
 include FMT
 

--- a/src/lsp/cobol_ptree/terms_helpers.ml
+++ b/src/lsp/cobol_ptree/terms_helpers.ml
@@ -18,11 +18,21 @@ open Srcloc.INFIX
 let neg_condition ~neg (c: 'r cond with_loc): 'r cond =
   if not neg then ~&c else Not c
 
-let cast_no_rel_cond (c: no_rel cond): 'r cond = 
-    (* OCaml typechecker is not clever enough to deduce that no_rel cond and 
-       'r. 'r cond are equivalent. We use Obj.magic to allow the cast without 
-       rebuilding recursiveley the full condition. *)
-    Obj.magic c 
+(* OCaml typechecker only allows converting between no_rel cond and 'r cond by
+   rebuilding recursively the full condition. Keep this version to show type
+   equivalence. *)
+let rec cast_no_rel_cond: 'r. no_rel cond -> 'r cond = 
+  function 
+  | Expr e -> Expr e
+  | Relation _ -> .
+  | ClassCond (e, c) -> ClassCond (e, c)
+  | SignCond (e, s) -> SignCond (e, s)
+  | Omitted e -> Omitted e
+  | Not c -> Not (cast_no_rel_cond ~&c &@<- c)
+  | Logop (c1, op, c2) -> Logop (cast_no_rel_cond ~&c1 &@<- c1, op, cast_no_rel_cond ~&c2 &@<- c2)
+(* We can instead use an external %identity to bypass the typechecker limitation
+   and cast without rebuilding the full condition *)
+external cast_no_rel_cond: no_rel cond -> 'r cond = "%identity"
 
 (** [abbrev_condition_expansion_state] is used internally by [expand_abbrev_cond]
     to remember the previous subject and relational operator that are omitted

--- a/src/lsp/cobol_ptree/terms_helpers.ml
+++ b/src/lsp/cobol_ptree/terms_helpers.ml
@@ -15,8 +15,14 @@ open Terms
 open Cobol_common
 open Srcloc.INFIX
 
-let neg_condition ~neg (c: cond with_loc): cond =
+let neg_condition ~neg (c: 'r cond with_loc): 'r cond =
   if not neg then ~&c else Not c
+
+let cast_no_rel_cond (c: no_rel cond): 'r cond = 
+    (* OCaml typechecker is not clever enough to deduce that no_rel cond and 
+       'r. 'r cond are equivalent. We use Obj.magic to allow the cast without 
+       rebuilding recursiveley the full condition. *)
+    Obj.magic c 
 
 (** [abbrev_condition_expansion_state] is used internally by [expand_abbrev_cond]
     to remember the previous subject and relational operator that are omitted
@@ -41,10 +47,10 @@ exception AbbrevMissingRelOpAfterSubject
     combined relation condition from [cond] by an equivalent non-abbreviated
     condition (with abbreviated relations replaced with binary relations). *)
 let rec expand_every_abbrev_cond
-  : cond -> cond = function
-  | Expr _ | Relation _ | ClassCond _ | SignCond _ | Omitted _ as c ->
+  : condition -> expanded_cond = function
+  | Expr _ | ClassCond _ | SignCond _ | Omitted _ as c ->
       c
-  | Abbrev a ->
+  | Relation a ->
       expand_abbrev_cond a
   | Not c ->
       Not (expand_every_abbrev_condition c)
@@ -62,7 +68,7 @@ and expand_every_abbrev_condition cond = expand_every_abbrev_cond ~&cond &@<- co
     {i NOT [relation_condition] [logop] abbrev-combined-conditions} if [neg]
     holds), where [logop] and {i abbrev-combined-conditions} are given via
     [logop], and [flatop]. *)
-and expand_abbrev_cond (abbrev : abbrev_combined_relation) : cond =
+and expand_abbrev_cond (abbrev : abbrev_combined_relation) : expanded_cond =
 
   let rec disambiguate abbrevop sr =
     (* Recursively constructs a valid condition based on the abbreviated
@@ -92,8 +98,8 @@ and expand_abbrev_cond (abbrev : abbrev_combined_relation) : cond =
         let c, sr = disambiguate a sr in
         neg_condition ~neg c &@<- abbrevop, sr
     | AbbrevOther c, _ ->
-        expand_every_abbrev_condition (c &@<- abbrevop), AfterNonAbbrev
-    | AbbrevComb (a1, logop, a2), sr ->
+        cast_no_rel_cond c &@<- abbrevop, AfterNonAbbrev
+    | AbbrevLogop (a1, logop, a2), sr ->
         let c1, sr = disambiguate a1 sr in
         let c2, sr = disambiguate a2 sr in
         Logop (c1, logop, c2) &@<- abbrevop, sr

--- a/src/lsp/cobol_ptree/terms_helpers.mli
+++ b/src/lsp/cobol_ptree/terms_helpers.mli
@@ -13,7 +13,8 @@
 
 (** Some utilities to construct or rewrite terms (mostly conditions for now) *)
 
-val neg_condition: neg:bool -> Terms.cond Cobol_common.with_loc -> Terms.cond
+val neg_condition: neg:bool -> 'r Terms.cond Cobol_common.with_loc -> 'r Terms.cond
+val cast_no_rel_cond: Terms.no_rel Terms.cond -> 'r Terms.cond
 
-val expand_every_abbrev_cond: Terms.cond -> Terms.cond
-val expand_abbrev_cond: Terms.abbrev_combined_relation -> Terms.cond
+val expand_every_abbrev_cond: Terms.condition -> Terms.expanded_cond
+val expand_abbrev_cond: Terms.abbrev_combined_relation -> Terms.expanded_cond

--- a/src/lsp/cobol_ptree/terms_visitor.ml
+++ b/src/lsp/cobol_ptree/terms_visitor.ml
@@ -62,8 +62,8 @@ class ['a] folder = object
   method fold_expr: (expr, 'a) fold = default
   method fold_expr': (expr with_loc, 'a) fold = default
   method fold_class: (class_, 'a) fold = default
-  method fold_cond: (cond, 'a) fold = default
-  method fold_cond': (cond with_loc, 'a) fold = default
+  method fold_condition: (condition, 'a) fold = default
+  method fold_condition': (condition with_loc, 'a) fold = default
   method fold_abbrev_relation_operand: (abbrev_relation_operand, 'a) fold = default
   method fold_abbrev_relation_operand': (abbrev_relation_operand with_loc, 'a) fold = default
   method fold_logop: (logop, 'a) fold = default
@@ -421,14 +421,12 @@ let fold_class (v: _ #folder) =
       | ClassNumeric -> Fun.id
     end
 
-let rec fold_cond: _ #folder -> cond -> _ = fun v ->
-  handle v#fold_cond
-    ~continue:begin fun (c: cond) x -> match c with
+let rec fold_condition: _ #folder -> condition -> _ = fun v ->
+  handle v#fold_condition
+    ~continue:begin fun (c: condition) x -> match c with
       | Expr e | Omitted e -> x
           >> fold_expr' v e
-      | Relation rel -> x
-          >> fold_binary_relation v rel
-      | Abbrev (_n, e, a) -> x
+      | Relation (_n, e, a) -> x
           >> fold_expr' v e
           >> fold_abbrev_relation_operand' v a
       | ClassCond (e, c) -> x
@@ -438,15 +436,15 @@ let rec fold_cond: _ #folder -> cond -> _ = fun v ->
           >> fold_expr' v e
           >> fold_signz v s
       | Not c -> x
-          >> fold_cond' v c
+          >> fold_condition' v c
       | Logop (c, l, d) -> x
-          >> fold_cond' v c
+          >> fold_condition' v c
           >> fold_logop v l
-          >> fold_cond' v d
+          >> fold_condition' v d
     end
 
-and fold_cond' (v: _ #folder) =
-  handle' v#fold_cond' ~fold:fold_cond v
+and fold_condition' (v: _ #folder) =
+  handle' v#fold_condition' ~fold:fold_condition v
 
 and fold_binary_relation (v: _ #folder) (e, r, f) x = x
   >> fold_expr' v e
@@ -469,8 +467,8 @@ and fold_abbrev_relation_operand (v: _ #folder) =
           >> fold_bool v neg
           >> fold_abbrev_relation_operand' v a
       | AbbrevOther c -> x
-          >> fold_cond v c
-      | AbbrevComb (a1, o, a2) -> x
+          >> fold_condition v (Terms_helpers.cast_no_rel_cond c)
+      | AbbrevLogop (a1, o, a2) -> x
           >> fold_abbrev_relation_operand' v a1
           >> fold_logop v o
           >> fold_abbrev_relation_operand' v a2
@@ -480,7 +478,7 @@ and fold_abbrev_relation_operand' (v: _ #folder) =
   handle' v#fold_abbrev_relation_operand' ~fold:fold_abbrev_relation_operand v
 
 let fold_expression = fold_expr'                                     (* alias *)
-let fold_condition = fold_cond'                                      (* alias *)
+let fold_condition = fold_condition'                                      (* alias *)
 
 let fold_ident_or_alphanum (v: _ #folder) : ident_or_alphanum -> 'a -> 'a = function
   | Alphanum a -> fold_alphanum v a

--- a/test/cobol_parsing/test_combined_relations_parsing.ml
+++ b/test/cobol_parsing/test_combined_relations_parsing.ml
@@ -21,11 +21,11 @@ open Cobol_parser.Tokens
 open Cobol_parser.INTERNAL.Grammar
 open Cobol_parser.INTERNAL.Dummy
 
-let condition: cond with_loc testable = testable pp_cond' (fun a b -> compare_cond' a b = 0)
+let expanded_cond: expanded_cond with_loc testable = testable (pp_cond' pp_binary_relation) (fun a b -> compare_cond' compare_binary_relation a b = 0)
 let parse_condition = parse_list_as standalone_condition
 let expand_condition = Srcloc.map_payload Terms_helpers.expand_every_abbrev_cond
 let check_condition toks cond =
-  check condition "correct conditions parsing" cond
+  check expanded_cond "correct conditions parsing" cond
     (expand_condition @@ parse_condition toks)
 and fail_condition toks =
   check_raises "syntax-error" Error
@@ -52,12 +52,12 @@ let test_conditions =
   let ( !. ) a = Not a &@ Srcloc.dummy
   and ( &&. ) a b = Logop (a, LAnd, b) &@ Srcloc.dummy
   and ( ||. ) a b = Logop (a, LOr, b) &@ Srcloc.dummy
-  and ( ==. ) a b : cond with_loc = Relation (a, Eq, b) &@ Srcloc.dummy
-  and ( <>. ) a b : cond with_loc = Relation (a, Ne, b) &@ Srcloc.dummy
-  and ( >. ) a b : cond with_loc = Relation (a, Gt, b) &@ Srcloc.dummy
-  and ( >=. ) a b : cond with_loc = Relation (a, Ge, b) &@ Srcloc.dummy
-  and ( <. ) a b : cond with_loc = Relation (a, Lt, b) &@ Srcloc.dummy
-  and ( <=. ) a b : cond with_loc = Relation (a, Le, b) &@ Srcloc.dummy
+  and ( ==. ) a b : expanded_cond with_loc = Relation (a, Eq, b) &@ Srcloc.dummy
+  and ( <>. ) a b : expanded_cond with_loc = Relation (a, Ne, b) &@ Srcloc.dummy
+  and ( >. ) a b : expanded_cond with_loc = Relation (a, Gt, b) &@ Srcloc.dummy
+  and ( >=. ) a b : expanded_cond with_loc = Relation (a, Ge, b) &@ Srcloc.dummy
+  and ( <. ) a b : expanded_cond with_loc = Relation (a, Lt, b) &@ Srcloc.dummy
+  and ( <=. ) a b : expanded_cond with_loc = Relation (a, Le, b) &@ Srcloc.dummy
   and ( +. ) a b = Binop (a, BPlus, b) &@ Srcloc.dummy in
   [
     chk "NOT A"         [NOT; a]             !.ac;

--- a/test/syntax-todo/syntax.at
+++ b/test/syntax-todo/syntax.at
@@ -852,7 +852,6 @@ AT_CLEANUP
 
 AT_SETUP([MF WHEN COND AND COND])
 
-# promoted on 2024-04-05T13:38
 AT_DATA([prog.cob], [
        program-id. GetFlyerLevel.
        procedure division.
@@ -863,20 +862,10 @@ AT_DATA([prog.cob], [
        end program.
 ])
 
-AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [1],
+AT_CHECK([$SUPERBOL check --recovery=false --std=mf prog.cob], [0],
 [Checking `prog.cob'
 ],
 [SuperBOL, by OCamlPro. https://get-superbol.com. Affero GPL version.
-prog.cob:5.28-5.31:
-   2          program-id. GetFlyerLevel.
-   3          procedure division.
-   4              evaluate lnk-award-points
-   5 >                 when >= 300 and < 700
-----                               ^^^
-   6                      move "Silver" to lnk-award-level
-   7              end-evaluate.
->> Error: Invalid syntax
-
 ])
 
 AT_CLEANUP

--- a/test/testing_utils/testing_helpers.ml
+++ b/test/testing_utils/testing_helpers.ml
@@ -42,7 +42,7 @@ module Make (Tags: TAGS) = struct
 
   module Cond = struct
     open Expr
-    let expr e : cond with_loc = Expr e &@ Srcloc.dummy
+    let expr e : 'r cond with_loc = Expr e &@ Srcloc.dummy
     let ident x = expr (ident x)
   end
 

--- a/test/testsuite/microfocus/complex_cond.cbl
+++ b/test/testsuite/microfocus/complex_cond.cbl
@@ -1,0 +1,51 @@
+      $ SET SOURCEFORMAT"FREE"
+IDENTIFICATION DIVISION.
+PROGRAM-ID.  COMPLEX_COND.
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+    01 A PIC X.
+    01 B PIC X.
+    01 C PIC X.
+    01 D PIC X.
+PROCEDURE DIVISION.
+    IF A >= (1 OR B <= 2) CONTINUE.
+    IF NOT A CONTINUE.
+    IF (NOT A) CONTINUE.
+    IF A OR B CONTINUE.
+    IF A AND B CONTINUE.
+    IF A AND NOT B CONTINUE.
+    IF NOT A OR B CONTINUE.
+    IF A AND B AND C CONTINUE.
+    IF A OR B AND C CONTINUE.
+    IF A = 'a' CONTINUE.
+    IF A OR A AND B OR C CONTINUE.
+    IF NOT (A AND B) CONTINUE.
+    IF (A = 'a') CONTINUE.
+    IF A = 'a' CONTINUE.
+    IF A = 'a' OR (NOT B) CONTINUE.
+    IF (A >= B) AND (A <= C) CONTINUE.
+    IF (A >= B) AND A <= C CONTINUE.
+    IF (A = 'a') AND (B = 'b') CONTINUE.
+    IF A = 'a' OR B = 'b' CONTINUE.
+    IF A EQUAL TO B AND C CONTINUE.
+    IF A EQUAL TO B AND B EQUAL TO 1 CONTINUE.
+    IF A = 1 OR 2 CONTINUE.
+    IF A = 1 OR 2 OR 2 = B CONTINUE.
+    IF A = 1 OR 1 + 1 OR 1 + 1 = B CONTINUE.
+
+*> GnuCOBOL and MF do not agree on this example:
+    IF (A = 'a') AND NOT B CONTINUE.
+           
+*> ISO COBOL2014 examples
+    IF a > b AND NOT < c OR d CONTINUE.
+    IF a NOT EQUAL b OR c CONTINUE.
+    IF NOT a = b OR c CONTINUE.
+    IF NOT (a > b OR < c) CONTINUE.
+    IF NOT (a NOT > b AND c AND NOT d) CONTINUE.
+
+*> MicroFocus OSVS: https://www.microfocus.com/documentation/reuze/60d/lhpdf60q.htm
+    IF a = (1 OR 2) CONTINUE.
+    IF a > b OR (c AND d) CONTINUE.
+    IF a > (b OR c) AND d CONTINUE.
+    IF a (= b OR > c) CONTINUE.
+    IF a = b AND (> c OR < d) CONTINUE.


### PR DESCRIPTION
This commit also removes ambiguous Relation vs Abbrev distinction in cond and unifies SelCond and SelRelation by using the more permissive abbrev_relation_operand in SelCond.