### PR TITLE
Fix name of dune executable targets when cross-compiling for Windows

### DIFF
--- a/.drom
+++ b/.drom
@@ -20,9 +20,7 @@ da33ce03322570a859125f4b976aa0f2:.github/workflows/workflow.yml
 
 # begin context for Makefile
 # file Makefile
-8cd31f8eff1c5ecc519df4e8f8aba2ce:Makefile
-8c09c4eb1a406394b92cd1f9f84f6841:Makefile
-c51046d60e2999a38d5adb4cd95865a8:Makefile
+9329cd139176803f14ec41f51bc9c2a6:Makefile
 # end context for Makefile
 
 # begin context for docs/README.txt

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ DUNE_INSTALL_CONTEXT = ${DUNE_BUILD_DIR}/install/default$(DUNE_CONTEXT)
 DOT_EXE = $(if $(filter win32,$(TARGET_PLAT)),.exe)
 EXE_TARGETS ?=
 
+# Add exe extension for dune executable targets on windows
+DUNE_DOT_EXE = $(if $(filter win32,$(BUILD_PLAT)),$(DOT_EXE))
+
 CP ?= cp -fl
 
 VERSION = 1.0.1
@@ -57,7 +60,7 @@ else
   ifneq ($(EXE_TARGETS),)
 	${DUNE} build ${DUNE_ARGS} ${DUNE_CROSS_ARGS}	\
 		$(addprefix $(DUNE_INSTALL_CONTEXT)/bin/,		\
-		  $(addsuffix $(DOT_EXE),$(EXE_TARGETS)))
+		  $(addsuffix $(DUNE_DOT_EXE),$(EXE_TARGETS)))
 	./scripts/copy-bin.sh superbol-studio-oss superbol-vscode-lib superbol-vscode-oss interop-js-stubs node-js-stubs vscode-js-stubs vscode-languageclient-js-stubs vscode-json vscode-debugadapter vscode-debugprotocol superbol-free superbol_free_lib superbol_preprocs superbol_project superbol_platform cobol_common cobol_parser cobol_ptree ebcdic_lib cobol_lsp ppx_cobcflags pretty cobol_config cobol_indent cobol_indent_old cobol_preproc cobol_data cobol_typeck cobol_unit ez_toml ezr_toml sql_preproc sql_ast sql_parser cobol_cfg autofonce autofonce_core autofonce_lib autofonce_m4 autofonce_share autofonce_patch autofonce_config autofonce_misc ez_win32 ez_call h2mlstubs tramabol tramabol_lib ezlibcob cobol_interp cobol_ir
   endif
 endif

--- a/Makefile.drom-tpl
+++ b/Makefile.drom-tpl
@@ -31,6 +31,9 @@ DUNE_INSTALL_CONTEXT = ${DUNE_BUILD_DIR}/install/default$(DUNE_CONTEXT)
 DOT_EXE = $(if $(filter win32,$(TARGET_PLAT)),.exe)
 EXE_TARGETS ?=
 
+# Add exe extension for dune executable targets on windows
+DUNE_DOT_EXE = $(if $(filter win32,$(BUILD_PLAT)),$(DOT_EXE))
+
 CP ?= cp -fl
 
 VERSION = !{version}
@@ -57,7 +60,7 @@ else
   ifneq ($(EXE_TARGETS),)
 	${DUNE} build!{build-profile} ${DUNE_ARGS} ${DUNE_CROSS_ARGS}	\
 		$(addprefix $(DUNE_INSTALL_CONTEXT)/bin/,		\
-		  $(addsuffix $(DOT_EXE),$(EXE_TARGETS)))
+		  $(addsuffix $(DUNE_DOT_EXE),$(EXE_TARGETS)))
 	./scripts/copy-bin.sh !{packages}
   endif
 endif

--- a/Makefile.header
+++ b/Makefile.header
@@ -148,35 +148,37 @@ build-master:
 
 TRAMABOL = $(basename $(notdir $(TRAMABOL_PKG)))
 ifneq ($(TARGET_PLAT),universal)
-  EXE_TARGETS += $(TRAMABOL)
-  TRAMABOL_EXE = $(TRAMABOL)-$(TARGET_SPEC)$(DOT_EXE)
-  ifeq ($(TARGET_PLAT)_$(LINKING_MODE),$(BUILD_PLAT)_static)
-    TRAMABOL_BUILT = $(TRAMABOL)
-  else
-    TRAMABOL_BUILT = ${DUNE_BUILD_CONTEXT}/src/$(TRAMABOL_PKG)/main.exe
-  endif
+  ifneq ($(HAVE_LIBCOB5),false)
+    EXE_TARGETS += $(TRAMABOL)
+    TRAMABOL_EXE = $(TRAMABOL)-$(TARGET_SPEC)$(DOT_EXE)
+    ifeq ($(TARGET_PLAT)_$(LINKING_MODE),$(BUILD_PLAT)_static)
+      TRAMABOL_BUILT = $(TRAMABOL)
+    else
+      TRAMABOL_BUILT = ${DUNE_BUILD_CONTEXT}/src/$(TRAMABOL_PKG)/main.exe
+    endif
 
-  .PHONY: tramabol tramabol-interpreter
-  all: tramabol
-  tramabol: tramabol-interpreter
-  tramabol-interpreter: $(TRAMABOL_BUILT)
+    .PHONY: tramabol tramabol-interpreter
+    all: tramabol
+    tramabol: tramabol-interpreter
+    tramabol-interpreter: $(TRAMABOL_BUILT)
 	$(CP) $(TRAMABOL_BUILT) $(TRAMABOL_EXE)
 
-  $(TRAMABOL_BUILT): build
+    $(TRAMABOL_BUILT): build
 
-  .PHONY: test-tramabol
-  test-tramabol:
+    .PHONY: test-tramabol
+    test-tramabol:
 	${DUNE} runtest test/tramabol
 
-  .PHONY: test-tramabol-promote
-  test-promote: test-tramabol-promote
-  test-tramabol-promote:
+    .PHONY: test-tramabol-promote
+    test-promote: test-tramabol-promote
+    test-tramabol-promote:
 	${DUNE} runtest test/tramabol --auto-promote
 
-  .PHONY: clean-tramabol
-  clean-execs: clean-tramabol
-  clean-tramabol:
+    .PHONY: clean-tramabol
+    clean-execs: clean-tramabol
+    clean-tramabol:
 	rm -f $(TRAMABOL) $(wildcard $(TRAMABOL)-*-*)
+  endif
 endif
 
 # ---


### PR DESCRIPTION
Additonally: only enable build rules for TramaBOL when libcob5 is not explicitly disabled